### PR TITLE
Adding ABINIT v.7.4.3 with dummy and goolf (parallel version) toolchains

### DIFF
--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.4.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.4.3-goolf-1.4.10.eb
@@ -1,0 +1,38 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2013-2014 The Cyprus Institute
+# Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>
+# License:: MIT/GPL
+#
+##
+
+name = 'ABINIT'
+version = '7.4.3'
+
+homepage = 'http://www.abinit.org/'
+description = """Abinit is a plane wave pseudopotential code for doing
+ condensed phase electronic structure calculations using DFT."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+# eg. http://ftp.abinit.org/abinit-7.0.5_x86_64_linux_gnu4.5.bz2
+sources = ['%s-%s.tar.gz' % (name.lower(), version)]
+source_urls = ['http://ftp.abinit.org/']
+
+configopts = '--enable-mpi --enable-mpi-io --with-mpi-prefix=$EBROOTOPENMPI --enable-fallbacks '
+configopts += '--with-netcdf-incs="-I$EBROOTNETCDF/include" --with-netcdf-libs="-L$EBROOTNETCDF/lib -lnetcdf -lnetcdff" '
+configopts += '--with-fft-libs="-L$EBROOTFFTW/lib -lfftw3 -lfftw3f" --with-fft-flavor=fftw3 '
+configopts += '--with-trio-flavor="netcdf+etsf_io" --enable-gw-dpc'
+
+dependencies = [
+                ('netCDF', '4.1.3'),
+                ('ETSF_IO', '1.0.4'),
+]
+
+sanity_check_paths = {
+                      'files': ["bin/abinit"], 
+                      'dirs': []
+                     }
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.4.3-x86_64_linux_gnu4.5.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.4.3-x86_64_linux_gnu4.5.eb
@@ -1,0 +1,32 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2013-2014 The Cyprus Institute
+# Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>
+# License:: MIT/GPL
+#
+##
+
+easyblock = "Tarball"
+
+name = 'ABINIT'
+version = '7.4.3'
+versionsuffix = '-x86_64_linux_gnu4.5'
+
+altversions = ['7.0.3', '7.0.4', '7.0.5']
+
+homepage = 'http://www.abinit.org/'
+description = """Abinit is a plane wave pseudopotential code for doing condensed phase electronic structure calculations using DFT."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+# eg. http://ftp.abinit.org/abinit-7.0.5_x86_64_linux_gnu4.5.bz2
+sources = [('abinit-%s_%s.bz2' % (version, versionsuffix[1:]), 'tar xfj %s')]
+source_urls = ['http://ftp.abinit.org/']
+
+sanity_check_paths = {
+                      'files': ["bin/abinit"], 
+                      'dirs': []
+                     }
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/e/ETSF_IO/ETSF_IO-1.0.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/e/ETSF_IO/ETSF_IO-1.0.4-goolf-1.4.10.eb
@@ -1,0 +1,29 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2013-2014 The Cyprus Institute
+# Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>
+# License:: MIT/GPL
+#
+##
+
+name = 'ETSF_IO'
+version = '1.0.4'
+
+homepage = 'http://www.etsf.eu/resources/software/libraries_and_tools'
+description = """A library of F90 routines to read/write the ETSF file format has been written. It is called ETSF_IO and available under LGPL. """
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+sources = ['http://www.etsf.eu/system/files/etsf_io-1.0.4.tar.gz']
+
+configopts = "--with-netcdf-prefix=$EBROOTNETCDF --with-netcdf-libs='-L$EBROOTNETCDF/lib -lnetcdf -lnetcdff' --with-netcdf-incs='-I$EBROOTNETCDF/include'"
+
+dependencies = [ ('netCDF', '4.1.3') ]
+
+sanity_check_paths = {
+                      'files': ["bin/etsf_io"], 
+                      'dirs': []
+                     }
+
+moduleclass = 'chem'


### PR DESCRIPTION
Adding ABINIT v.7.4.3 built with dummy toolchain and also parallel version of ABINIT 7.4.3
ETSF_IO is a dependency for the parallel version of ABINIT. 