### PR TITLE
consistently use https for PyPI URLs in homepage/source_urls

### DIFF
--- a/easybuild/easyconfigs/c/Cython/Cython-0.16-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/c/Cython/Cython-0.16-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = 'Cython'
 version = '0.16'
 
-homepage = 'http://pypi.python.org/pypi/Cython/'
+homepage = 'https://pypi.python.org/pypi/Cython/'
 description = """The Cython language makes writing C extensions for the Python language as easy as Python itself.
  Cython is a source code translator based on the well-known Pyrex, but supports more cutting edge functionality and optimizations."""
 

--- a/easybuild/easyconfigs/c/Cython/Cython-0.16-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/c/Cython/Cython-0.16-goolf-1.4.10-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = 'Cython'
 version = '0.16'
 
-homepage = 'http://pypi.python.org/pypi/Cython/'
+homepage = 'https://pypi.python.org/pypi/Cython/'
 description = """The Cython language makes writing C extensions for the Python language as easy as Python itself.
  Cython is a source code translator based on the well-known Pyrex, but supports more cutting edge functionality and optimizations."""
 

--- a/easybuild/easyconfigs/c/Cython/Cython-0.16-ictce-4.0.6-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/c/Cython/Cython-0.16-ictce-4.0.6-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = 'Cython'
 version = '0.16'
 
-homepage = 'http://pypi.python.org/pypi/Cython/'
+homepage = 'https://pypi.python.org/pypi/Cython/'
 description = """The Cython language makes writing C extensions for the Python language as easy as Python itself.
  Cython is a source code translator based on the well-known Pyrex, but supports more cutting edge functionality and optimizations."""
 

--- a/easybuild/easyconfigs/c/Cython/Cython-0.16-ictce-4.1.13-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/c/Cython/Cython-0.16-ictce-4.1.13-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = 'Cython'
 version = '0.16'
 
-homepage = 'http://pypi.python.org/pypi/Cython/'
+homepage = 'https://pypi.python.org/pypi/Cython/'
 description = """The Cython language makes writing C extensions for the Python language as easy as Python itself.
  Cython is a source code translator based on the well-known Pyrex, but supports more cutting edge functionality and optimizations."""
 

--- a/easybuild/easyconfigs/c/Cython/Cython-0.16-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/c/Cython/Cython-0.16-ictce-5.3.0-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = 'Cython'
 version = '0.16'
 
-homepage = 'http://pypi.python.org/pypi/Cython/'
+homepage = 'https://pypi.python.org/pypi/Cython/'
 description = """The Cython language makes writing C extensions for the Python language as easy as Python itself.
  Cython is a source code translator based on the well-known Pyrex, but supports more cutting edge functionality and optimizations."""
 

--- a/easybuild/easyconfigs/c/Cython/Cython-0.19.1-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/c/Cython/Cython-0.19.1-goolf-1.4.10-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = 'Cython'
 version = '0.19.1'
 
-homepage = 'http://pypi.python.org/pypi/Cython/'
+homepage = 'https://pypi.python.org/pypi/Cython/'
 description = """The Cython language makes writing C extensions for the Python language as easy as Python itself.
  Cython is a source code translator based on the well-known Pyrex, but supports more cutting edge functionality and optimizations."""
 

--- a/easybuild/easyconfigs/c/Cython/Cython-0.19.1-ictce-4.1.13-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/c/Cython/Cython-0.19.1-ictce-4.1.13-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = 'Cython'
 version = '0.19.1'
 
-homepage = 'http://pypi.python.org/pypi/Cython/'
+homepage = 'https://pypi.python.org/pypi/Cython/'
 description = """The Cython language makes writing C extensions for the Python language as easy as Python itself.
  Cython is a source code translator based on the well-known Pyrex, but supports more cutting edge functionality and optimizations."""
 

--- a/easybuild/easyconfigs/c/Cython/Cython-0.19.1-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/c/Cython/Cython-0.19.1-ictce-5.3.0-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = 'Cython'
 version = '0.19.1'
 
-homepage = 'http://pypi.python.org/pypi/Cython/'
+homepage = 'https://pypi.python.org/pypi/Cython/'
 description = """The Cython language makes writing C extensions for the Python language as easy as Python itself.
  Cython is a source code translator based on the well-known Pyrex, but supports more cutting edge functionality and optimizations."""
 

--- a/easybuild/easyconfigs/c/Cython/Cython-0.19.2-ictce-5.5.0-Python-2.7.6.eb
+++ b/easybuild/easyconfigs/c/Cython/Cython-0.19.2-ictce-5.5.0-Python-2.7.6.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = 'Cython'
 version = '0.19.2'
 
