### PR TITLE
cutadapt-1.4.1-goolf-1.4.10-Python-2.7.5.eb

### DIFF
--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.4.1-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.4.1-goolf-1.4.10-Python-2.7.5.eb
@@ -1,0 +1,38 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics (SIB)
+# Biozentrum - University of Basel
+
+easyblock = "PythonPackage"
+
+name = 'cutadapt'
+version = '1.4.1'
+
+homepage = 'http://code.google.com/p/cutadapt/'
+description = """ cutadapt removes adapter sequences 
+ from high-throughput sequencing data. This is usually 
+ necessary when the read length of the sequencing machine 
+ is longer than the molecule that is sequenced, for 
+ example when sequencing microRNAs.  """
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+source_urls = ['https://github.com/marcelm/cutadapt/archive/']
+sources = ['v%(version)s.tar.gz']
+
+python = 'Python'
+pyver = '2.7.5'
+pyshortver = '.'.join(pyver.split('.')[:2])
+
+versionsuffix = "-%s-%s" % (python, pyver)
+
+dependencies = [
+    (python, pyver),
+]
+
+sanity_check_paths = {
+    'files': ['bin/cutadapt'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
updated to latest release

updated download url. Now code is on github and no longer in googlecode.