### PR TITLE
patch out svnversion command in Python 2.5.6

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-goalf-1.1.0-no-OFED-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-goalf-1.1.0-no-OFED-bare.eb
@@ -11,6 +11,8 @@ toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 
+patches = ['Python-%(version)s_svnversion-cmd.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.7'),

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-gompi-1.4.12-no-OFED-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-gompi-1.4.12-no-OFED-bare.eb
@@ -11,6 +11,8 @@ toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 
+patches = ['Python-%(version)s_svnversion-cmd.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.7'),

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-goolf-1.4.10-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-goolf-1.4.10-bare.eb
@@ -11,6 +11,8 @@ toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 
+patches = ['Python-%(version)s_svnversion-cmd.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.7'),

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.0.6-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.0.6-bare.eb
@@ -11,9 +11,10 @@ toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 
-patches = ['Python-%(version)s_svnversion-cmd.patch']
-
-patches = ['python_libffi_int128_icc.patch']
+patches = [
+    'python_libffi_int128_icc.patch',
+    'Python-%(version)s_svnversion-cmd.patch',
+]
 
 dependencies = [
     ('bzip2', '1.0.6'),

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.0.6-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.0.6-bare.eb
@@ -11,6 +11,8 @@ toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 
+patches = ['Python-%(version)s_svnversion-cmd.patch']
+
 patches = ['python_libffi_int128_icc.patch']
 
 dependencies = [

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.1.13-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.1.13-bare.eb
@@ -11,9 +11,10 @@ toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 
-patches = ['Python-%(version)s_svnversion-cmd.patch']
-
-patches = ['python_libffi_int128_icc.patch']
+patches = [
+    'python_libffi_int128_icc.patch',
+    'Python-%(version)s_svnversion-cmd.patch',
+]
 
 dependencies = [
     ('bzip2', '1.0.6'),

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.1.13-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-4.1.13-bare.eb
@@ -11,6 +11,8 @@ toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 
+patches = ['Python-%(version)s_svnversion-cmd.patch']
+
 patches = ['python_libffi_int128_icc.patch']
 
 dependencies = [

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-5.2.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-5.2.0-bare.eb
@@ -11,6 +11,8 @@ toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 
+patches = ['Python-%(version)s_svnversion-cmd.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.7'),

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-5.3.0-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6-ictce-5.3.0-bare.eb
@@ -11,6 +11,8 @@ toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 
+patches = ['Python-%(version)s_svnversion-cmd.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.7'),

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6_svnversion-cmd.patch
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6_svnversion-cmd.patch
@@ -1,3 +1,5 @@
+replace svnversion call with mimiced output for non-SVN tarballs for older versions of svnversion, i.e 'exported'
+author: Kenneth Hoste (Ghent University)
 --- Python-2.5.6/configure.orig	2015-04-29 10:40:05.254502098 +0200
 +++ Python-2.5.6/configure	2015-04-29 10:42:01.739388944 +0200
 @@ -4242,7 +4242,8 @@

--- a/easybuild/easyconfigs/p/Python/Python-2.5.6_svnversion-cmd.patch
+++ b/easybuild/easyconfigs/p/Python/Python-2.5.6_svnversion-cmd.patch
@@ -1,0 +1,12 @@
+--- Python-2.5.6/configure.orig	2015-04-29 10:40:05.254502098 +0200
++++ Python-2.5.6/configure	2015-04-29 10:42:01.739388944 +0200
+@@ -4242,7 +4242,8 @@
+ 
+ if test $SVNVERSION = found
+ then
+-	SVNVERSION="svnversion \$(srcdir)"
++	#SVNVERSION="svnversion \$(srcdir)"
++	SVNVERSION="echo exported"
+ else
+ 	SVNVERSION="echo exported"
+ fi


### PR DESCRIPTION
include patch for Python 2.5.6 to fix issue with newer versions of `svnversion` command that spits out '`Unversioned directory`' rather than '`exported`'

this is an alternative to include subversion as a build dep in the Python 2.5.6 easyconfigs, which is rather a crazy endeavour (see #758)