### PR TITLE
{tools}[GCC/4.9.2] numactl 2.0.10 (FIX)

### DIFF
--- a/easybuild/easyconfigs/n/numactl/numactl-2.0.10-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/n/numactl/numactl-2.0.10-GCC-4.9.2.eb
@@ -13,6 +13,8 @@ source_urls = ['ftp://oss.sgi.com/www/projects/libnuma/download/']
 
 toolchain = {'name': 'GCC', 'version': '4.9.2'}
 
+preconfigopts = './autogen.sh && '
+
 sanity_check_paths = {
     'files': ['bin/numactl', 'bin/numastat', 'lib/libnuma.so', 'lib/libnuma.a'],
     'dirs': ['share/man', 'include']


### PR DESCRIPTION
The current version fails. The autogen.sh needs to be run before the configure.