### PR TITLE
Add Hadoop-2.5.0-cdh5.3.1 and patch them.

### DIFF
--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-2.4.0-seagate-722af1-native.eb
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-2.4.0-seagate-722af1-native.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'dummy', 'version': ''}
 sources = ['%s.tar.gz' % commit]
 source_urls = ['https://github.com/Seagate/hadoop-on-lustre2/archive']
 
+patches = ['Hadoop-TeraSort-on-local-filesystem.patch']
+
 java = 'Java'
 javaver = '1.7.0_76'
 
@@ -21,7 +23,6 @@ builddependencies = [
 ]
 dependencies = [(java, javaver)]
 
-patches = [('Hadoop-TeraSort-on-local-filesystem.patch', 0)]
 
 build_native_libs = True
 

--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-2.4.0-seagate-722af1-native.eb
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-2.4.0-seagate-722af1-native.eb
@@ -26,4 +26,6 @@ dependencies = [(java, javaver)]
 
 build_native_libs = True
 
+parallel = 1
+
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
@@ -25,4 +25,6 @@ dependencies = [(java, javaver)]
 
 build_native_libs = True
 
+parallel = 1
+
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
@@ -1,15 +1,13 @@
 name = 'Hadoop'
-version = '2.4.0'
-commit = '722af1'
-versionsuffix = '-seagate-%s-native' % commit
+version = '2.5.0-cdh5.3.1'
 
-homepage = 'https://github.com/Seagate/hadoop-on-lustre2'
-description = """Hadoop MapReduce for Parallel File Systems as provided by Seagate"""
+homepage = 'http://archive.cloudera.com/cdh5/cdh/5/'
+description = """Hadoop MapReduce by Cloudera"""
 
 toolchain = {'name': 'dummy', 'version': ''}
 
-sources = ['%s.tar.gz' % commit]
-source_urls = ['https://github.com/Seagate/hadoop-on-lustre2/archive']
+sources = ['%(namelower)s-%(version)s-src.tar.gz']
+source_urls = ['http://archive.cloudera.com/cdh5/cdh/5/']
 
 java = 'Java'
 javaver = '1.7.0_76'
@@ -19,6 +17,7 @@ builddependencies = [
     ('protobuf', '2.5.0'),
     ('CMake', '3.1.3'),
 ]
+
 dependencies = [(java, javaver)]
 
 patches = [('Hadoop-TeraSort-on-local-filesystem.patch', 0)]

--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
@@ -1,5 +1,6 @@
 name = 'Hadoop'
 version = '2.5.0-cdh5.3.1'
+versionsuffix = '-native'
 
 homepage = 'http://archive.cloudera.com/cdh5/cdh/5/'
 description = """Hadoop MapReduce by Cloudera"""

--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
@@ -10,6 +10,8 @@ toolchain = {'name': 'dummy', 'version': ''}
 sources = ['%(namelower)s-%(version)s-src.tar.gz']
 source_urls = ['http://archive.cloudera.com/cdh5/cdh/5/']
 
+patches = ['Hadoop-TeraSort-on-local-filesystem.patch']
+
 java = 'Java'
 javaver = '1.7.0_76'
 
@@ -20,8 +22,6 @@ builddependencies = [
 ]
 
 dependencies = [(java, javaver)]
-
-patches = [('Hadoop-TeraSort-on-local-filesystem.patch', 0)]
 
 build_native_libs = True
 

--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-TeraSort-on-local-filesystem.patch
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-TeraSort-on-local-filesystem.patch
@@ -1,4 +1,5 @@
 diff --git a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/TeraSort.java b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/TeraSort.java
+Sourced from https://issues.apache.org/jira/browse/MAPREDUCE-5528
 index 6022f6c..b913769 100644
 --- hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/TeraSort.java
 +++ hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/TeraSort.java

--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-TeraSort-on-local-filesystem.patch
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-TeraSort-on-local-filesystem.patch
@@ -1,0 +1,31 @@
+diff --git a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/TeraSort.java b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/TeraSort.java
+index 6022f6c..b913769 100644
+--- hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/TeraSort.java
++++ hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/terasort/TeraSort.java
+@@ -28,6 +28,7 @@
+ import org.apache.hadoop.conf.Configurable;
+ import org.apache.hadoop.conf.Configuration;
+ import org.apache.hadoop.conf.Configured;
++import org.apache.hadoop.filecache.DistributedCache;;
+ import org.apache.hadoop.fs.FileSystem;
+ import org.apache.hadoop.fs.Path;
+ import org.apache.hadoop.io.Text;
+@@ -209,8 +210,8 @@ public void setConf(Configuration conf) {
+       try {
+         FileSystem fs = FileSystem.getLocal(conf);
+         this.conf = conf;
+-        Path partFile = new Path(TeraInputFormat.PARTITION_FILENAME);
+-        splitPoints = readPartitions(fs, partFile, conf);
++        Path[] localPaths = DistributedCache.getLocalCacheFiles(conf);
++        splitPoints = readPartitions(fs, localPaths[0], conf);
+         trie = buildTrie(splitPoints, 0, splitPoints.length, new Text(), 2);
+       } catch (IOException ie) {
+         throw new IllegalArgumentException("can't read partitions file", ie);
+@@ -279,6 +280,7 @@ public static void setOutputReplication(Job job, int value) {
+ 
+   public int run(String[] args) throws Exception {
+     LOG.info("starting");
++    LOG.info("starting with terasort on native filesystem patch");
+     Job job = Job.getInstance(getConf());
+     Path inputDir = new Path(args[0]);
+     Path outputDir = new Path(args[1]);


### PR DESCRIPTION
The patch it to make TeraSort work with native file systems (MAPREDUCE-5528).