-homepage = 'http://pypi.python.org/pypi/Cython/'
+homepage = 'https://pypi.python.org/pypi/Cython/'
 description = """The Cython language makes writing C extensions for the Python language as easy as Python itself.
  Cython is a source code translator based on the well-known Pyrex, but supports more cutting edge functionality and optimizations."""
 

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.3-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.3-goolf-1.4.10-Python-2.7.3.eb
@@ -17,8 +17,8 @@ description = """ cutadapt removes adapter sequences
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-source_urls = ['http://cutadapt.googlecode.com/files/']
-sources = ['%(namelower)s-%(version)s.tar.gz']
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.3'

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.3-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.3-goolf-1.4.10-Python-2.7.5.eb
@@ -17,8 +17,8 @@ description = """ cutadapt removes adapter sequences
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-source_urls = ['http://cutadapt.googlecode.com/files/']
-sources = ['%(namelower)s-%(version)s.tar.gz']
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.5'

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.4.1-foss-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.4.1-foss-2014b-Python-2.7.8.eb
@@ -15,8 +15,8 @@ description = """ cutadapt removes adapter sequences from high-throughput sequen
 
 toolchain = {'name': 'foss', 'version': '2014b'}
 
-source_urls = ['https://github.com/marcelm/cutadapt/archive/']
-sources = ['v%(version)s.tar.gz']
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.8'

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.4.1-goolf-1.4.10-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.4.1-goolf-1.4.10-Python-2.7.5.eb
@@ -17,8 +17,8 @@ description = """ cutadapt removes adapter sequences
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-source_urls = ['https://github.com/marcelm/cutadapt/archive/']
-sources = ['v%(version)s.tar.gz']
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.5'

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.5-foss-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.5-foss-2014b-Python-2.7.8.eb
@@ -15,8 +15,8 @@ description = """ cutadapt removes adapter sequences from high-throughput sequen
 
 toolchain = {'name': 'foss', 'version': '2014b'}
 
-source_urls = ['https://github.com/marcelm/cutadapt/archive/']
-sources = ['v%(version)s.tar.gz']
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.8'

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.5-intel-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.5-intel-2014b-Python-2.7.8.eb
@@ -12,8 +12,8 @@ description = """ cutadapt removes adapter sequences
 
 toolchain = {'name': 'intel', 'version': '2014b'}
 
-source_urls = ['https://pypi.python.org/packages/source/c/cutadapt/']
-sources = ['%(namelower)s-%(version)s.tar.gz']
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.8'

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.6-foss-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.6-foss-2014b-Python-2.7.8.eb
@@ -15,8 +15,8 @@ description = """ cutadapt removes adapter sequences from high-throughput sequen
 
 toolchain = {'name': 'foss', 'version': '2014b'}
 
-source_urls = ['https://github.com/marcelm/cutadapt/archive/']
-sources = ['v%(version)s.tar.gz']
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.8'

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.7-foss-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.7-foss-2014b-Python-2.7.8.eb
@@ -15,8 +15,8 @@ description = """ cutadapt removes adapter sequences from high-throughput sequen
 
 toolchain = {'name': 'foss', 'version': '2014b'}
 
-source_urls = ['https://github.com/marcelm/cutadapt/archive/']
-sources = ['v%(version)s.tar.gz']
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.8'

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.7.1-foss-2014b-Python-2.7.8.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.7.1-foss-2014b-Python-2.7.8.eb
@@ -15,8 +15,8 @@ description = """ cutadapt removes adapter sequences from high-throughput sequen
 
 toolchain = {'name': 'foss', 'version': '2014b'}
 
-source_urls = ['https://github.com/marcelm/cutadapt/archive/']
-sources = ['v%(version)s.tar.gz']
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.8'

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-1.8.1-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-1.8.1-intel-2015a-Python-2.7.9.eb
@@ -15,8 +15,8 @@ description = """ cutadapt removes adapter sequences from high-throughput sequen
 
 toolchain = {'name': 'intel', 'version': '2015a'}
 
