### PR TITLE
add easyconfig for Platanus (binary)

### DIFF
--- a/easybuild/easyconfigs/p/Platanus/Platanus-1.2.1-linux-x86_64.eb
+++ b/easybuild/easyconfigs/p/Platanus/Platanus-1.2.1-linux-x86_64.eb
@@ -2,6 +2,7 @@ easyblock = 'Binary'
 
 name = 'Platanus'
 version = '1.2.1'
+versionsuffix = '-linux-x86_64'
 
 homepage = 'http://platanus.bio.titech.ac.jp/'
 description = """PLATform for Assembling NUcleotide Sequences"""

--- a/easybuild/easyconfigs/p/Platanus/Platanus-1.2.1-linux-x86_64.eb
+++ b/easybuild/easyconfigs/p/Platanus/Platanus-1.2.1-linux-x86_64.eb
@@ -1,0 +1,20 @@
+easyblock = 'Binary'
+
+name = 'Platanus'
+version = '1.2.1'
+
+homepage = 'http://platanus.bio.titech.ac.jp/'
+description = """PLATform for Assembling NUcleotide Sequences"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+source_urls = ['http://platanus.bio.titech.ac.jp/Platanus_release/20130901010201']
+sources = ['platanus']
+checksums = ['02cf92847ec704d010a54df293b9c60a']
+
+sanity_check_paths = {
+    'files': ['platanus'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
no sources available (yet), see remark at http://platanus.bio.titech.ac.jp/platanus-assembler/:

```
Latest version of platanus is 1.2.1. Only precompiled binary for 64bit-linux system version is available now. We’ll provide source code of Platanus a.s.a.p.
```