### PR TITLE
{lang}[intel/2015a] R-bundle devtools (Rv3.1.3) (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/r/R-bundles/R-bundles-20150520-intel-2015a-R-3.1.3-devtools.eb
+++ b/easybuild/easyconfigs/r/R-bundles/R-bundles-20150520-intel-2015a-R-3.1.3-devtools.eb
@@ -17,7 +17,7 @@ exts_filter = ("R -q --no-save", "library(%(ext_name)s)")
 
 dependencies = [
     ('R', rver),
-    ('cURL', '7.41.0'),
+    ('cURL', '7.40.0'),
     ('libxml2', '2.9.2'),
 ]
 

--- a/easybuild/easyconfigs/r/R-bundles/R-bundles-20150520-intel-2015a-R-3.1.3-devtools.eb
+++ b/easybuild/easyconfigs/r/R-bundles/R-bundles-20150520-intel-2015a-R-3.1.3-devtools.eb
@@ -1,0 +1,51 @@
+easyblock = 'Bundle'
+
+name = 'R-bundles'
+version = '20150520'
+bundlename = 'devtools'
+rver = '3.1.3'
+versionsuffix = '-R-%s-%s' % (rver, bundlename)
+
+homepage = 'http://www.r-project.org/'
+description = """R is a free software environment for statistical computing and graphics."""
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+
+# these are extensions for R
+exts_defaultclass = 'RPackage'
+exts_filter = ("R -q --no-save", "library(%(ext_name)s)")
+
+dependencies = [
+    ('R', rver),
+    ('cURL', '7.41.0'),
+    ('libxml2', '2.9.2'),
+]
+
+name_tmpl = '%(name)s_%(version)s.tar.gz'
+ext_options = {
+    'source_urls': [
+        'http://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'http://cran.r-project.org/src/contrib/',  # current version of packages
+        'http://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': name_tmpl,
+}
+
+# !! order of packages is important !!
+exts_list = [
+    ('XML', '3.98-1.1', ext_options),
+    ('memoise', '0.2.1', ext_options),
+    ('whisker', '0.3-2', ext_options),
+    ('rstudioapi', '0.3.1', ext_options),
+    ('roxygen2', '4.1.1', ext_options),
+    ('git2r', '0.10.1', ext_options),
+    ('RCurl', '1.95-4.6', ext_options),
+    ('httr', '0.6.1', ext_options),
+    ('rversions', '1.0.0', ext_options),
+    ('devtools', '1.8.0', ext_options),
+]
+
+modextrapaths = {'R_LIBS': ''}
+
+moduleclass = 'lang'
+


### PR DESCRIPTION
devtools is a useful package for letting users install packages from, e.g. github. This was made as a bundle based on @boegel's suggestion.

edit: we should sync this with #1387, this should depend on the bundle contributed there