### PR TITLE
added libopenssl-devel to the list of acceptable OS deps for openssl dev packages

### DIFF
--- a/easybuild/easyconfigs/c/cURL/cURL-7.37.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/c/cURL/cURL-7.37.1-intel-2014b.eb
@@ -17,7 +17,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://curl.haxx.se/download/']
 
 #dependencies = [('OpenSSL', '1.0.1i')] # OS dependency should be preferred for security reasons
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
     'files': ['bin/curl', 'lib/libcurl.a', 'lib/libcurl.so'],

--- a/easybuild/easyconfigs/m/MySQL/MySQL-5.6.20-intel-2014b-clientonly.eb
+++ b/easybuild/easyconfigs/m/MySQL/MySQL-5.6.20-intel-2014b-clientonly.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 
 toolchain = {'name': 'intel', 'version': '2014b'}
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 dependencies = [
     ('libevent', '2.0.21'),

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-goalf-1.1.0-no-OFED-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-goalf-1.1.0-no-OFED-bare.eb
@@ -19,6 +19,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-gompi-1.4.12-no-OFED-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-gompi-1.4.12-no-OFED-bare.eb
@@ -19,6 +19,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-goolf-1.4.10-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-goolf-1.4.10-bare.eb
@@ -19,6 +19,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.0.6-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.0.6-bare.eb
@@ -21,6 +21,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.1.13-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.1.13-bare.eb
@@ -21,6 +21,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-5.2.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-5.2.0-bare.eb
@@ -19,6 +19,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-5.3.0-bare.eb
@@ -19,6 +19,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmpolf-1.1.6.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmpolf-1.1.6.eb
@@ -80,6 +80,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmvolf-1.1.12rc1.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmvolf-1.1.12rc1.eb
@@ -78,6 +78,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmvolf-1.2.7.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmvolf-1.2.7.eb
@@ -80,6 +80,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-cgoolf-1.1.7.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-cgoolf-1.1.7.eb
@@ -78,6 +78,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-gmpolf-1.4.8.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-gmpolf-1.4.8.eb
@@ -80,6 +80,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-gmvolf-1.7.12.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-gmvolf-1.7.12.eb
@@ -80,6 +80,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-gmvolf-1.7.12rc1.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-gmvolf-1.7.12rc1.eb
@@ -80,6 +80,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-goalf-1.1.0-no-OFED.eb
@@ -80,6 +80,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.4.10.eb
@@ -80,6 +80,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.5.14.eb
@@ -80,6 +80,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-4.0.6.eb
@@ -80,6 +80,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-4.1.13.eb
@@ -80,6 +80,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.2.0.eb
@@ -78,6 +78,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.3.0.eb
@@ -78,6 +78,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-iomkl-4.6.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-iomkl-4.6.13.eb
@@ -80,6 +80,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-iqacml-3.7.3.eb
@@ -84,6 +84,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-goalf-1.5.12-no-OFED.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-goalf-1.5.12-no-OFED.eb
@@ -78,6 +78,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-goolf-1.4.10.eb
@@ -80,6 +80,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-4.1.13.eb
@@ -83,6 +83,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.3.0.eb
@@ -81,6 +81,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.5.0.eb
@@ -81,6 +81,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-iqacml-3.7.3.eb
@@ -85,6 +85,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.6-goolf-1.4.10.eb
@@ -80,6 +80,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-4.1.13.eb
@@ -83,6 +83,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-5.5.0.eb
@@ -83,6 +83,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-foss-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-foss-2014b.eb
@@ -87,6 +87,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-ictce-7.1.2.eb
@@ -92,6 +92,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2014b.eb
@@ -89,6 +89,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-goalf-1.1.0-no-OFED.eb
@@ -64,6 +64,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-goolf-1.4.10.eb
@@ -64,6 +64,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-4.0.6.eb
@@ -66,6 +66,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-5.3.0.eb
@@ -64,6 +64,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-3.3.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.3.2-goolf-1.4.10.eb
@@ -42,6 +42,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-3.3.2-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.3.2-ictce-4.1.13.eb
@@ -44,6 +44,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-3.3.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.3.2-ictce-5.3.0.eb
@@ -44,6 +44,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
@@ -91,6 +91,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'


### PR DESCRIPTION
A lot of existing easyconfigs used 'openssl-devel' and 'libssl-dev' under osdependencies to indicate the need to have development files for openssl. SLES 11 uses 'libopenssl-devel', so we add that as a third option.