### PR TITLE
Consistently use CLooG 0.18.0 for GCC 4.8 series

### DIFF
--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.3-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.3-CLooG-multilib.eb
@@ -22,7 +22,7 @@ sources = [
     'gmp-5.1.3.tar.bz2',
     'mpfr-3.1.2.tar.gz',
     'mpc-1.0.1.tar.gz',
-    'cloog-0.18.1.tar.gz',
+    'cloog-0.18.0.tar.gz',
     'isl-0.11.1.tar.bz2',
 ]
 
@@ -31,7 +31,7 @@ checksums = [
     'a082867cbca5e898371a97bb27b31fea',     # gmp-5.1.3.tar.bz2
     '181aa7bb0e452c409f2788a4a7f38476',     # mpfr-3.1.2.tar.gz
     'b32a2e1a3daa392372fbd586d1ed3679',     # mpc-1.0.1.tar.gz
-    'e34fca0540d840e5d0f6427e98c92252',     # cloog-0.18.1.tar.gz
+    'be78a47bd82523250eb3e91646db5b3d',     # cloog-0.18.0.tar.gz
     'bce1586384d8635a76d2f017fb067cd2',     # isl-0.11.1.tar.bz2
 ]
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.4-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.4-CLooG-multilib.eb
@@ -22,7 +22,7 @@ sources = [
     'gmp-5.1.3.tar.bz2',
     'mpfr-3.1.2.tar.gz',
     'mpc-1.0.1.tar.gz',
-    'cloog-0.18.1.tar.gz',
+    'cloog-0.18.0.tar.gz',
     'isl-0.11.1.tar.bz2',
 ]
 
@@ -31,7 +31,7 @@ checksums = [
     'a082867cbca5e898371a97bb27b31fea',     # gmp-5.1.3.tar.bz2
     '181aa7bb0e452c409f2788a4a7f38476',     # mpfr-3.1.2.tar.gz
     'b32a2e1a3daa392372fbd586d1ed3679',     # mpc-1.0.1.tar.gz
-    'e34fca0540d840e5d0f6427e98c92252',     # cloog-0.18.1.tar.gz
+    'be78a47bd82523250eb3e91646db5b3d',     # cloog-0.18.0.tar.gz
     'bce1586384d8635a76d2f017fb067cd2',     # isl-0.11.1.tar.bz2
 ]
 


### PR DESCRIPTION
CLooG 0.18.0 is specified as a dependency in the `INSTALL/prerequisites.html` file of GCC 4.8.[1-4]. Thus, don't try to use a newer version.