### PR TITLE
Contributing parallel version of ABINIT built with ETSF_IO

### DIFF
--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.4.3-goolf-1.4.10-ETSF_IO-1.0.4.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.4.3-goolf-1.4.10-ETSF_IO-1.0.4.eb
@@ -1,35 +1,40 @@
 ##
 # This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
 #
-# Copyright:: Copyright 2014 The Cyprus Institute
+# Copyright:: Copyright 2013-2014 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>
+# License:: MIT/GPL
 #
 ##
+easyblock = "ConfigureMake"
 
 name = 'ABINIT'
 version = '7.4.3'
+versionsuffix = '-ETSF_IO-1.0.4'
 
 homepage = 'http://www.abinit.org/'
-description = """Abinit is a plane wave pseudopotential code for doing condensed phase electronic structure calculations using DFT."""
+description = """Abinit is a plane wave pseudopotential code for doing
+ condensed phase electronic structure calculations using DFT."""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-sources = ['%s-%s.tar.gz' % (name.lower(), version)]
 source_urls = ['http://ftp.abinit.org/']
+sources = [SOURCELOWER_TAR_GZ]
 
 configopts = '--enable-mpi --enable-mpi-io --with-mpi-prefix=$EBROOTOPENMPI --enable-fallbacks '
-configopts += '--with-netcdf-incs="-I$EBROOTNETCDF/include" --with-netcdf-libs="-L$EBROOTNETCDF/lib -lnetcdf -lnetcdff" '
+configopts += '--with-netcdf-incs="-I$EBROOTNETCDF/include" '
+configopts += '--with-netcdf-libs="-L$EBROOTNETCDF/lib -lnetcdf -lnetcdff" '
 configopts += '--with-fft-libs="-L$EBROOTFFTW/lib -lfftw3 -lfftw3f" --with-fft-flavor=fftw3 '
 configopts += '--with-trio-flavor="netcdf+etsf_io" --enable-gw-dpc'
 
 dependencies = [
-                ('netCDF', '4.1.3'),
-                ('ETSF_IO', '1.0.4'),
+    ('netCDF', '4.1.3'),
+    ('ETSF_IO', '1.0.4'),
 ]
 
 sanity_check_paths = {
-                      'files': ["bin/abinit"], 
-                      'dirs': []
-                     }
+    'files': ["bin/abinit"], 
+    'dirs': []
+}
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.4.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.4.3-goolf-1.4.10.eb
@@ -1,0 +1,35 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2014 The Cyprus Institute
+# Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>
+#
+##
+
+name = 'ABINIT'
+version = '7.4.3'
+
+homepage = 'http://www.abinit.org/'
+description = """Abinit is a plane wave pseudopotential code for doing condensed phase electronic structure calculations using DFT."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+sources = ['%s-%s.tar.gz' % (name.lower(), version)]
+source_urls = ['http://ftp.abinit.org/']
+
+configopts = '--enable-mpi --enable-mpi-io --with-mpi-prefix=$EBROOTOPENMPI --enable-fallbacks '
+configopts += '--with-netcdf-incs="-I$EBROOTNETCDF/include" --with-netcdf-libs="-L$EBROOTNETCDF/lib -lnetcdf -lnetcdff" '
+configopts += '--with-fft-libs="-L$EBROOTFFTW/lib -lfftw3 -lfftw3f" --with-fft-flavor=fftw3 '
+configopts += '--with-trio-flavor="netcdf+etsf_io" --enable-gw-dpc'
+
+dependencies = [
+                ('netCDF', '4.1.3'),
+                ('ETSF_IO', '1.0.4'),
+]
+
+sanity_check_paths = {
+                      'files': ["bin/abinit"], 
+                      'dirs': []
+                     }
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/e/ETSF_IO/ETSF_IO-1.0.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/e/ETSF_IO/ETSF_IO-1.0.4-goolf-1.4.10.eb
@@ -1,27 +1,34 @@
 ##
 # This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
 #
-# Copyright:: Copyright 2014 The Cyprus Institute
+# Copyright:: Copyright 2013-2014 The Cyprus Institute
 # Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>
+# License:: MIT/GPL
 #
 ##
+easyblock = 'ConfigureMake'
 
 name = 'ETSF_IO'
 version = '1.0.4'
 
 homepage = 'http://www.etsf.eu/resources/software/libraries_and_tools'
-description = """A library of F90 routines to read/write the ETSF file format has been written. It is called ETSF_IO and available under LGPL. """
+description = """A library of F90 routines to read/write the ETSF file 
+format has been written. It is called ETSF_IO and available under LGPL. """
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-sources = ['http://www.etsf.eu/system/files/etsf_io-1.0.4.tar.gz']
+source_urls = ['http://www.etsf.eu/system/files']
+sources = [SOURCELOWER_TAR_GZ]
 
-configopts = "--with-netcdf-prefix=$EBROOTNETCDF --with-netcdf-libs='-L$EBROOTNETCDF/lib -lnetcdf -lnetcdff' --with-netcdf-incs='-I$EBROOTNETCDF/include'"
+configopts = "--with-netcdf-prefix=$EBROOTNETCDF "
+configopts += "--with-netcdf-libs='-L$EBROOTNETCDF/lib -lnetcdf -lnetcdff' "
+configopts += " --with-netcdf-incs='-I$EBROOTNETCDF/include'"
 
 dependencies = [ ('netCDF', '4.1.3') ]
 
 sanity_check_paths = {
-                      'files': ["bin/etsf_io"], 
-                      'dirs': []
-                     }
+    'files': ["bin/etsf_io"], 
+    'dirs': []
+}
 
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/e/ETSF_IO/ETSF_IO-1.0.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/e/ETSF_IO/ETSF_IO-1.0.4-goolf-1.4.10.eb
@@ -1,0 +1,27 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2014 The Cyprus Institute
+# Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>
+#
+##
+
+name = 'ETSF_IO'
+version = '1.0.4'
+
+homepage = 'http://www.etsf.eu/resources/software/libraries_and_tools'
+description = """A library of F90 routines to read/write the ETSF file format has been written. It is called ETSF_IO and available under LGPL. """
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+sources = ['http://www.etsf.eu/system/files/etsf_io-1.0.4.tar.gz']
+
+configopts = "--with-netcdf-prefix=$EBROOTNETCDF --with-netcdf-libs='-L$EBROOTNETCDF/lib -lnetcdf -lnetcdff' --with-netcdf-incs='-I$EBROOTNETCDF/include'"
+
+dependencies = [ ('netCDF', '4.1.3') ]
+
+sanity_check_paths = {
+                      'files': ["bin/etsf_io"], 
+                      'dirs': []
+                     }
+


### PR DESCRIPTION
Contributing ABINIT build in parallel with OpenMPI. To also enable checkpointing ABINIT should be build with ETSF_IO and netCDF