### PR TITLE
[gcc-4.9.2] fixed git to include EB perl and path (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/g/git/git-2.2.2-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/git/git-2.2.2-GCC-4.9.2.eb
@@ -25,18 +25,18 @@ toolchain = {'name': 'GCC', 'version': '4.9.2'}
 sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/git/git/archive']
 
-preconfigopts = 'make configure && '
-
-# Work around git build system bug.  If LIBS contains -lpthread, then configure
-# will not append -lpthread to LDFLAGS, but Makefile ignores LIBS.
-configopts = "--with-perl=${EBPERLROOT} --enable-pthreads='-lpthread'"
-
 dependencies = [
     ('cURL', '7.40.0'),
     ('expat', '2.1.0'),
     ('gettext', '0.19.4'),
     ('Perl', '5.20.1', '-bare'),
 ]
+
+preconfigopts = 'make configure && '
+
+# Work around git build system bug.  If LIBS contains -lpthread, then configure
+# will not append -lpthread to LDFLAGS, but Makefile ignores LIBS.
+configopts = "--with-perl=${EBPERLROOT} --enable-pthreads='-lpthread'"
 
 sanity_check_paths = {
     'files': ['bin/git'],

--- a/easybuild/easyconfigs/g/git/git-2.4.1-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/git/git-2.4.1-GCC-4.9.2.eb
@@ -25,18 +25,18 @@ toolchain = {'name': 'GCC', 'version': '4.9.2'}
 sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/git/git/archive']
 
-preconfigopts = 'make configure && '
-
-# Work around git build system bug.  If LIBS contains -lpthread, then configure
-# will not append -lpthread to LDFLAGS, but Makefile ignores LIBS.
-configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
-
 dependencies = [
     ('cURL', '7.40.0'),
     ('expat', '2.1.0'),
     ('gettext', '0.19.4'),
     ('Perl', '5.20.1', '-bare'),
 ]
+
+preconfigopts = 'make configure && '
+
+# Work around git build system bug.  If LIBS contains -lpthread, then configure
+# will not append -lpthread to LDFLAGS, but Makefile ignores LIBS.
+configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
 
 sanity_check_paths = {
     'files': ['bin/git'],

--- a/easybuild/easyconfigs/g/git/git-2.4.1-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/git/git-2.4.1-GCC-4.9.2.eb
@@ -14,7 +14,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'git'
-version = '2.2.2'
+version = '2.4.1'
 
 homepage = 'http://git-scm.com/'
 description = """Git is a free and open source distributed version control system designed
@@ -29,7 +29,7 @@ preconfigopts = 'make configure && '
 
 # Work around git build system bug.  If LIBS contains -lpthread, then configure
 # will not append -lpthread to LDFLAGS, but Makefile ignores LIBS.
-configopts = "--with-perl=${EBPERLROOT} --enable-pthreads='-lpthread'"
+configopts = "--with-perl=${EBROOTPERL}/bin/perl --enable-pthreads='-lpthread'"
 
 dependencies = [
     ('cURL', '7.40.0'),


### PR DESCRIPTION
Some of git, especially the submodules code, is written in Perl.

I had some problems with the base version of perl included in centos6, so it makes some sense to use the version of perl available in EB.