### PR TITLE
distutils_multiple-lib-dirs patch file for numpy 1.8.1

### DIFF
--- a/easybuild/easyconfigs/n/numpy/numpy-1.8.1_distutils_multiple-lib-dirs.patch
+++ b/easybuild/easyconfigs/n/numpy/numpy-1.8.1_distutils_multiple-lib-dirs.patch
@@ -1,0 +1,200 @@
+diff -ru numpy-1.8.1.orig/numpy/distutils/fcompiler/__init__.py numpy-1.8.1/numpy/distutils/fcompiler/__init__.py
+--- numpy-1.8.1.orig/numpy/distutils/fcompiler/__init__.py	2014-04-09 14:38:52.000000000 +1200
++++ numpy-1.8.1/numpy/distutils/fcompiler/__init__.py	2014-04-09 14:47:35.000000000 +1200
+@@ -628,7 +628,11 @@
+         return options
+ 
+     def library_option(self, lib):
+-        return "-l" + lib
++        if lib[0]=='-':
++            return lib
++        else:
++            return "-l" + lib
++
+     def library_dir_option(self, dir):
+         return "-L" + dir
+ 
+diff -ru numpy-1.8.1.orig/numpy/distutils/system_info.py numpy-1.8.1/numpy/distutils/system_info.py
+--- numpy-1.8.1.orig/numpy/distutils/system_info.py	2014-04-09 14:38:49.000000000 +1200
++++ numpy-1.8.1/numpy/distutils/system_info.py	2014-04-09 14:47:43.000000000 +1200
+@@ -600,7 +600,7 @@
+             if is_string(default):
+                 return [default]
+             return default
+-        return [b for b in [a.strip() for a in libs.split(',')] if b]
++        return [b for b in [a.strip().replace(':',',') for a in libs.split(',')] if b]
+ 
+     def get_libraries(self, key='libraries'):
+         return self.get_libs(key, '')
+@@ -642,6 +642,23 @@
+                      lib_dirs)
+         return info
+ 
++    def check_libs_all(self,lib_dir,libs,opt_libs =[]):
++        """If static or shared libraries are available then return
++        their info dictionary.
++
++        Checks for all libraries as shared libraries first, then
++        static (or vice versa if self.search_static_first is True).
++        """
++        exts = self.library_extensions()
++        info = None
++        for ext in exts:
++            info = self._check_libs_all(lib_dir,libs,opt_libs,[ext])
++            if info is not None:
++                break
++        if not info:
++            log.info('  libraries %s not found in %s', ','.join(libs), lib_dir)
++        return info
++
+     def check_libs2(self, lib_dirs, libs, opt_libs=[]):
+         """If static or shared libraries are available then return
+         their info dictionary.
+@@ -655,6 +672,18 @@
+                      lib_dirs)
+         return info
+ 
++    def check_libs2_all(self, lib_dirs, libs, opt_libs =[]):
++        """If static or shared libraries are available then return
++        their info dictionary.
++
++        Checks each library for shared or static.
++        """
++        exts = self.library_extensions()
++        info = self._check_libs_all(lib_dirs,libs,opt_libs,exts)
++        if not info:
++            log.info('  libraries %s not found in %s', ','.join(libs), os.pathsep.join(lib_dirs))
++        return info
++
+     def _lib_list(self, lib_dir, libs, exts):
+         assert is_string(lib_dir)
+         liblist = []
+@@ -665,6 +694,9 @@
+             lib_prefixes = ['lib']
+         # for each library name, see if we can find a file for it.
+         for l in libs:
++            if l[0]=='-':
++                liblist.append(l)
++                continue
+             for ext in exts:
+                 for prefix in lib_prefixes:
+                     p = self.combine_paths(lib_dir, prefix + l + ext)
+@@ -680,6 +712,19 @@
+                     break
+         return liblist
+ 
++    def _lib_list_all(self, lib_dirs, libs, exts):
++        assert (type(lib_dirs)==list)
++        if lib_dirs:
++           assert is_string(lib_dirs[0])
++        liblist=[]
++        for lib_dir in lib_dirs:
++           ls=self._lib_list(lib_dir,libs,exts)
++           for l in ls:
++               log.info("(_lib_list_all) Found %s in %s"%(l,lib_dir))
++               if l not in liblist:
++                   liblist.append(l)
++        return liblist
++
+     def _check_libs(self, lib_dirs, libs, opt_libs, exts):
+         """Find mandatory and optional libs in expected paths.
+ 
+@@ -721,6 +766,22 @@
+         else:
+             return None
+ 
++    def _check_libs_all(self, lib_dirs, libs, opt_libs, exts):
++        found_libs_unordered = self._lib_list_all(lib_dirs, libs, exts)
++        # ensure same order as in lib_dirs
++        found_libs = []
++        for lib_dir in libs:
++            if lib_dir in found_libs_unordered:
++                found_libs.append(lib_dir)
++        if len(found_libs) == len(libs):
++            info = {'libraries' : found_libs, 'library_dirs' : lib_dirs}
++            opt_found_libs = self._lib_list_all(lib_dirs, opt_libs, exts)
++            if len(opt_found_libs) == len(opt_libs):
++                info['libraries'].extend(opt_found_libs)
++            return info
++        else:
++            return
++
+     def combine_paths(self, *args):
+         """Return a list of existing paths composed by all combinations
+         of items from the arguments.
+@@ -953,7 +1014,7 @@
+         lib_dirs = self.get_lib_dirs()
+         incl_dirs = self.get_include_dirs()
+         mkl_libs = self.get_libs('mkl_libs', self._lib_mkl)
+-        info = self.check_libs2(lib_dirs, mkl_libs)
++        info = self.check_libs2_all(lib_dirs, mkl_libs)
+         if info is None:
+             return
+         dict_append(info,
+@@ -1017,16 +1078,13 @@
+         atlas = None
+         lapack = None
+         atlas_1 = None
+-        for d in lib_dirs:
+-            atlas = self.check_libs2(d, atlas_libs, [])
+-            lapack_atlas = self.check_libs2(d, ['lapack_atlas'], [])
+-            if atlas is not None:
+-                lib_dirs2 = [d] + self.combine_paths(d, ['atlas*', 'ATLAS*'])
+-                lapack = self.check_libs2(lib_dirs2, lapack_libs, [])
+-                if lapack is not None:
+-                    break
+-            if atlas:
+-                atlas_1 = atlas
++        atlas = self.check_libs2_all(lib_dirs, atlas_libs)
++        lapack_atlas = self.check_libs2_all(lib_dirs, ['lapack_atlas'])
++        if atlas is not None:
++            lib_dirs2 = lib_dirs + self.combine_paths(lib_dirs,['atlas*','ATLAS*'])
++            lapack = self.check_libs2_all(lib_dirs2, lapack_libs)
++        if atlas:
++            atlas_1 = atlas
+         log.info(self.__class__)
+         if atlas is None:
+             atlas = atlas_1
+@@ -1105,7 +1163,7 @@
+         info = {}
+         atlas_libs = self.get_libs('atlas_libs',
+                                    self._lib_names + self._lib_atlas)
+-        atlas = self.check_libs2(lib_dirs, atlas_libs, [])
++        atlas = self.check_libs2_all(lib_dirs, atlas_libs, [])
+         if atlas is None:
+             return
+         include_dirs = self.get_include_dirs()
+@@ -1153,7 +1211,7 @@
+         lib_dirs = self.get_lib_dirs()
+ 
+         lapack_libs = self.get_libs('lapack_libs', self._lib_names)
+-        info = self.check_libs(lib_dirs, lapack_libs, [])
++        info = self.check_libs_all(lib_dirs, lapack_libs, [])
+         if info is None:
+             return
+         info['language'] = 'f77'
+@@ -1548,7 +1606,7 @@
+         lib_dirs = self.get_lib_dirs()
+ 
+         blas_libs = self.get_libs('blas_libs', self._lib_names)
+-        info = self.check_libs(lib_dirs, blas_libs, [])
++        info = self.check_libs_all(lib_dirs, blas_libs, [])
+         if info is None:
+             return
+         info['language'] = 'f77'  # XXX: is it generally true?
+diff -ru numpy-1.8.1.orig/numpy/distutils/unixccompiler.py numpy-1.8.1/numpy/distutils/unixccompiler.py
+--- numpy-1.8.1.orig/numpy/distutils/unixccompiler.py	2014-04-09 14:38:49.000000000 +1200
++++ numpy-1.8.1/numpy/distutils/unixccompiler.py	2014-04-09 14:47:53.000000000 +1200
+@@ -111,3 +111,12 @@
+ 
+ replace_method(UnixCCompiler, 'create_static_lib',
+                UnixCCompiler_create_static_lib)
++
++def UnixCCompiler_library_option(self, lib):
++    if lib[0]=='-':
++        return lib
++    else:
++        return "-l" + lib
++
++replace_method(UnixCCompiler, 'library_option',
++               UnixCCompiler_library_option)


### PR DESCRIPTION
Also known to work with numpy 1.8.2, this patch is equivalent to the similarly named one for numpy 1.7.1, but some lines have moved around in the target files.