### PR TITLE
Add OpenCV without CUDA.

### DIFF
--- a/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.3.0-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.3.0-ictce-5.5.0.eb
@@ -1,0 +1,22 @@
+name = 'libjpeg-turbo'
+version = '1.3.0'
+
+homepage = 'http://sourceforge.net/libjpeg-turbo/'
+description = """libjpeg-turbo is a fork of the original IJG libjpeg which uses SIMD to accelerate baseline JPEG 
+compression and decompression. libjpeg is a library that implements JPEG image encoding, decoding and transcoding.
+"""
+
+toolchain = {'name': 'ictce', 'version': '5.5.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('NASM', '2.07'),
+]
+
+configopts = "--with-jpeg8"
+runtest = "test"
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/NASM/NASM-2.07-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.07-ictce-5.5.0.eb
@@ -1,0 +1,30 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
+# Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-90.html
+##
+
+name = 'NASM'
+version = '2.07'
+
+homepage = 'http://nasm.sourceforge.net/'
+description = """NASM-2.07: General-purpose x86 assembler"""
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = ['http://sourceforge.net/projects/nasm/files', 'download']
+
+
+toolchain = {'name': 'ictce', 'version': '5.5.0'}
+
+sanity_check_paths = {
+                      'files': ['bin/nasm'],
+                      'dirs': []
+                     }
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/o/OpenCV/OpenCV-2.4.8-ictce-5.5.0-nocuda.eb
+++ b/easybuild/easyconfigs/o/OpenCV/OpenCV-2.4.8-ictce-5.5.0-nocuda.eb
@@ -1,0 +1,24 @@
+easyblock = 'CMakeMake'
+
+name = 'OpenCV'
+version = '2.4.8'
+
+homepage = 'http://opencv.org'
+description = """OpenCV (Open Source Computer Vision) is a library of programming functions for real time computer vision."""
+
+toolchain = {'name':'ictce','version':'5.5.0'}
+
+source_urls = ['http://download.sourceforge.net/opencvlibrary/opencv-unix/%s/' % version]
+sources = ['opencv-%s.zip' % version]
+
+builddependencies = [('CMake', '2.8.12')]
+
+configopts='-DWITH_CUDA=OFF'
+
+sanity_check_paths = {
+    'files': ['lib/libopencv_photo.so'],
+    'dirs': ['bin', 'lib'],
+}
+
+moduleclass = 'devel'
+


### PR DESCRIPTION
This is OpenCV for the ictce 5.5.0 toolchain without CUDA. One of the challenges we've had is to make sure we have all the deps taken care of. Running `ldd` on the binaries in the installed directories and filtering out EasyBuild dependencies results in the following:
```
-bash-4.1$ ldd ~/.local/easybuild/software/OpenCV/2.4.8-ictce-5.5.0/bin/* | grep -v `whoami`| grep -v sandy | sort  | awk '{print $1}' | uniq
/lib64/ld-linux-x86-64.so.2
libc.so.6
libdl.so.2
libgcc_s.so.1
libglib-2.0.so.0
libgthread-2.0.so.0
libm.so.6
libpthread.so.0
librt.so.1
/$LIB/snoopy.so
libstdc++.so.6
linux-vdso.so.1
```

This required libjpeg (for which I've used libjpeg-turbo) and thus a toolchain version of NASM.