-source_urls = ['https://github.com/marcelm/cutadapt/archive/']
-sources = ['v%(version)s.tar.gz']
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.9'

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.1.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.0.2.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.1.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.1.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.10.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.10.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.11.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.11.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.11.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.11.1.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.12.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.12.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.12.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.12.1.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.13.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.13.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.14.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.14.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.1.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.15.2.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.1.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.16.2.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.2.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.2.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.3.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.3.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.4.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.4.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.5.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.5.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.6.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.6.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.7.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.7.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.1.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.2.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.8.2.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.9.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-1.9.0.eb
@@ -11,9 +11,9 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.0.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.0.0.eb
@@ -11,10 +11,10 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/v/vsc-base/',
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/v/vsc-base/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.1.0.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.1.0.eb
@@ -11,10 +11,10 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://pypi.python.org/packages/source/v/vsc-base/',
-    'http://pypi.python.org/packages/source/e/easybuild-framework/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyblocks/',
-    'http://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
+    'https://pypi.python.org/packages/source/v/vsc-base/',
+    'https://pypi.python.org/packages/source/e/easybuild-framework/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyblocks/',
+    'https://pypi.python.org/packages/source/e/easybuild-easyconfigs/',
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [

--- a/easybuild/easyconfigs/g/Greenlet/Greenlet-0.4.2-ictce-5.5.0-Python-2.7.6.eb
+++ b/easybuild/easyconfigs/g/Greenlet/Greenlet-0.4.2-ictce-5.5.0-Python-2.7.6.eb
@@ -13,8 +13,8 @@ scheduling; coroutines, in other words. This is useful when you want to control 
 
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 
-source_urls = ['http://pypi.python.org/packages/source/g/greenlet/']
-sources = ['%s-%s.zip' % (name.lower(), version)]
+source_urls = [PYPI_LOWER_SOURCE]
+sources = [SOURCELOWER_ZIP]
 
 python = "Python"
 pythonversion = '2.7.6'

--- a/easybuild/easyconfigs/h/HTSeq/HTSeq-0.5.4p5-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/h/HTSeq/HTSeq-0.5.4p5-goolf-1.4.10-Python-2.7.3.eb
@@ -8,7 +8,7 @@ description = """A framework to process and analyze data from high-throughput se
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-source_urls = ['https://pypi.python.org/packages/source/H/HTSeq/']
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = 'Python'

--- a/easybuild/easyconfigs/h/HTSeq/HTSeq-0.5.4p5-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/h/HTSeq/HTSeq-0.5.4p5-ictce-5.3.0-Python-2.7.3.eb
@@ -8,7 +8,7 @@ description = """A framework to process and analyze data from high-throughput se
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
-source_urls = ['https://pypi.python.org/packages/source/H/HTSeq/']
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = 'Python'

--- a/easybuild/easyconfigs/h/HTSeq/HTSeq-0.5.4p5-ictce-5.5.0-Python-2.7.6.eb
+++ b/easybuild/easyconfigs/h/HTSeq/HTSeq-0.5.4p5-ictce-5.5.0-Python-2.7.6.eb
@@ -8,7 +8,7 @@ description = """A framework to process and analyze data from high-throughput se
 
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 
-source_urls = ['https://pypi.python.org/packages/source/H/HTSeq/']
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = 'Python'

--- a/easybuild/easyconfigs/j/Jinja2/Jinja2-2.6-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/j/Jinja2/Jinja2-2.6-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = "Jinja2"
 version = "2.6"
 
-homepage = "http://pypi.python.org/pypi/Jinja2"
+homepage = "https://pypi.python.org/pypi/Jinja2"
 description = """Jinja2 is a template engine written in pure Python. It provides a Django inspired
  non-XML syntax but supports inline expressions and an optional sandboxed environment."""
 

--- a/easybuild/easyconfigs/j/Jinja2/Jinja2-2.6-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/j/Jinja2/Jinja2-2.6-goolf-1.4.10-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = "Jinja2"
 version = "2.6"
 
-homepage = "http://pypi.python.org/pypi/Jinja2"
+homepage = "https://pypi.python.org/pypi/Jinja2"
 description = """Jinja2 is a template engine written in pure Python. It provides a Django inspired
 non-XML syntax but supports inline expressions and an optional sandboxed environment."""
 toolchain = {'name': 'goolf', 'version': '1.4.10'}

--- a/easybuild/easyconfigs/j/Jinja2/Jinja2-2.6-ictce-4.0.6-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/j/Jinja2/Jinja2-2.6-ictce-4.0.6-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = "Jinja2"
 version = "2.6"
 
-homepage = "http://pypi.python.org/pypi/Jinja2"
+homepage = "https://pypi.python.org/pypi/Jinja2"
 description = """Jinja2 is a template engine written in pure Python. It provides a Django inspired
  non-XML syntax but supports inline expressions and an optional sandboxed environment."""
 

--- a/easybuild/easyconfigs/j/Jinja2/Jinja2-2.6-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/j/Jinja2/Jinja2-2.6-ictce-5.3.0-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = "Jinja2"
 version = "2.6"
 
-homepage = "http://pypi.python.org/pypi/Jinja2"
+homepage = "https://pypi.python.org/pypi/Jinja2"
 description = """Jinja2 is a template engine written in pure Python. It provides a Django inspired
  non-XML syntax but supports inline expressions and an optional sandboxed environment."""
 

--- a/easybuild/easyconfigs/m/monty/monty-0.6.4-intel-2015a-Python-2.7.9-gmatteo-20150325.eb
+++ b/easybuild/easyconfigs/m/monty/monty-0.6.4-intel-2015a-Python-2.7.9-gmatteo-20150325.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = 'monty'
 version = '0.6.4'
 
-homepage = 'http://pypi.python.org/pypi/monty/'
+homepage = 'https://pypi.python.org/pypi/monty/'
 description = """Monty implements supplementary useful functions for Python that are not part of the standard library.
  Examples include useful utilities like transparent support for zipped files, useful design patterns such as singleton
  and cached_class, and many more."""

--- a/easybuild/easyconfigs/m/monty/monty-0.6.4-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/m/monty/monty-0.6.4-intel-2015a-Python-2.7.9.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = 'monty'
 version = '0.6.4'
 
-homepage = 'http://pypi.python.org/pypi/monty/'
+homepage = 'https://pypi.python.org/pypi/monty/'
 description = """Monty implements supplementary useful functions for Python that are not part of the standard library.
  Examples include useful utilities like transparent support for zipped files, useful design patterns such as singleton
  and cached_class, and many more."""

--- a/easybuild/easyconfigs/n/netaddr/netaddr-0.7.10-ictce-5.5.0-Python-2.7.6.eb
+++ b/easybuild/easyconfigs/n/netaddr/netaddr-0.7.10-ictce-5.5.0-Python-2.7.6.eb
@@ -8,7 +8,7 @@ description = """Pythonic manipulation of IPv4, IPv6, CIDR, EUI and MAC network 
 
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 
-source_urls = ['https://pypi.python.org/packages/source/n/netaddr/']
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = 'Python'

--- a/easybuild/easyconfigs/p/PyYAML/PyYAML-3.11-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/p/PyYAML/PyYAML-3.11-intel-2015a-Python-2.7.9.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = "PyYAML"
 version = "3.11"
 
-homepage = "http://pypi.python.org/pypi/PyYAML/"
+homepage = "https://pypi.python.org/pypi/PyYAML/"
 description = """PyYAML is a YAML parser and emitter for the Python programming language."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmpolf-1.1.6.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmpolf-1.1.6.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmvolf-1.1.12rc1.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmvolf-1.1.12rc1.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -46,7 +46,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -62,7 +62,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmvolf-1.2.7.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-cgmvolf-1.2.7.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-cgoolf-1.1.7.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-cgoolf-1.1.7.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -46,7 +46,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -62,7 +62,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-gmpolf-1.4.8.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-gmpolf-1.4.8.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-gmvolf-1.7.12.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-gmvolf-1.7.12.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-gmvolf-1.7.12rc1.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-gmvolf-1.7.12rc1.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-goalf-1.1.0-no-OFED.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.4.10.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.5.14.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-4.0.6.eb
@@ -29,13 +29,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-4.1.13.eb
@@ -29,13 +29,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.2.0.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -46,7 +46,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -62,7 +62,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.3.0.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -46,7 +46,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -62,7 +62,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-intel-2015a.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -46,7 +46,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -62,7 +62,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-iomkl-4.6.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-iomkl-4.6.13.eb
@@ -29,13 +29,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-iqacml-3.7.3.eb
@@ -30,13 +30,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -52,7 +52,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -68,7 +68,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-goalf-1.5.12-no-OFED.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-goalf-1.5.12-no-OFED.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -46,7 +46,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -62,7 +62,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-goolf-1.4.10.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-4.1.13.eb
@@ -30,13 +30,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -51,7 +51,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -67,7 +67,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.3.0.eb
@@ -30,13 +30,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -49,7 +49,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -65,7 +65,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.5.0.eb
@@ -30,13 +30,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -49,7 +49,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -65,7 +65,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-iqacml-3.7.3.eb
@@ -31,13 +31,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '0.6c11', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -53,7 +53,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -69,7 +69,7 @@ exts_list = [
     }),
     ('dateutil', '2.1', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.6-goolf-1.4.10.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '1.4.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.0', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.2', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-4.1.13.eb
@@ -30,13 +30,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '1.4.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.0', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -51,7 +51,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -67,7 +67,7 @@ exts_list = [
     }),
     ('dateutil', '2.2', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-5.5.0.eb
@@ -30,13 +30,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '1.4.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.0', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -51,7 +51,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -67,7 +67,7 @@ exts_list = [
     }),
     ('dateutil', '2.2', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '0.9.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-foss-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-foss-2014b.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '5.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.5.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.3', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,7 +48,7 @@ exts_list = [
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -64,7 +64,7 @@ exts_list = [
     }),
     ('dateutil', '2.2', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://deap.googlecode.com/files/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-goolf-1.5.14.eb
@@ -30,13 +30,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '5.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.5.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.3', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,16 +48,16 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('six', '1.7.3', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/six/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -70,7 +70,7 @@ exts_list = [
     }),
     ('dateutil', '2.2', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-ictce-7.1.2.eb
@@ -34,13 +34,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # Version updated 08/JULY/2014
 exts_list = [
     ('setuptools', '5.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.5.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.3', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -52,13 +52,13 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -74,7 +74,7 @@ exts_list = [
     }),
     ('dateutil', '2.2', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2014.06.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2014.06.eb
@@ -31,13 +31,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # Version updated 08/JULY/2014
 exts_list = [
     ('setuptools', '5.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.5.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.3', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -49,13 +49,13 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -71,7 +71,7 @@ exts_list = [
     }),
     ('dateutil', '2.2', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2014b.eb
@@ -31,13 +31,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # Version updated 08/JULY/2014
 exts_list = [
     ('setuptools', '5.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.5.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.3', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -49,13 +49,13 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -71,7 +71,7 @@ exts_list = [
     }),
     ('dateutil', '2.2', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2015a.eb
@@ -30,13 +30,13 @@ dependencies = [
 # Version updated 08/JULY/2014
 exts_list = [
     ('setuptools', '5.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.5.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.3', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,13 +48,13 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -70,7 +70,7 @@ exts_list = [
     }),
     ('dateutil', '2.2', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-CrayGNU-5.1.29.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-CrayGNU-5.1.29.eb
@@ -31,13 +31,13 @@ buildopts = 'LINKCC="$CC -dynamic"'
 # package versions updated Jan 19th 2015
 exts_list = [
     ('setuptools', '11.3.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '6.0.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.4', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -49,13 +49,13 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -71,7 +71,7 @@ exts_list = [
     }),
     ('dateutil', '2.4.0', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-CrayGNU-5.2.25.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-CrayGNU-5.2.25.eb
@@ -31,13 +31,13 @@ buildopts = 'LINKCC="$CC -dynamic"'
 # package versions updated Jan 19th 2015
 exts_list = [
     ('setuptools', '11.3.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '6.0.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.4', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -49,13 +49,13 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -71,7 +71,7 @@ exts_list = [
     }),
     ('dateutil', '2.4.0', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-CrayGNU-5.2.40.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-CrayGNU-5.2.40.eb
@@ -31,13 +31,13 @@ buildopts = 'LINKCC="$CC -dynamic"'
 # package versions updated Jan 19th 2015
 exts_list = [
     ('setuptools', '11.3.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '6.0.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.4', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -49,13 +49,13 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -71,7 +71,7 @@ exts_list = [
     }),
     ('dateutil', '2.4.0', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
@@ -30,13 +30,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # package versions updated Jan 19th 2015
 exts_list = [
     ('setuptools', '11.3.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '6.0.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.4', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -45,13 +45,13 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -70,7 +70,7 @@ exts_list = [
     }),
     ('dateutil', '2.4.0', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
@@ -30,13 +30,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # package versions updated Jan 19th 2015
 exts_list = [
     ('setuptools', '11.3.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '6.0.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.4', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -45,13 +45,13 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -70,7 +70,7 @@ exts_list = [
     }),
     ('dateutil', '2.4.0', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
@@ -30,13 +30,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # package versions updated Jan 19th 2015
 exts_list = [
     ('setuptools', '11.3.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '6.0.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.4', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,13 +48,13 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -73,7 +73,7 @@ exts_list = [
     }),
     ('dateutil', '2.4.0', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-goalf-1.1.0-no-OFED.eb
@@ -27,14 +27,14 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('distribute', '0.6.26', {
-        'source_urls': ['http://pypi.python.org/packages/source/d/distribute'],
+        'source_urls': ['https://pypi.python.org/packages/source/d/distribute'],
         'modulename': 'setuptools',
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-goolf-1.4.10.eb
@@ -27,14 +27,14 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('distribute', '0.6.26', {
-        'source_urls': ['http://pypi.python.org/packages/source/d/distribute'],
+        'source_urls': ['https://pypi.python.org/packages/source/d/distribute'],
         'modulename': 'setuptools',
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-4.0.6.eb
@@ -29,14 +29,14 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('distribute', '0.6.26', {
-        'source_urls': ['http://pypi.python.org/packages/source/d/distribute'],
+        'source_urls': ['https://pypi.python.org/packages/source/d/distribute'],
         'modulename': 'setuptools',
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-5.3.0.eb
@@ -27,14 +27,14 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('distribute', '0.6.26', {
-        'source_urls': ['http://pypi.python.org/packages/source/d/distribute'],
+        'source_urls': ['https://pypi.python.org/packages/source/d/distribute'],
         'modulename': 'setuptools',
     }),
     ('pip', '1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.1.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],

--- a/easybuild/easyconfigs/p/Python/Python-3.3.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.3.2-goolf-1.4.10.eb
@@ -27,13 +27,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '1.1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools'],
     }),
     ('pip', '1.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.0', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],

--- a/easybuild/easyconfigs/p/Python/Python-3.3.2-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.3.2-ictce-4.1.13.eb
@@ -29,13 +29,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '1.1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools'],
     }),
     ('pip', '1.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.0', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],

--- a/easybuild/easyconfigs/p/Python/Python-3.3.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.3.2-ictce-5.3.0.eb
@@ -29,13 +29,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # order is important!
 exts_list = [
     ('setuptools', '1.1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools'],
     }),
     ('pip', '1.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.0', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],

--- a/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
@@ -31,13 +31,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # Version updated 08/JULY/2014
 exts_list = [
     ('setuptools', '5.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.5.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.3', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -49,13 +49,13 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -73,7 +73,7 @@ exts_list = [
     }),
     ('dateutil', '2.2', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2015a.eb
@@ -31,13 +31,13 @@ osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 # Version updated 08/JULY/2014
 exts_list = [
     ('setuptools', '5.4.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '1.5.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.3', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -49,13 +49,13 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -73,7 +73,7 @@ exts_list = [
     }),
     ('dateutil', '2.2', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.4.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.3-intel-2015a.eb
@@ -30,13 +30,13 @@ osdependencies = [('openssl-devel', 'libssl-dev')]
 exts_filter = ('PYTHONPATH="%(installdir)s:$PYTHONPATH python -c "import %(ext_name)s"', '')
 exts_list = [
     ('setuptools', '15.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/setuptools/'],
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
     }),
     ('pip', '6.1.1', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pip/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
     }),
     ('nose', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/nose/'],
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
     ('numpy', numpyversion, {
         'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
@@ -48,13 +48,13 @@ exts_list = [
         'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
     }),
     ('blist', '1.3.6', {
-        'source_urls': ['http://pypi.python.org/packages/source/b/blist/'],
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
     }),
     ('mpi4py', '1.3.1', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
     ('paycheck', '1.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/paycheck/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
     }),
     ('argparse', '1.3.0', {
         'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],
@@ -73,7 +73,7 @@ exts_list = [
     }),
     ('dateutil', '2.4.2', {
         'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
-        'source_urls': ['http://pypi.python.org/packages/source/p/python-dateutil/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
     }),
     ('deap', '1.0.2', {
         'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',

--- a/easybuild/easyconfigs/p/pandas/pandas-0.11.0-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/p/pandas/pandas-0.11.0-goolf-1.4.10-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = "pandas"
 version = "0.11.0"
 
-homepage = "http://pypi.python.org/pypi/pandas/"
+homepage = "https://pypi.python.org/pypi/pandas/"
 description = """pandas is an open source, BSD-licensed library providing high-performance, easy-to-use data structures
 and data analysis tools for the Python programming language."""
 

--- a/easybuild/easyconfigs/p/pandas/pandas-0.11.0-ictce-4.1.13-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/p/pandas/pandas-0.11.0-ictce-4.1.13-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = "pandas"
 version = "0.11.0"
 
-homepage = "http://pypi.python.org/pypi/pandas/"
+homepage = "https://pypi.python.org/pypi/pandas/"
 description = """pandas is an open source, BSD-licensed library providing high-performance, easy-to-use data structures
 and data analysis tools for the Python programming language."""
 

--- a/easybuild/easyconfigs/p/pandas/pandas-0.11.0-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/p/pandas/pandas-0.11.0-ictce-5.3.0-Python-2.7.3.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = "pandas"
 version = "0.11.0"
 
-homepage = "http://pypi.python.org/pypi/pandas/"
+homepage = "https://pypi.python.org/pypi/pandas/"
 description = """pandas is an open source, BSD-licensed library providing high-performance, easy-to-use data structures
  and data analysis tools for the Python programming language."""
 

--- a/easybuild/easyconfigs/p/pandas/pandas-0.12.0-ictce-5.5.0-Python-2.7.6.eb
+++ b/easybuild/easyconfigs/p/pandas/pandas-0.12.0-ictce-5.5.0-Python-2.7.6.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = "pandas"
 version = "0.12.0"
 
-homepage = "http://pypi.python.org/pypi/pandas/"
+homepage = "https://pypi.python.org/pypi/pandas/"
 description = """pandas is an open source, BSD-licensed library providing high-performance, easy-to-use data structures
  and data analysis tools for the Python programming language."""
 

--- a/easybuild/easyconfigs/p/pandas/pandas-0.13.1-ictce-5.5.0-Python-2.7.6.eb
+++ b/easybuild/easyconfigs/p/pandas/pandas-0.13.1-ictce-5.5.0-Python-2.7.6.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = "pandas"
 version = "0.13.1"
 
-homepage = "http://pypi.python.org/pypi/pandas/"
+homepage = "https://pypi.python.org/pypi/pandas/"
 description = """pandas is an open source, BSD-licensed library providing high-performance, easy-to-use data structures
  and data analysis tools for the Python programming language."""
 

--- a/easybuild/easyconfigs/p/pandas/pandas-0.16.0-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/p/pandas/pandas-0.16.0-intel-2015a-Python-2.7.9.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = "pandas"
 version = "0.16.0"
 
-homepage = "http://pypi.python.org/pypi/pandas/"
+homepage = "https://pypi.python.org/pypi/pandas/"
 description = """pandas is an open source, BSD-licensed library providing high-performance, easy-to-use data structures
  and data analysis tools for the Python programming language."""
 

--- a/easybuild/easyconfigs/p/paycheck/paycheck-1.0.2-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/p/paycheck/paycheck-1.0.2-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -3,15 +3,13 @@ easyblock = 'PythonPackage'
 name = 'paycheck'
 version = '1.0.2'
 
-homepage = 'http://pypi.python.org/pypi/paycheck/'
+homepage = 'https://pypi.python.org/pypi/paycheck/'
 description = """PayCheck is a half-baked implementation of ScalaCheck, which itself is an implementation of QuickCheck for Haskell.
  PayCheck is useful for defining a specification of what a function should do, rather than testing its results for a given input."""
 
 toolchain = {'name': 'goalf', 'version': '1.1.0-no-OFED'}
 
-source_urls = [
-               'http://pypi.python.org/packages/source/p/paycheck/',
-              ]
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = 'Python'

--- a/easybuild/easyconfigs/p/paycheck/paycheck-1.0.2-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/p/paycheck/paycheck-1.0.2-goolf-1.4.10-Python-2.7.3.eb
@@ -3,14 +3,12 @@ easyblock = 'PythonPackage'
 name = 'paycheck'
 version = '1.0.2'
 
-homepage = 'http://pypi.python.org/pypi/paycheck/'
+homepage = 'https://pypi.python.org/pypi/paycheck/'
 description = """PayCheck is a half-baked implementation of ScalaCheck, which itself is an implementation of QuickCheck for Haskell. PayCheck is useful for defining a specification of what a function should do, rather than testing its results for a given input."""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-source_urls = [
-               'http://pypi.python.org/packages/source/p/paycheck/',
-              ]
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = 'Python'

--- a/easybuild/easyconfigs/p/paycheck/paycheck-1.0.2-ictce-4.1.13-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/p/paycheck/paycheck-1.0.2-ictce-4.1.13-Python-2.7.3.eb
@@ -3,15 +3,13 @@ easyblock = 'PythonPackage'
 name = 'paycheck'
 version = '1.0.2'
 
-homepage = 'http://pypi.python.org/pypi/paycheck/'
+homepage = 'https://pypi.python.org/pypi/paycheck/'
 description = """PayCheck is a half-baked implementation of ScalaCheck, which itself is an implementation of QuickCheck for Haskell.
  PayCheck is useful for defining a specification of what a function should do, rather than testing its results for a given input."""
 
 toolchain = {'name': 'ictce', 'version': '4.1.13'}
 
-source_urls = [
-               'http://pypi.python.org/packages/source/p/paycheck/',
-              ]
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = 'Python'

--- a/easybuild/easyconfigs/p/paycheck/paycheck-1.0.2-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/p/paycheck/paycheck-1.0.2-ictce-5.3.0-Python-2.7.3.eb
@@ -3,16 +3,13 @@ easyblock = 'PythonPackage'
 name = 'paycheck'
 version = '1.0.2'
 
-homepage = 'http://pypi.python.org/pypi/paycheck/'
+homepage = 'https://pypi.python.org/pypi/paycheck/'
 description = """PayCheck is a half-baked implementation of ScalaCheck, which itself is an implementation of QuickCheck for Haskell.
  PayCheck is useful for defining a specification of what a function should do, rather than testing its results for a given input."""
 
-
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
-source_urls = [
-               'http://pypi.python.org/packages/source/p/paycheck/',
-              ]
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = 'Python'

--- a/easybuild/easyconfigs/p/paycheck/paycheck-1.0.2-iomkl-4.6.13-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/p/paycheck/paycheck-1.0.2-iomkl-4.6.13-Python-2.7.3.eb
@@ -3,15 +3,13 @@ easyblock = 'PythonPackage'
 name = 'paycheck'
 version = '1.0.2'
 
-homepage = 'http://pypi.python.org/pypi/paycheck/'
+homepage = 'https://pypi.python.org/pypi/paycheck/'
 description = """PayCheck is a half-baked implementation of ScalaCheck, which itself is an implementation of QuickCheck for Haskell.
  PayCheck is useful for defining a specification of what a function should do, rather than testing its results for a given input."""
 
 toolchain = {'name': 'iomkl', 'version': '4.6.13'}
 
-source_urls = [
-               'http://pypi.python.org/packages/source/p/paycheck/',
-              ]
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = 'Python'

--- a/easybuild/easyconfigs/p/pymatgen/pymatgen-3.0.13-intel-2015a-Python-2.7.9-gmatteo-20150407.eb
+++ b/easybuild/easyconfigs/p/pymatgen/pymatgen-3.0.13-intel-2015a-Python-2.7.9-gmatteo-20150407.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = 'pymatgen'
 version = '3.0.13'
 
-homepage = 'http://pypi.python.org/pypi/pymatgen'
+homepage = 'https://pypi.python.org/pypi/pymatgen'
 description = """Python Materials Genomics is a robust materials analysis code that defines core object
  representations for structures and molecules with support for many electronic structure codes."""
 

--- a/easybuild/easyconfigs/p/pymatgen/pymatgen-3.0.13-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/p/pymatgen/pymatgen-3.0.13-intel-2015a-Python-2.7.9.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = 'pymatgen'
 version = '3.0.13'
 
-homepage = 'http://pypi.python.org/pypi/pymatgen'
+homepage = 'https://pypi.python.org/pypi/pymatgen'
 description = """Python Materials Genomics is a robust materials analysis code that defines core object
  representations for structures and molecules with support for many electronic structure codes."""
 

--- a/easybuild/easyconfigs/s/setuptools/setuptools-0.6c11-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/setuptools/setuptools-0.6c11-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -3,12 +3,12 @@ easyblock = "PythonPackage"
 name = "setuptools"
 version = "0.6c11"
 
-homepage = "http://pypi.python.org/pypi/setuptools/"
+homepage = "https://pypi.python.org/pypi/setuptools/"
 description = """Download, build, install, upgrade, and uninstall Python packages -- easily!"""
 
 toolchain = {'name': 'goalf', 'version': '1.1.0-no-OFED'}
 
-source_urls = ['http://pypi.python.org/packages/source/s/%s/' % name]
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = "Python"

--- a/easybuild/easyconfigs/s/setuptools/setuptools-0.6c11-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/setuptools/setuptools-0.6c11-goolf-1.4.10-Python-2.7.3.eb
@@ -3,12 +3,12 @@ easyblock = "PythonPackage"
 name = "setuptools"
 version = "0.6c11"
 
-homepage = "http://pypi.python.org/pypi/setuptools/"
+homepage = "https://pypi.python.org/pypi/setuptools/"
 description = """Download, build, install, upgrade, and uninstall Python packages -- easily!"""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
-source_urls = ['http://pypi.python.org/packages/source/s/%s/' % name]
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = "Python"

--- a/easybuild/easyconfigs/s/setuptools/setuptools-0.6c11-ictce-4.0.6-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/setuptools/setuptools-0.6c11-ictce-4.0.6-Python-2.7.3.eb
@@ -3,12 +3,12 @@ easyblock = "PythonPackage"
 name = "setuptools"
 version = "0.6c11"
 
-homepage = "http://pypi.python.org/pypi/setuptools/"
+homepage = "https://pypi.python.org/pypi/setuptools/"
 description = """Download, build, install, upgrade, and uninstall Python packages -- easily!"""
 
 toolchain = {'name': 'ictce', 'version': '4.0.6'}
 
-source_urls = ['http://pypi.python.org/packages/source/s/%s/' % name]
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = "Python"

--- a/easybuild/easyconfigs/s/setuptools/setuptools-0.6c11-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/setuptools/setuptools-0.6c11-ictce-5.3.0-Python-2.7.3.eb
@@ -3,13 +3,12 @@ easyblock = "PythonPackage"
 name = "setuptools"
 version = "0.6c11"
 
-homepage = "http://pypi.python.org/pypi/setuptools/"
+homepage = "https://pypi.python.org/pypi/setuptools/"
 description = """Download, build, install, upgrade, and uninstall Python packages -- easily!"""
-
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
-source_urls = ['http://pypi.python.org/packages/source/s/%s/' % name]
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = "Python"

--- a/easybuild/easyconfigs/s/setuptools/setuptools-1.4.2.eb
+++ b/easybuild/easyconfigs/s/setuptools/setuptools-1.4.2.eb
@@ -3,12 +3,12 @@ easyblock = "VersionIndependentPythonPackage"
 name = "setuptools"
 version = "1.4.2"
 
-homepage = "http://pypi.python.org/pypi/setuptools/"
+homepage = "https://pypi.python.org/pypi/setuptools/"
 description = """Download, build, install, upgrade, and uninstall Python packages -- easily!"""
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-source_urls = ['http://pypi.python.org/packages/source/s/%(name)s/']
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/s/stemming/stemming-1.0-ictce-5.5.0-Python-2.7.6.eb
+++ b/easybuild/easyconfigs/s/stemming/stemming-1.0-ictce-5.5.0-Python-2.7.6.eb
@@ -3,7 +3,7 @@ easyblock = "PythonPackage"
 name = "stemming"
 version = "1.0"
 
-homepage = "http://pypi.python.org/pypi/stemming/"
+homepage = "https://pypi.python.org/pypi/stemming/"
 description = """Python implementations of the Porter, Porter2, Paice-Husk, and Lovins stemming algorithms for English."""
 
 toolchain = {'name': 'ictce', 'version': '5.5.0'}


### PR DESCRIPTION
requires https://github.com/hpcugent/easybuild-framework/pull/1286 to avoid breaking currently working downloads (where https was already being used)