### PR TITLE
Raster3D-3.0-2-goolf-1.4.10.eb

### DIFF
--- a/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.3.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.3.0-goolf-1.4.10.eb
@@ -2,8 +2,9 @@ name = 'libjpeg-turbo'
 version = '1.3.0'
 
 homepage = 'http://sourceforge.net/libjpeg-turbo/'
-description = """libjpeg-turbo is a fork of the original IJG libjpeg which uses SIMD to accelerate baseline JPEG 
-compression and decompression. libjpeg is a library that implements JPEG image encoding, decoding and transcoding.
+description = """ libjpeg-turbo is a fork of the original IJG libjpeg which 
+ uses SIMD to accelerate baseline JPEG compression and decompression. libjpeg 
+ is a library that implements JPEG image encoding, decoding and transcoding.
 """
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}

--- a/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.3.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.3.0-goolf-1.4.10.eb
@@ -1,3 +1,5 @@
+easyblock = 'ConfigureMake'
+
 name = 'libjpeg-turbo'
 version = '1.3.0'
 

--- a/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.3.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.3.0-goolf-1.4.10.eb
@@ -1,0 +1,21 @@
+name = 'libjpeg-turbo'
+version = '1.3.0'
+
+homepage = 'http://sourceforge.net/libjpeg-turbo/'
+description = """libjpeg-turbo is a fork of the original IJG libjpeg which uses SIMD to accelerate baseline JPEG 
+compression and decompression. libjpeg is a library that implements JPEG image encoding, decoding and transcoding.
+"""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('NASM', '2.07'),
+]
+
+configopts = "--with-jpeg8"
+runtest = "test"
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/r/Raster3D/Raster3D-3.0-2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/Raster3D/Raster3D-3.0-2-goolf-1.4.10.eb
@@ -3,6 +3,8 @@
 # Swiss Institute of Bioinformatics
 # Biozentrum - University of Basel
 
+easyblock = 'ConfigureMake'
+
 name = 'Raster3D'
 version = '3.0-2'
 
@@ -22,7 +24,7 @@ source_urls = [homepage]
 sources = ['%(name)s_%(version)s.tar.gz']
 
 skipsteps = ['configure']
-makeopts = ' linux && make all'
+buildopts = ' linux && make all'
 installopts = 'prefix=%(installdir)s'
 
 dependencies = [ 

--- a/easybuild/easyconfigs/r/Raster3D/Raster3D-3.0-2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/Raster3D/Raster3D-3.0-2-goolf-1.4.10.eb
@@ -1,0 +1,39 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics
+# Biozentrum - University of Basel
+
+name = 'Raster3D'
+version = '3.0-2'
+
+homepage = 'http://skuld.bmsc.washington.edu/raster3d/'
+description = """ Raster3D is a set of tools for generating high quality raster images 
+ of proteins or other molecules. The core program renders spheres, triangles, cylinders, 
+ and quadric surfaces with specular highlighting, Phong shading, and shadowing. It uses an 
+ efficient software Z-buffer algorithm which is independent of any graphics hardware. 
+ Ancillary programs process atomic coordinates from PDB files into rendering descriptions for 
+ pictures composed of ribbons, space-filling atoms, bonds, ball+stick, etc. Raster3D can also 
+ be used to render pictures composed in other programs such as Molscript in glorious 3D with highlights, 
+ shadowing, etc. Output is to pixel image files with 24 bits of color information per pixel.  """ 
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+source_urls = [homepage]
+sources = ['%(name)s_%(version)s.tar.gz']
+
+skipsteps = ['configure']
+makeopts = ' linux && make all'
+installopts = 'prefix=%(installdir)s'
+
+# this are RHEL/CentOS package names
+osdependencies = [('libjpeg-turbo-devel', 'libpng-devel', 'libtiff-devel')]
+
+modextrapaths = {'R3D_LIB': 'share/Raster3D/materials'}
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ["avs2ps", "balls", "normal3d", "rastep", "render",
+      "ribbon", "rings3d", "rods", "stereo3d", "worms" ]],
+    'dirs': []
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/r/Raster3D/Raster3D-3.0-2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/Raster3D/Raster3D-3.0-2-goolf-1.4.10.eb
@@ -25,14 +25,21 @@ skipsteps = ['configure']
 makeopts = ' linux && make all'
 installopts = 'prefix=%(installdir)s'
 
+dependencies = [ 
+    ('libjpeg-turbo', '1.3.0'),
+    ('libpng', '1.6.2'),
+    ('LibTIFF', '4.0.3'),
+]
+
 # this are RHEL/CentOS package names
-osdependencies = [('libjpeg-turbo-devel', 'libpng-devel', 'libtiff-devel')]
+# in case you prefer to rely in OS dependencies
+#osdependencies = [('libjpeg-turbo-devel', 'libpng-devel', 'libtiff-devel')]
 
 modextrapaths = {'R3D_LIB': 'share/Raster3D/materials'}
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ["avs2ps", "balls", "normal3d", "rastep", "render",
-      "ribbon", "rings3d", "rods", "stereo3d", "worms" ]],
+              "ribbon", "rings3d", "rods", "stereo3d", "worms" ]],
     'dirs': []
 }
 

--- a/easybuild/easyconfigs/r/Raster3D/Raster3D-3.0-2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/Raster3D/Raster3D-3.0-2-goolf-1.4.10.eb
@@ -1,7 +1,7 @@
 # This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
 # Author: Pablo Escobar Lopez
-# Swiss Institute of Bioinformatics
-# Biozentrum - University of Basel
+# sciCORE - University of Basel
+# SIB Swiss Institute of Bioinformatics 
 
 easyblock = 'ConfigureMake'
 


### PR DESCRIPTION
I have added the dependencies as osdepencencies as in our cluster we prefer to do it like this. If requested I can modify it to add dependencies the "easybuild way"

this are RHEL/CentOS package names
osdependencies = [('libjpeg-turbo-devel', 'libpng-devel', 'libtiff-devel')]