### PR TITLE
add easyconfig for intel/2015a + HPL for testing

### DIFF
--- a/easybuild/easyconfigs/h/HPL/HPL-2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.1-intel-2015a.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.1'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+toolchainopts = {'optarch': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/HPL/HPL-2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.1-intel-2015a.eb
@@ -1,3 +1,5 @@
+easyblock = 'ConfigureMake'
+
 name = 'HPL'
 version = '2.1'
 

--- a/easybuild/easyconfigs/h/HPL/HPL-2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.1-intel-2015a.eb
@@ -1,5 +1,3 @@
-easyblock = 'ConfigureMake'
-
 name = 'HPL'
 version = '2.1'
 

--- a/easybuild/easyconfigs/i/intel/intel-2015a.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2015a.eb
@@ -1,0 +1,21 @@
+easyblock = "Toolchain"
+
+name = 'intel'
+version = '2015a'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MPI & Intel MKL."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+compver = '2015.1.133'
+gccsuff = '-GCC-4.9.2'
+
+dependencies = [
+    ('icc', compver, gccsuff),
+    ('ifort', compver, gccsuff),
+    ('impi', '5.0.2.044', '', ('iccifort', '%s%s' % (compver, gccsuff))),
+    ('imkl', '11.2.1.133', '', ('iimpi', '7.2.3%s' % gccsuff)),
+]
+
+moduleclass = 'toolchain'


### PR DESCRIPTION
Proposal for the `intel/2015a` "common toolchain".

Identical to the recently contributed `intel/2014.11` toolchain, consisting of:

* GCC version 4.9.2 (latest to date)
* icc/ifort release 2015.1.133, a.k.a. version 15.0.1.133 (Oct 31st 2014, latest to date)
* impi version 5.0.2.044 (Nov 17th 2014, latest to date)
* imkl version 11.2.1.133 (Oct 31st 2014, latest to date)

Latest available versions of all components were selected keeping in mind that they are required for several important features, including (full) C++11 support, OpenMP v4, MPI3.
This tips the scale in favour of most recent releases rather than being conservative and going for the last update of the previous major release.

Results from testing this toolchain by rebuilding existing `ictce`/`intel` easyconfigs with `intel/2015a` will be posted soon. 