### PR TITLE
add SLES11 package to openssl devel os dependency

### DIFF
--- a/easybuild/easyconfigs/c/cURL/cURL-7.37.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/c/cURL/cURL-7.37.1-intel-2014b.eb
@@ -17,7 +17,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://curl.haxx.se/download/']
 
 #dependencies = [('OpenSSL', '1.0.1i')] # OS dependency should be preferred for security reasons
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
     'files': ['bin/curl', 'lib/libcurl.a', 'lib/libcurl.so'],

--- a/easybuild/easyconfigs/c/cURL/cURL-7.37.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/c/cURL/cURL-7.37.1-intel-2015a.eb
@@ -17,7 +17,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://curl.haxx.se/download/']
 
 #dependencies = [('OpenSSL', '1.0.1i')] # OS dependency should be preferred for security reasons
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
     'files': ['bin/curl', 'lib/libcurl.a', 'lib/libcurl.so'],

--- a/easybuild/easyconfigs/c/cURL/cURL-7.40.0-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/c/cURL/cURL-7.40.0-GCC-4.9.2.eb
@@ -18,7 +18,7 @@ source_urls = ['http://curl.haxx.se/download/']
 
 # dependencies = [('OpenSSL', '1.0.1k')]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # configopts = "--with-ssl=$EBROOTOPENSSL"
 

--- a/easybuild/easyconfigs/c/cURL/cURL-7.40.0-foss-2015a.eb
+++ b/easybuild/easyconfigs/c/cURL/cURL-7.40.0-foss-2015a.eb
@@ -16,7 +16,7 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://curl.haxx.se/download/']
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
     'files': ['bin/curl', 'lib/libcurl.a', 'lib/libcurl.so'],

--- a/easybuild/easyconfigs/c/cURL/cURL-7.40.0-intel-2015a.eb
+++ b/easybuild/easyconfigs/c/cURL/cURL-7.40.0-intel-2015a.eb
@@ -18,7 +18,7 @@ source_urls = ['http://curl.haxx.se/download/']
 
 # dependencies = [('OpenSSL', '1.0.1k')]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # configopts = "--with-ssl=$EBROOTOPENSSL"
 

--- a/easybuild/easyconfigs/m/MySQL/MySQL-5.6.20-intel-2014b-clientonly.eb
+++ b/easybuild/easyconfigs/m/MySQL/MySQL-5.6.20-intel-2014b-clientonly.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 
 toolchain = {'name': 'intel', 'version': '2014b'}
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 dependencies = [
     ('libevent', '2.0.21'),

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-goalf-1.1.0-no-OFED-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-goalf-1.1.0-no-OFED-bare.eb
@@ -19,6 +19,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-gompi-1.4.12-no-OFED-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-gompi-1.4.12-no-OFED-bare.eb
@@ -19,6 +19,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-goolf-1.4.10-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-goolf-1.4.10-bare.eb
@@ -19,6 +19,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.0.6-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.0.6-bare.eb
@@ -21,6 +21,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.1.13-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.1.13-bare.eb
@@ -21,6 +21,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-5.2.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-5.2.0-bare.eb
@@ -19,6 +19,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-5.3.0-bare.eb
@@ -19,6 +19,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmpolf-1.1.6.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmpolf-1.1.6.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmvolf-1.1.12rc1.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmvolf-1.1.12rc1.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmvolf-1.2.7.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmvolf-1.2.7.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-cgoolf-1.1.7.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-cgoolf-1.1.7.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-gmpolf-1.4.8.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-gmpolf-1.4.8.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-gmvolf-1.7.12.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-gmvolf-1.7.12.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-gmvolf-1.7.12rc1.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-gmvolf-1.7.12rc1.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-goalf-1.1.0-no-OFED.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.4.10.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.5.14.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-4.0.6.eb
@@ -24,7 +24,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-4.1.13.eb
@@ -24,7 +24,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.2.0.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.3.0.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-iomkl-4.6.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-iomkl-4.6.13.eb
@@ -24,7 +24,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-iqacml-3.7.3.eb
@@ -25,7 +25,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-goalf-1.5.12-no-OFED.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-goalf-1.5.12-no-OFED.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-goolf-1.4.10.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-4.1.13.eb
@@ -25,7 +25,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.3.0.eb
@@ -25,7 +25,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.5.0.eb
@@ -25,7 +25,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-iqacml-3.7.3.eb
@@ -26,7 +26,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.6-goolf-1.4.10.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-4.1.13.eb
@@ -25,7 +25,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-5.5.0.eb
@@ -25,7 +25,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-foss-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-foss-2014b.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1g'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-ictce-7.1.2.eb
@@ -28,7 +28,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1g'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 # Version updated 08/JULY/2014

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2014b.eb
@@ -25,7 +25,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1g'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 # Version updated 08/JULY/2014

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2015a.eb
@@ -97,6 +97,6 @@ exts_list = [
     }),
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a-bare.eb
@@ -21,7 +21,7 @@ dependencies = [
 #   nice to have an up to date openssl for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # bare installation: no extensions included
 exts_list = []

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
@@ -23,7 +23,7 @@ dependencies = [
 #   nice to have an up to date openssl for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 # package versions updated Jan 19th 2015

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-gompi-1.5.16-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-gompi-1.5.16-bare.eb
@@ -19,6 +19,6 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
@@ -23,7 +23,7 @@ dependencies = [
 #   nice to have an up to date openssl for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 # package versions updated Jan 19th 2015

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a-bare.eb
@@ -21,7 +21,7 @@ dependencies = [
 #   nice to have an up to date openssl for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # bare installation: no extensions included
 exts_list = []

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
@@ -23,7 +23,7 @@ dependencies = [
 #   nice to have an up to date openssl for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 # package versions updated Jan 19th 2015

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-goalf-1.1.0-no-OFED.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-goolf-1.4.10.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-4.0.6.eb
@@ -24,7 +24,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-5.3.0.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-3.3.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.3.2-goolf-1.4.10.eb
@@ -22,7 +22,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-3.3.2-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.3.2-ictce-4.1.13.eb
@@ -24,7 +24,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-3.3.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.3.2-ictce-5.3.0.eb
@@ -24,7 +24,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1f'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 exts_list = [

--- a/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
@@ -25,7 +25,7 @@ dependencies = [
 #   ('OpenSSL', '1.0.1g'),  # OS dependency should be preferred for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 # Version updated 08/JULY/2014


### PR DESCRIPTION
A lot of existing easyconfigs used 'openssl-devel' and 'libssl-dev' under osdependencies to indicate the need to have development files for openssl. SLES 11 uses 'libopenssl-devel', so we add that as a third option.