### PR TITLE
add unit test to check that all extra_options keys are defined in EasyConfig instance

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -266,6 +266,10 @@ def template_easyconfig_test(self, spec):
                     msg = "Patch file %s is available for %s" % (ext_patch_full, specfn)
                     self.assertTrue(os.path.isfile(ext_patch_full), msg)
 
+    # check whether all extra_options defined for used easyblock are defined
+    for key in app.extra_options():
+        self.assertTrue(key in app.cfg)
+
     app.close_log()
     os.remove(app.logfile)
 


### PR DESCRIPTION
Enhanced unit tests to cover the situation where the (new) generic easyblock used for PyQt4 had a bug in it that went unnoticed, cfr. https://github.com/hpcugent/easybuild-easyconfigs/pull/1349.

depends on https://github.com/hpcugent/easybuild-framework/pull/1155 and https://github.com/hpcugent/easybuild-easyblocks/pull/547 to avoid triggering deprecated behaviour