### PR TITLE
{toolchain} [iomkl/2015.01] (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.1.133-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.1.133-GCC-4.9.2.eb
@@ -16,6 +16,7 @@ configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple 
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += ' CC=icc F77=ifort FC=ifort CXX=icpc '
 
 dependencies = [('hwloc', '1.10.0')]
 


### PR DESCRIPTION
with the previous openMPI easyconfig gfortran was being used instead of ifort when running "mpifort"

```
[escobar@maia ~]$ mpifort --version
GNU Fortran (GCC) 4.9.2
```

I have updated the configopts for OpenMPI and now ifort is being used

```
[pub@maia easybuild-easyconfigs]$ mpifort --version
ifort (IFORT) 15.0.1 20141023
```

@boegel can you review?