### PR TITLE
Cuda 6.0.37

### DIFF
--- a/easybuild/easyconfigs/c/CUDA/CUDA-6.0.37.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-6.0.37.eb
@@ -21,9 +21,8 @@ description = """CUDA (formerly Compute Unified Device Architecture) is a parall
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-# eg. http://developer.download.nvidia.com/compute/cuda/5_0/rel-update-1/installers/cuda_5.0.35_linux_64_rhel5.x-1.run
-source_urls = ['http://developer.download.nvidia.com/compute/cuda/%(version_major)s_0/rel/installers/']
-
+# http://developer.download.nvidia.com/compute/cuda/6_0/rel/installers/cuda_6.0.37_linux_64.run
+source_urls = ['http://developer.download.nvidia.com/compute/cuda/%(version_major)s_%(version_minor)s/rel/installers/']
 sources = ['%(namelower)s_%(version)s_linux_64.run']
 
 moduleclass = 'system'

--- a/easybuild/easyconfigs/c/CUDA/CUDA-6.0.37.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-6.0.37.eb
@@ -1,0 +1,29 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB, Ghent University
+# Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>, Kenneth Hoste
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-99.html
+##
+
+name = 'CUDA'
+version = '6.0.37'
+
+homepage = 'https://developer.nvidia.com/cuda-toolkit'
+description = """CUDA (formerly Compute Unified Device Architecture) is a parallel
+ computing platform and programming model created by NVIDIA and implemented by the
+ graphics processing units (GPUs) that they produce. CUDA gives developers access
+ to the virtual instruction set and memory of the parallel computational elements in CUDA GPUs."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+# eg. http://developer.download.nvidia.com/compute/cuda/5_0/rel-update-1/installers/cuda_5.0.35_linux_64_rhel5.x-1.run
+source_urls = ['http://developer.download.nvidia.com/compute/cuda/%(version_major)s_0/rel/installers/']
+
+sources = ['%(namelower)s_%(version)s_linux_64.run']
+
+moduleclass = 'system'


### PR DESCRIPTION
added %(version_major)s_%(version_minor)s to source_urls so it works with future major releases

reviewing the install_dir I see these folders which contains a few libraries and binaries:

```
libnvvp  nvvm  open64
```

but those are not included in LD_LIBRARY_PATH, LIBRARY_PATH and PATH in the generated modulefile. There is also a new folder "pkgconfig" which was not present in cuda-5.x releases.  

Maybe we should improve the cuda easyblock to add this in the modulefile? 

maybe @ajdecon can give some advice about this?