### PR TITLE
R 3.0.2 modules sources update

### DIFF
--- a/easybuild/easyconfigs/r/R/R-2.15.2-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goalf-1.1.0-no-OFED.eb
@@ -134,7 +134,7 @@ exts_list = [
     ('R.methodsS3', '1.4.2', ext_options),
     ('R.oo', '1.13.0', ext_options),
     ('R.matlab', '1.7.0', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('gbm', '2.1', ext_options),
 
 ]

--- a/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-goolf-1.4.10.eb
@@ -134,7 +134,7 @@ exts_list = [
     ('R.methodsS3', '1.4.2', ext_options),
     ('R.oo', '1.13.0', ext_options),
     ('R.matlab', '1.7.0', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('gbm', '2.1', ext_options),
 ]
 

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.10.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.10.eb
@@ -134,7 +134,7 @@ exts_list = [
     ('R.methodsS3', '1.4.2', ext_options),
     ('R.oo', '1.13.0', ext_options),
     ('R.matlab', '1.7.0', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('gbm', '2.1', ext_options),
 ]
 

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-4.0.6.eb
@@ -134,7 +134,7 @@ exts_list = [
     ('R.methodsS3', '1.4.2', ext_options),
     ('R.oo', '1.13.0', ext_options),
     ('R.matlab', '1.7.0', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('gbm', '2.1', ext_options),
 ]
 

--- a/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.2-ictce-5.3.0.eb
@@ -134,7 +134,7 @@ exts_list = [
     ('R.methodsS3', '1.4.2', ext_options),
     ('R.oo', '1.13.0', ext_options),
     ('R.matlab', '1.7.0', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('gbm', '2.1', ext_options),
 ]
 

--- a/easybuild/easyconfigs/r/R/R-2.15.3-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-goalf-1.1.0-no-OFED.eb
@@ -127,7 +127,7 @@ exts_list = [
     ('R.methodsS3', '1.4.2', ext_options),
     ('R.oo', '1.13.0', ext_options),
     ('R.matlab', '1.7.0', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('BiocGenerics', '0.6.0', bioconductor_options),
     ('Biobase', '2.20.0', bioconductor_options),
     ('IRanges', '1.18.1', bioconductor_options),

--- a/easybuild/easyconfigs/r/R/R-2.15.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-goolf-1.4.10.eb
@@ -127,7 +127,7 @@ exts_list = [
     ('R.methodsS3', '1.4.2', ext_options),
     ('R.oo', '1.13.0', ext_options),
     ('R.matlab', '1.7.0', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('BiocGenerics', '0.6.0', bioconductor_options),
     ('Biobase', '2.20.0', bioconductor_options),
     ('IRanges', '1.18.1', bioconductor_options),

--- a/easybuild/easyconfigs/r/R/R-2.15.3-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-ictce-4.1.13.eb
@@ -127,7 +127,7 @@ exts_list = [
     ('R.methodsS3', '1.4.2', ext_options),
     ('R.oo', '1.13.0', ext_options),
     ('R.matlab', '1.7.0', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('BiocGenerics', '0.6.0', bioconductor_options),
     ('Biobase', '2.20.0', bioconductor_options),
     ('IRanges', '1.18.1', bioconductor_options),

--- a/easybuild/easyconfigs/r/R/R-2.15.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-2.15.3-ictce-5.3.0.eb
@@ -127,7 +127,7 @@ exts_list = [
     ('R.methodsS3', '1.4.2', ext_options),
     ('R.oo', '1.13.0', ext_options),
     ('R.matlab', '1.7.0', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('BiocGenerics', '0.6.0', bioconductor_options),
     ('Biobase', '2.20.0', bioconductor_options),
     ('IRanges', '1.18.1', bioconductor_options),

--- a/easybuild/easyconfigs/r/R/R-3.0.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-goolf-1.4.10.eb
@@ -132,7 +132,7 @@ exts_list = [
     ('R.methodsS3', '1.5.2', ext_options),
     ('R.oo', '1.15.8', ext_options),
     ('R.matlab', '2.0.5', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-35', rforge_options),
     ('BiocGenerics', '0.8.0', bioconductor_options),
     ('Biobase', '2.22.0', bioconductor_options),
     ('IRanges', '1.20.5', bioconductor_options),
@@ -142,7 +142,7 @@ exts_list = [
     ('GenomicRanges', '1.14.3', bioconductor_options),
     ('BSgenome', '1.30.0', bioconductor_options),
     ('zlibbioc', '1.8.0', bioconductor_options),
-    ('Rsamtools', '1.14.1', bioconductor_options),
+    ('Rsamtools', '1.14.3', bioconductor_options),
     ('ShortRead', '1.20.0', bioconductor_options),
     ('graph', '1.40.0', bioconductor_options),
     ('igraph0', '0.5.7', ext_options),
@@ -166,7 +166,7 @@ exts_list = [
     ('speff2trial', '1.0.4', ext_options),
     ('nleqslv', '2.1', ext_options),
     ('glmnet', '1.9-5', ext_options),
-    ('pim', '1.1.5.4', rforge_options),
+    ('pim', '1.1.5.6', rforge_options),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.0.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-goolf-1.4.10.eb
@@ -132,7 +132,7 @@ exts_list = [
     ('R.methodsS3', '1.5.2', ext_options),
     ('R.oo', '1.15.8', ext_options),
     ('R.matlab', '2.0.5', ext_options),
-    ('Rniftilib', '0.0-35', rforge_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('BiocGenerics', '0.8.0', bioconductor_options),
     ('Biobase', '2.22.0', bioconductor_options),
     ('IRanges', '1.20.5', bioconductor_options),
@@ -142,7 +142,7 @@ exts_list = [
     ('GenomicRanges', '1.14.3', bioconductor_options),
     ('BSgenome', '1.30.0', bioconductor_options),
     ('zlibbioc', '1.8.0', bioconductor_options),
-    ('Rsamtools', '1.14.3', bioconductor_options),
+    ('Rsamtools', '1.14.1', bioconductor_options),
     ('ShortRead', '1.20.0', bioconductor_options),
     ('graph', '1.40.0', bioconductor_options),
     ('igraph0', '0.5.7', ext_options),
@@ -166,7 +166,7 @@ exts_list = [
     ('speff2trial', '1.0.4', ext_options),
     ('nleqslv', '2.1', ext_options),
     ('glmnet', '1.9-5', ext_options),
-    ('pim', '1.1.5.6', rforge_options),
+    ('pim', '1.1.5.4', rforge_options),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0.eb
@@ -131,7 +131,7 @@ exts_list = [
     ('R.methodsS3', '1.5.2', ext_options),
     ('R.oo', '1.15.8', ext_options),
     ('R.matlab', '2.0.5', ext_options),
-    ('Rniftilib', '0.0-35', rforge_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('BiocGenerics', '0.8.0', bioconductor_options),
     ('Biobase', '2.22.0', bioconductor_options),
     ('IRanges', '1.20.5', bioconductor_options),
@@ -141,7 +141,7 @@ exts_list = [
     ('GenomicRanges', '1.14.3', bioconductor_options),
     ('BSgenome', '1.30.0', bioconductor_options),
     ('zlibbioc', '1.8.0', bioconductor_options),
-    ('Rsamtools', '1.14.3', bioconductor_options),
+    ('Rsamtools', '1.14.1', bioconductor_options),
     ('ShortRead', '1.20.0', bioconductor_options),
     ('graph', '1.40.0', bioconductor_options),
     ('igraph0', '0.5.7', ext_options),
@@ -165,7 +165,7 @@ exts_list = [
     ('speff2trial', '1.0.4', ext_options),
     ('nleqslv', '2.1', ext_options),
     ('glmnet', '1.9-5', ext_options),
-    ('pim', '1.1.5.6', rforge_options),
+    ('pim', '1.1.5.4', rforge_options),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.3.0.eb
@@ -131,7 +131,7 @@ exts_list = [
     ('R.methodsS3', '1.5.2', ext_options),
     ('R.oo', '1.15.8', ext_options),
     ('R.matlab', '2.0.5', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-35', rforge_options),
     ('BiocGenerics', '0.8.0', bioconductor_options),
     ('Biobase', '2.22.0', bioconductor_options),
     ('IRanges', '1.20.5', bioconductor_options),
@@ -141,7 +141,7 @@ exts_list = [
     ('GenomicRanges', '1.14.3', bioconductor_options),
     ('BSgenome', '1.30.0', bioconductor_options),
     ('zlibbioc', '1.8.0', bioconductor_options),
-    ('Rsamtools', '1.14.1', bioconductor_options),
+    ('Rsamtools', '1.14.3', bioconductor_options),
     ('ShortRead', '1.20.0', bioconductor_options),
     ('graph', '1.40.0', bioconductor_options),
     ('igraph0', '0.5.7', ext_options),
@@ -165,7 +165,7 @@ exts_list = [
     ('speff2trial', '1.0.4', ext_options),
     ('nleqslv', '2.1', ext_options),
     ('glmnet', '1.9-5', ext_options),
-    ('pim', '1.1.5.4', rforge_options),
+    ('pim', '1.1.5.6', rforge_options),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/r/R/R-3.0.2-ictce-5.5.0.eb
@@ -131,7 +131,7 @@ exts_list = [
     ('R.methodsS3', '1.5.2', ext_options),
     ('R.oo', '1.15.8', ext_options),
     ('R.matlab', '2.0.5', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('BiocGenerics', '0.8.0', bioconductor_options),
     ('Biobase', '2.22.0', bioconductor_options),
     ('IRanges', '1.20.5', bioconductor_options),

--- a/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.0-ictce-5.5.0.eb
@@ -116,7 +116,7 @@ exts_list = [
     ('R.oo', '1.18.0', ext_options),
     ('R.utils', '1.32.4', ext_options),
     ('R.matlab', '3.0.1', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('iterators', '1.0.7', ext_options),
     ('foreach', '1.4.2', ext_options),
     ('BBmisc', '1.6', ext_options),

--- a/easybuild/easyconfigs/r/R/R-3.1.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.1-intel-2014b.eb
@@ -206,7 +206,7 @@ exts_list = [
     ('cgdsr', '1.1.30', ext_options),
     ('R.utils', '1.32.4', ext_options),
     ('R.matlab', '3.0.1', ext_options),
-    ('Rniftilib', '0.0-32', ext_options),
+    ('Rniftilib', '0.0-32', rforge_options),
     ('BiocGenerics', '0.10.0', bioconductor_options),
     ('Biobase', '2.24.0', bioconductor_options),
     ('IRanges', '1.22.10', bioconductor_options),


### PR DESCRIPTION
Some of the modules are not available anymore in their current version of the easyconfig file and/or not at the same URL. I just changed some minor version versions to fit with the ones currently available and/or the source URL from which the module is available.

These changes may be applicable to the R-3.0.2-ictce-5.5.0.eb easyconfig file too, but since I hadn't the ictce-5.5.0 toolchain to test it, I prefered to not take a wild guess that it would also work.