### PR TITLE
Create CP2K-2.6.0-intel-para-2014.11.eb

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-2.6.0-intel-para-2014.11.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-2.6.0-intel-para-2014.11.eb
@@ -1,0 +1,40 @@
+name = 'CP2K'
+version = '2.6.0'
+
+homepage = 'http://www.cp2k.org/'
+description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
+ simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
+ methods such as e.g. density functional theory (DFT) using a mixed Gaussian and plane waves approach (GPW), and
+ classical pair and many-body potentials. """
+
+toolchain = {'name': 'intel-para', 'version': '2014.11'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = [SOURCEFORGE_SOURCE]
+
+patches = [
+    'CP2K-2.6.0-ifort-compiler-bug-fix.patch',
+    'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+
+dependencies = [
+    ('Libint', '1.1.4'),
+    ('libxc', '2.2.1'),
+]
+
+builddependencies = [
+    ('flex', '2.5.39'),
+    ('Bison', '3.0.2'),
+]
+
+# don't use parallel make, results in compilation failure
+# because Fortran module files aren't created before they are needed
+parallel = 1
+
+# regression test reports failures
+ignore_regtest_fails = True
+
+moduleclass = 'chem'
+
+runtest = "False"

--- a/easybuild/easyconfigs/c/CP2K/CP2K-2.6.0-intel-para-2014.12.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-2.6.0-intel-para-2014.12.eb
@@ -7,7 +7,7 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
  methods such as e.g. density functional theory (DFT) using a mixed Gaussian and plane waves approach (GPW), and
  classical pair and many-body potentials. """
 
-toolchain = {'name': 'intel-para', 'version': '2014.11'}
+toolchain = {'name': 'intel-para', 'version': '2014.12'}
 toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_BZ2]


### PR DESCRIPTION
To be used in conjunction with a proposed easyblock that supports MPICH mpi families. 
```runtest = "False"``` is required because our system does not support mpirun (but can be omitted for most others)