### PR TITLE
Contrib goolf 1.4.20

### DIFF
--- a/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-GCC-4.7.4.eb
+++ b/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-GCC-4.7.4.eb
@@ -1,0 +1,24 @@
+name = 'Autoconf'
+version = '2.69'
+
+homepage = 'http://www.gnu.org/software/autoconf/'
+description = """Autoconf is an extensible package of M4 macros that produce shell scripts
+ to automatically configure software source code packages. These scripts can adapt the
+ packages to many kinds of UNIX-like systems without manual user intervention. Autoconf
+ creates a configuration script for a package from a template file that lists the
+ operating system features that the package can use, in the form of M4 macro calls."""
+
+toolchain = {'name': 'GCC', 'version': '4.7.4'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('M4', '1.4.16')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["autoconf", "autoheader", "autom4te", "autoreconf", "autoscan",
+                                     "autoupdate", "ifnames"]],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Automake/Automake-1.14-GCC-4.7.4.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.14-GCC-4.7.4.eb
@@ -1,0 +1,31 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg/Luxembourg Centre for Systems Biomedicine
+# Authors::   Fotis Georgatos <fotis.georgatos@uni.lu>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+name = 'Automake'
+version = "1.14"
+
+homepage = 'http://www.gnu.org/software/automake/automake.html'
+description = "Automake: GNU Standards-compliant Makefile generator"
+
+toolchain = {'name': 'GCC', 'version': '4.7.4'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('Autoconf', '2.69')]
+
+sanity_check_paths = {
+    'files': ['bin/automake', 'bin/aclocal'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-1.4.20.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-1.4.20.eb
@@ -1,0 +1,32 @@
+name = 'FFTW'
+version = '3.3.4'
+
+homepage = 'http://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+ in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'gompi', 'version': '1.4.20'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [homepage]
+
+common_configopts = "--enable-openmp --with-pic"
+
+configopts = [
+    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    common_configopts + " --enable-long-double --enable-mpi",
+    common_configopts + " --enable-quad-precision",
+    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+]
+
+sanity_check_paths = {
+    'files': ['bin/fftw%s' % x for x in ['-wisdom', '-wisdom-to-conf', 'f-wisdom', 'l-wisdom', 'q-wisdom']] +
+             ['include/fftw3%s' % x for x in ['-mpi.f03', '-mpi.h', '.f', '.f03',
+                                              '.h', 'l-mpi.f03', 'l.f03', 'q.f03']] +
+             ['lib/libfftw3%s.a' % x for x in ['', '_mpi', '_omp', 'f', 'f_mpi', 'f_omp',
+                                               'l', 'l_mpi', 'l_omp', 'q', 'q_omp']],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/g/gompi/gompi-1.4.20.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-1.4.20.eb
@@ -1,0 +1,25 @@
+easyblock = "Toolchain"
+
+name = 'gompi'
+version = '1.4.20'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain,
+ including OpenMPI for MPI support."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+compname = 'GCC'
+compver = '4.7.4'
+comp = (compname, compver)
+
+mpilib = 'OpenMPI'
+mpiver = '1.7.5'
+
+# compiler toolchain dependencies
+dependencies = [
+    comp,
+    (mpilib, mpiver, '', comp),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-1.4.20.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-1.4.20.eb
@@ -14,7 +14,7 @@ compver = '4.7.4'
 comp = (compname, compver)
 
 mpilib = 'OpenMPI'
-mpiver = '1.7.5'
+mpiver = '1.6.6'
 
 # compiler toolchain dependencies
 dependencies = [

--- a/easybuild/easyconfigs/g/goolf/goolf-1.4.20.eb
+++ b/easybuild/easyconfigs/g/goolf/goolf-1.4.20.eb
@@ -1,0 +1,37 @@
+easyblock = "Toolchain"
+
+name = 'goolf'
+version = '1.4.20'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain, including
+ OpenMPI for MPI support, OpenBLAS (BLAS and LAPACK support), FFTW and ScaLAPACK."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+comp_name = 'GCC'
+comp_version = '4.7.4'
+comp = (comp_name, comp_version)
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.9'
+blas = '%s-%s' % (blaslib, blasver)
+blassuff = '-LAPACK-3.5.0'
+
+# toolchain used to build goolf dependencies
+comp_mpi_tc_name = 'gompi'
+comp_mpi_tc_ver = "%s" % version
+comp_mpi_tc = (comp_mpi_tc_name, comp_mpi_tc_ver)
+
+# compiler toolchain depencies
+# we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
+# because of toolchain preperation functions
+dependencies = [
+    ('GCC', comp_version),
+    ('OpenMPI', '1.7.5', '', comp),  # part of gompi-1.4.20
+    (blaslib, blasver, blassuff, comp_mpi_tc),
+    ('FFTW', '3.3.4', '', comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/goolf/goolf-1.4.20.eb
+++ b/easybuild/easyconfigs/g/goolf/goolf-1.4.20.eb
@@ -28,7 +28,7 @@ comp_mpi_tc = (comp_mpi_tc_name, comp_mpi_tc_ver)
 # because of toolchain preperation functions
 dependencies = [
     ('GCC', comp_version),
-    ('OpenMPI', '1.7.5', '', comp),  # part of gompi-1.4.20
+    ('OpenMPI', '1.6.6', '', comp),  # part of gompi-1.4.20
     (blaslib, blasver, blassuff, comp_mpi_tc),
     ('FFTW', '3.3.4', '', comp_mpi_tc),
     ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc),

--- a/easybuild/easyconfigs/h/HPL/HPL-2.0-goolf-1.4.20.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.0-goolf-1.4.20.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.0'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.20'}
+toolchainopts = {'optarch': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.9-GCC-4.7.4.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.9-GCC-4.7.4.eb
@@ -1,0 +1,17 @@
+name = 'hwloc'
+version = "1.9"
+
+homepage = 'http://www.open-mpi.org/projects/hwloc/'
+description = """The Portable Hardware Locality (hwloc) software package provides a portable abstraction
+ (across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including
+ NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading. It also gathers various
+ system attributes such as cache and memory information as well as the locality of I/O devices such as
+ network interfaces, InfiniBand HCAs or GPUs. It primarily aims at helping applications with gathering
+ information about modern computing hardware so as to exploit it accordingly and efficiently."""
+
+toolchain = {'name': 'GCC', 'version': '4.7.4'}
+  
+source_urls = ['http://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/']
+sources = [SOURCE_TAR_GZ]
+
+moduleclass = 'system'

--- a/easybuild/easyconfigs/l/LAPACK/LAPACK-3.5.0-gompi-1.4.20.eb
+++ b/easybuild/easyconfigs/l/LAPACK/LAPACK-3.5.0-gompi-1.4.20.eb
@@ -1,0 +1,15 @@
+name = 'LAPACK'
+version = "3.5.0"
+
+homepage = 'http://www.netlib.org/lapack/'
+description = """LAPACK is written in Fortran90 and provides routines for solving systems of
+ simultaneous linear equations, least-squares solutions of linear systems of equations, eigenvalue
+ problems, and singular value problems."""
+
+toolchain = {'name': 'gompi', 'version': '1.4.20'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TGZ]
+source_urls = [homepage]
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-GCC-4.7.4.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-GCC-4.7.4.eb
@@ -1,0 +1,24 @@
+name = 'M4'
+version = '1.4.16'
+
+homepage = 'http://www.gnu.org/software/m4/m4.html'
+description = """GNU M4 is an implementation of the traditional Unix macro processor.
+ It is mostly SVR4 compatible although it has some extensions 
+ (for example, handling more than 9 positional parameters to macros).
+ GNU M4 also has built-in functions for including files, running shell commands, doing arithmetic, etc."""
+
+toolchain = {'name': 'GCC', 'version': '4.7.4'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+patches = ['M4-%(version)s-no-gets.patch']
+
+configopts = "--enable-cxx"
+
+sanity_check_paths = {
+    'files': ["bin/m4"],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.9-gompi-1.4.20-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.9-gompi-1.4.20-LAPACK-3.5.0.eb
@@ -1,0 +1,50 @@
+name = 'OpenBLAS'
+version = '0.2.9'
+
+lapackver = '3.5.0'
+versionsuffix = '-LAPACK-%s' % lapackver
+
+homepage = 'http://xianyi.github.com/OpenBLAS/'
+description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
+
+toolchain = {'name': 'gompi', 'version': '1.4.20'}
+
+lapack_src = 'lapack-%s.tgz' % lapackver
+large_src = 'large.tgz'
+timing_src = 'timing.tgz'
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
+source_urls = [
+    # order matters, trying to download the LAPACK tarball from GitHub causes trouble
+    "http://www.netlib.org/lapack/",
+    "http://www.netlib.org/lapack/timing/",
+    "https://github.com/xianyi/OpenBLAS/archive/",
+]
+
+patches = [
+    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    (large_src, '.'),
+    (timing_src, '.'),
+]
+
+skipsteps = ['configure']
+
+threading = 'USE_THREAD=1'
+makeopts = 'BINARY=64 ' + threading + ' CC="$CC" FC="$F77"'
+installopts = threading + " PREFIX=%(installdir)s"
+
+# extensive testing can be enabled by uncommenting the line below
+#runtest = 'PATH=.:$PATH lapack-timing'
+
+sanity_check_paths = {
+    'files': ['include/cblas.h', 'include/f77blas.h', 'include/lapacke_config.h', 'include/lapacke.h',
+              'include/lapacke_mangling.h', 'include/lapacke_utils.h', 'include/openblas_config.h',
+              'lib/libopenblas.a', 'lib/libopenblas.%s' % shared_lib_ext],
+    'dirs': [],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.6-GCC-4.7.4.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.6-GCC-4.7.4.eb
@@ -1,5 +1,5 @@
 name = 'OpenMPI'
-version = "1.7.5"
+version = "1.6.6"
 
 homepage = 'http://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.6-GCC-4.7.4.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.6-GCC-4.7.4.eb
@@ -9,11 +9,6 @@ toolchain = {'name': 'GCC', 'version': '4.7.4'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
-builddependencies = [
-    ('Automake', '1.14'),
-    ('Autoconf', '2.69'),
-]
-
 dependencies = [('hwloc', '1.9')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-GCC-4.8.2.eb
@@ -9,11 +9,6 @@ toolchain = {'name': 'GCC', 'version': '4.8.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
-builddependencies = [
-    ('Automake', '1.14'),
-    ('Autoconf', '2.69'),
-]
-
 dependencies = [('hwloc', '1.7.2')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-gcccuda-2.6.10.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-gcccuda-2.6.10.eb
@@ -9,11 +9,6 @@ toolchain = {'name': 'gcccuda', 'version': '2.6.10'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
-builddependencies = [
-    ('Automake', '1.14'),
-    ('Autoconf', '2.69'),
-]
-
 dependencies = [('hwloc', '1.8')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.5-GCC-4.7.4.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.5-GCC-4.7.4.eb
@@ -1,0 +1,42 @@
+name = 'OpenMPI'
+version = "1.7.5"
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'GCC', 'version': '4.7.4'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+
+builddependencies = [
+    ('Automake', '1.14'),
+    ('Autoconf', '2.69'),
+]
+
+dependencies = [('hwloc', '1.9')]
+
+configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+
+# needed for --with-openib
+if OS_NAME in ['debian', 'ubuntu']:
+    osdependencies = ['libibverbs-dev']
+else:
+    # OK for OS_NAME == redhat, fedora, RHEL, SL, centos
+    osdependencies = ['libibverbs-devel']
+
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, shared_lib_ext) for libfile in ["mpi_cxx", "mpi_mpifh",
+                                                                         "mpi", "ompitrace", "open-pal",
+                                                                         "mpi", "ompitrace", "open-pal",
+                                                                         "open-rte", "vt", "vt-hyb",
+                                                                         "vt-mpi", "vt-mpi-unify"]] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-1.4.20-OpenBLAS-0.2.9-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-1.4.20-OpenBLAS-0.2.9-LAPACK-3.5.0.eb
@@ -1,0 +1,25 @@
+name = 'ScaLAPACK'
+version = '2.0.2'
+
+homepage = 'http://www.netlib.org/scalapack/'
+description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
+ redesigned for distributed memory MIMD parallel computers."""
+
+toolchain = {'name': 'gompi', 'version': '1.4.20'}
+toolchainopts = {'pic': True}
+
+source_urls = [homepage]
+sources = [SOURCELOWER_TGZ]
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.9'
+blassuff = '-LAPACK-3.5.0'
+
+versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+
+dependencies = [(blaslib, blasver, blassuff)]
+
+## parallel build tends to fail, so disabling it
+parallel = 1
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.7-goolf-1.4.20.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.7-goolf-1.4.20.eb
@@ -1,0 +1,22 @@
+name = 'zlib'
+version = '1.2.7'
+
+homepage = 'http://www.zlib.net/'
+description = """zlib is designed to be a free, general-purpose, legally unencumbered -- that is, 
+ not covered by any patents -- lossless data-compression library for use on virtually any 
+ computer hardware and operating system."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.20'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [('http://sourceforge.net/projects/libpng/files/zlib/%(version)s', 'download')]
+
+preconfigopts = 'LDSHARED="$CC -shared"'
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
this goolf uses the same GCC compiler like #928 (GCC/4.7.4) and provides incremental upgrades for all the underlying components; this toolchain is expected to have maximal compatibility with debuggers.

The intention is to use it with recursive --try, to provide debugg-able builds.