### PR TITLE
Python package "lockfile" needs package "pbr"

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
@@ -55,6 +55,9 @@ exts_list = [
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
     }),
+    ('pbr', '0.10.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
     ('lockfile', '0.10.2', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
     }),

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
@@ -55,7 +55,7 @@ exts_list = [
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
     }),
-    ('pbr', '0.10.7', {
+    ('pbr', '0.10.8', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
     }),
     ('lockfile', '0.10.2', {
@@ -99,6 +99,12 @@ exts_list = [
     }),
     ('netaddr', '0.7.13', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('mock', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
+    }),
+    ('pytz', '2014.10', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
@@ -55,6 +55,9 @@ exts_list = [
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
     }),
+    ('pbr', '0.10.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
     ('lockfile', '0.10.2', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
     }),

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
@@ -55,7 +55,7 @@ exts_list = [
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
     }),
-    ('pbr', '0.10.7', {
+    ('pbr', '0.10.8', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
     }),
     ('lockfile', '0.10.2', {
@@ -99,6 +99,12 @@ exts_list = [
     }),
     ('netaddr', '0.7.13', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('mock', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
+    }),
+    ('pytz', '2014.10', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
@@ -58,6 +58,9 @@ exts_list = [
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
     }),
+    ('pbr', '0.10.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
     ('lockfile', '0.10.2', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
     }),

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
@@ -58,7 +58,7 @@ exts_list = [
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
     }),
-    ('pbr', '0.10.7', {
+    ('pbr', '0.10.8', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
     }),
     ('lockfile', '0.10.2', {
@@ -102,6 +102,12 @@ exts_list = [
     }),
     ('netaddr', '0.7.13', {
         'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('mock', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
+    }),
+    ('pytz', '2014.10', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
     }),
 ]
 


### PR DESCRIPTION
Lockfile installs pbr from pip, so we do not have any control on the version of pbr (as it installed always the newest version) Plus python installation fails on nodes without (or with restricted) internet access) 
I do not know what versions of Lockfile affected, I have only modified the latest Python versions. 