### PR TITLE
GCC LTO cleanup

### DIFF
--- a/easybuild/easyconfigs/g/GCC/GCC-4.6.3-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.6.3-CLooG-PPL.eb
@@ -29,7 +29,7 @@ sources = [
     'ppl-%s.tar.gz' % pplver,
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withppl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.6.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.6.3.eb
@@ -20,7 +20,7 @@ sources = [
     'mpc-0.9.tar.gz',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/easybuild/easyconfigs/g/GCC/GCC-4.6.4.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.6.4.eb
@@ -20,7 +20,7 @@ sources = [
     'mpc-1.0.1.tar.gz',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 patches = ['mpfr-3.1.0-changes_fix.patch']
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.0-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.0-CLooG-PPL.eb
@@ -31,7 +31,7 @@ sources = [
 
 patches = ['mpfr-3.1.0-changes_fix.patch']
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withppl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.0.eb
@@ -22,7 +22,7 @@ source_urls = [
 
 patches = ['mpfr-3.1.0-changes_fix.patch']
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.1-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.1-CLooG-PPL.eb
@@ -31,7 +31,7 @@ sources = [
 
 patches = ['mpfr-3.1.0-changes_fix.patch']
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withppl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.1.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.1.eb
@@ -22,7 +22,7 @@ sources = [
 
 patches = ['mpfr-3.1.0-changes_fix.patch']
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.2.eb
@@ -22,7 +22,7 @@ sources = [
 
 patches = ['mpfr-3.1.0-changes_fix.patch']
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.3-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.3-CLooG-PPL.eb
@@ -34,7 +34,7 @@ patches = [
     'mpfr-3.1.0-changes_fix.patch',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withppl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.3.eb
@@ -22,7 +22,7 @@ sources = [
 
 patches = ['mpfr-3.1.0-changes_fix.patch']
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.4-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.4-CLooG-PPL.eb
@@ -34,7 +34,7 @@ patches = [
     'mpfr-3.1.0-changes_fix.patch',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withppl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.4.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.4.eb
@@ -22,7 +22,7 @@ sources = [
 
 patches = ['mpfr-3.1.0-changes_fix.patch']
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.1-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.1-CLooG.eb
@@ -26,7 +26,7 @@ sources = [
     'isl-0.11.1.tar.bz2',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withisl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.1.eb
@@ -20,7 +20,7 @@ sources = [
     'mpc-1.0.1.tar.gz',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.2-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.2-CLooG-multilib.eb
@@ -26,7 +26,7 @@ sources = [
     'isl-0.11.1.tar.bz2',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withisl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.2-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.2-CLooG.eb
@@ -26,7 +26,7 @@ sources = [
     'isl-0.11.1.tar.bz2',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withisl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.2-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.2-multilib.eb
@@ -21,7 +21,7 @@ sources = [
     'mpc-1.0.1.tar.gz',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 multilib = True
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.2.eb
@@ -20,7 +20,7 @@ sources = [
     'mpc-1.0.1.tar.gz',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.3-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.3-CLooG-multilib.eb
@@ -26,7 +26,7 @@ sources = [
     'isl-0.11.1.tar.bz2',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withisl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.3.eb
@@ -20,7 +20,7 @@ sources = [
     'mpc-1.0.1.tar.gz',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG-multilib.eb
@@ -31,7 +31,7 @@ sources = [
 
 patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withisl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG.eb
@@ -31,7 +31,7 @@ sources = [
 
 patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withisl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.0.eb
@@ -25,7 +25,7 @@ sources = [
 
 patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG-multilib.eb
@@ -31,7 +31,7 @@ sources = [
 
 patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withisl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG.eb
@@ -31,7 +31,7 @@ sources = [
 
 patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withisl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.1.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.1.eb
@@ -25,7 +25,7 @@ sources = [
 
 patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG-multilib.eb
@@ -31,7 +31,7 @@ sources = [
 
 patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withisl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG.eb
@@ -31,7 +31,7 @@ sources = [
 
 patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 withcloog = True
 withisl = True

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2.eb
@@ -25,7 +25,7 @@ sources = [
 
 patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+languages = ['c', 'c++', 'fortran']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4


### PR DESCRIPTION
**NOTE: Requires https://github.com/hpcugent/easybuild-easyblocks/pull/535 to be functionally equivalent**, though this PR doesn't break anything but only suppresses the LTO sanity check if the aforementioned easyblocks PR is not applied.

Once https://github.com/hpcugent/easybuild-easyblocks/pull/535 is in place, link-time optimization support for GCC is entirely controlled via the custom `withlto` easyconfig parameter. Thus, listing `lto` in the language list is no longer necessary (it doesn't hurt but is silently ignored).

@wpoely86: If https://github.com/hpcugent/easybuild-easyblocks/pull/535 and this PR gets in, https://github.com/hpcugent/easybuild-easyconfigs/pull/1279 should also be adjusted accordingly.