### PR TITLE
list tcsh as build dep in WRF built with CrayGNU, rather than providing it as a build dep

### DIFF
--- a/easybuild/easyconfigs/w/WRF/WRF-3.6.1-CrayGNU-5.1.29-dmpar.eb
+++ b/easybuild/easyconfigs/w/WRF/WRF-3.6.1-CrayGNU-5.1.29-dmpar.eb
@@ -15,11 +15,9 @@ source_urls = [
     'http://www.mmm.ucar.edu/wrf/src/',
 ]
 
-# csh is used by WRF install scripts
-# tcsh provided via EasyBuild may cause build to hang (in interactive configure?)
-# ncurses related issue? rebuild tcsh without EB-provided ncurses?
-#builddependencies = [('tcsh', '6.18.01')]
+# use tcsh provided by system, using an EB-provided tcsh results in a hanging build command on some Cray systems
 osdependencies = ['tcsh']
+#builddependencies = [('tcsh', '6.18.01')]
 
 dependencies = [
     ('JasPer', '1.900.1'),

--- a/easybuild/easyconfigs/w/WRF/WRF-3.6.1-CrayGNU-5.1.29-dmpar.eb
+++ b/easybuild/easyconfigs/w/WRF/WRF-3.6.1-CrayGNU-5.1.29-dmpar.eb
@@ -16,7 +16,10 @@ source_urls = [
 ]
 
 # csh is used by WRF install scripts
-builddependencies = [('tcsh', '6.18.01')]
+# tcsh provided via EasyBuild may cause build to hang (in interactive configure?)
+# ncurses related issue? rebuild tcsh without EB-provided ncurses?
+#builddependencies = [('tcsh', '6.18.01')]
+osdependencies = ['tcsh']
 
 dependencies = [
     ('JasPer', '1.900.1'),


### PR DESCRIPTION
I'm still not quite sure why the build simply hangs when using a `tcsh` provided via EB.