### PR TITLE
{vis}[goolf-1.4.10-Python-2.7.5] Pmw 1.3.3 (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/p/Pmw/Pmw-1.3.3-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/p/Pmw/Pmw-1.3.3-goolf-1.4.10-Python-2.7.5.eb
@@ -1,0 +1,37 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Adam Mazur
+# Research IT
+# Biozentrum, University of Basel
+
+easyblock = "PythonPackage"
+
+name = 'Pmw'
+version = '1.3.3'
+
+homepage = 'http://pmw.sourceforge.net'
+description = """Pmw is a toolkit for building high-level compound widgets in Python
+ using the Tkinter module. """
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+source_urls = ['http://sourceforge.net/projects/%(namelower)s/files/%(name)s/%(name)s.%(version)s/', '/download']
+sources = ['%(name)s.%(version)s.tar.gz']
+
+python = 'Python'
+pyver = '2.7.5'
+pyshortver = '.'.join(pyver.split('.')[:2])
+
+versionsuffix = "-%s-%s" % (python, pyver)
+
+dependencies = [
+    (python, pyver),
+]
+
+options = {'modulename': 'Pmw'}
+
+sanity_check_paths = {
+    'files': ['lib/python%s/site-packages/%s-%s-py%s.egg-info' % (pyshortver, name, version, pyshortver)],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/Pmw/Pmw-1.3.3-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/p/Pmw/Pmw-1.3.3-goolf-1.4.10-Python-2.7.5.eb
@@ -14,7 +14,7 @@ description = """Pmw is a toolkit for building high-level compound widgets in Py
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-source_urls = ['http://sourceforge.net/projects/%(namelower)s/files/%(name)s/%(name)s.%(version)s/', '/download']
+source_urls = ['http://sourceforge.net/projects/%(namelower)s/files/%(name)s/%(name)s.%(version)s/']
 sources = ['%(name)s.%(version)s.tar.gz']
 
 python = 'Python'


### PR DESCRIPTION
Pmw library is required for fully funcional PyMOL