### PR TITLE
add patch for installing paycheck as Py3 extension

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
@@ -56,6 +56,9 @@ exts_list = [
     }),
     ('paycheck', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+        'patches': [
+            'paycheck-1.0.2_setup-open-README-utf8.patch',
+        ],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -77,6 +80,9 @@ exts_list = [
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+        'patches': [
+            'deap-1.0.2_setup-open-README-utf8.patch',
+        ],
     }),
     ('decorator', '3.4.0', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
@@ -81,7 +81,7 @@ exts_list = [
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
         'patches': [
-            'deap-1.0.2_setup-open-README-utf8.patch',
+            'deap-1.0.1_setup-open-README-utf8.patch',
         ],
     }),
     ('decorator', '3.4.0', {

--- a/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2015a.eb
@@ -56,6 +56,9 @@ exts_list = [
     }),
     ('paycheck', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+        'patches': [
+            'paycheck-1.0.2_setup-open-README-utf8.patch',
+        ],
     }),
     ('argparse', '1.2.1', {
         'source_urls': ['http://argparse.googlecode.com/files/'],
@@ -77,6 +80,9 @@ exts_list = [
     }),
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+        'patches': [
+            'deap-1.0.2_setup-open-README-utf8.patch',
+        ],
     }),
     ('decorator', '3.4.0', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2015a.eb
@@ -81,7 +81,7 @@ exts_list = [
     ('deap', '1.0.1', {
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
         'patches': [
-            'deap-1.0.2_setup-open-README-utf8.patch',
+            'deap-1.0.1_setup-open-README-utf8.patch',
         ],
     }),
     ('decorator', '3.4.0', {

--- a/easybuild/easyconfigs/p/Python/Python-3.4.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.3-intel-2015a.eb
@@ -55,6 +55,9 @@ exts_list = [
     }),
     ('paycheck', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+        'patches': [
+            'paycheck-1.0.2_setup-open-README-utf8.patch',
+        ],
     }),
     ('argparse', '1.3.0', {
         'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.4.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.3-intel-2015a.eb
@@ -81,6 +81,9 @@ exts_list = [
     ('deap', '1.0.2', {
         'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+        'patches': [
+            'deap-1.0.2_setup-open-README-utf8.patch',
+        ],
     }),
     ('decorator', '3.4.2', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],

--- a/easybuild/easyconfigs/p/Python/deap-1.0.1_setup-open-README-utf8.patch
+++ b/easybuild/easyconfigs/p/Python/deap-1.0.1_setup-open-README-utf8.patch
@@ -1,0 +1,17 @@
+--- deap-1.0.1.orig/setup.py	2014-04-08 15:49:52.000000000 +0200
++++ deap-1.0.1/setup.py	2015-05-21 22:25:37.345008000 +0200
+@@ -1,4 +1,5 @@
+ #!/usr/bin/env python
++import codecs
+ import sys
+ from distutils.core import setup
+ try:
+@@ -11,7 +12,7 @@
+ setup(name='deap',
+       version=deap.__revision__,
+       description='Distributed Evolutionary Algorithms in Python',
+-      long_description=open('README.txt').read(),
++      long_description=codecs.open('README.txt', encoding='utf-8').read(),
+       author='deap Development Team',
+       author_email='deap-users@googlegroups.com',
+       url='http://deap.googlecode.com',

--- a/easybuild/easyconfigs/p/Python/deap-1.0.2_setup-open-README-utf8.patch
+++ b/easybuild/easyconfigs/p/Python/deap-1.0.2_setup-open-README-utf8.patch
@@ -1,0 +1,17 @@
+--- deap-1.0.2.orig/setup.py	2015-05-12 04:06:49.000000000 +0200
++++ deap-1.0.2/setup.py	2015-05-21 19:06:03.792820042 +0200
+@@ -1,4 +1,5 @@
+ #!/usr/bin/env python
++import codecs
+ import sys
+ from distutils.core import setup
+ try:
+@@ -10,7 +11,7 @@
+     from pypandoc import convert
+ except ImportError:
+     print("warning: pypandoc module not found, could not convert Markdown to RST")
+-    read_md = lambda f: open(f, 'r').read()
++    read_md = lambda f: codecs.open(f, encoding='utf-8').read()
+ else:
+     read_md = lambda f: convert(f, 'rst')
+ 

--- a/easybuild/easyconfigs/p/Python/paycheck-1.0.2_setup-open-README-utf8.patch
+++ b/easybuild/easyconfigs/p/Python/paycheck-1.0.2_setup-open-README-utf8.patch
@@ -1,0 +1,22 @@
+open README file with utf-8 encoding, to avoid error like:
+UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 577: ordinal not in range(128)
+author: Kenneth Hoste (HPC-UGent)
+--- paycheck-1.0.2/setup.py.orig	2015-05-21 16:09:24.300074046 +0200
++++ paycheck-1.0.2/setup.py	2015-05-21 16:11:43.503945542 +0200
+@@ -1,6 +1,7 @@
+ from distutils.cmd import Command
+ from distutils.core import setup
+ 
++import codecs
+ import sys
+ if sys.version_info >= (3, 0):
+     try:
+@@ -24,7 +25,7 @@
+     name = 'paycheck',
+     version ='1.0.2',
+     description ='A Python QuickCheck implementation',
+-    long_description = open("README.txt").read(),
++    long_description = codecs.open("README.txt", encoding='utf-8').read(),
+     author ='Mark Chadwick',
+     author_email ='mark.chadwick@gmail.com',
+     maintainer ='Gregory Crosswhite',


### PR DESCRIPTION
without the patch, installing paycheck with Py3 fails if `$LC_ALL` isn't set to `en_US.utf8`