### PR TITLE
OpenFOAM foss 2015.05 flavour: needed for Centos6 on Haswell

### DIFF
--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015.05.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015.05.eb
@@ -1,4 +1,3 @@
-# Built with EasyBuild version 2.1.0 on 2015-05-21_15-38-14
 name = 'flex'
 version = '2.5.39'
 
@@ -14,27 +13,3 @@ source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
 moduleclass = 'lang'
 
-# Build statistics
-buildstats = [{
-    "easybuild-framework_version": "2.1.0",
-    "easybuild-easyblocks_version": "2.1.0",
-    "timestamp": 1432215494,
-    "build_time": 21.24,
-    "install_size": 2865429,
-    "command_line": ['--buildpath=/sw/eb/build', '--debug', '--installpath=/sw/eb', '--prefix=/sw/eb', '--repositorypath=/sw/eb/ebfiles_repo', '--robot=/sw/eb/software/EasyBuild/2.1.0/lib/python2.6/site-packages/easybuild_easyconfigs-2.1.0-py2.6.egg/easybuild/easyconfigs', '--sourcepath=/sw/eb/sources', '--try-toolchain="[\'foss\', \'2015.05\']"', 'OpenFOAM-2.3.1-intel-2015a.eb'],
-    "modules_tool": ('EnvironmentModulesC', '/usr/bin/modulecmd', '3.2.10'),
-    "core_count": 12,
-    "cpu_model": "Intel(R) Xeon(R) CPU E5-2603 v3 @ 1.60GHz",
-    "cpu_speed": 1600.0,
-    "cpu_vendor": "Intel",
-    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/sw/eb/software/GCC/4.9.2-binutils-2.25/libexec/gcc/x86_64-unknown-linux-gnu/4.9.2/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25 --with-local-prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25; Thread model: posix; gcc version 4.9.2 (GCC) ; ",
-    "glibc_version": "2.12",
-    "hostname": "boot-tenova",
-    "os_name": "centos",
-    "os_type": "Linux",
-    "os_version": "6.6",
-    "platform_name": "x86_64-unknown-linux",
-    "python_version": "2.6.6 (r266:84292, Jan 22 2014, 09:42:36) ; [GCC 4.4.7 20120313 (Red Hat 4.4.7-4)]",
-    "system_gcc_path": "/sw/eb/software/GCC/4.9.2-binutils-2.25/bin/gcc",
-    "system_python_path": "/usr/bin/python",
-}]

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015.05.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015.05.eb
@@ -1,0 +1,40 @@
+# Built with EasyBuild version 2.1.0 on 2015-05-21_15-38-14
+name = 'flex'
+version = '2.5.39'
+
+homepage = 'http://flex.sourceforge.net/'
+description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners. A scanner, 
+ sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
+
+toolchain = {'name': 'foss', 'version': '2015.05'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
+
+moduleclass = 'lang'
+
+# Build statistics
+buildstats = [{
+    "easybuild-framework_version": "2.1.0",
+    "easybuild-easyblocks_version": "2.1.0",
+    "timestamp": 1432215494,
+    "build_time": 21.24,
+    "install_size": 2865429,
+    "command_line": ['--buildpath=/sw/eb/build', '--debug', '--installpath=/sw/eb', '--prefix=/sw/eb', '--repositorypath=/sw/eb/ebfiles_repo', '--robot=/sw/eb/software/EasyBuild/2.1.0/lib/python2.6/site-packages/easybuild_easyconfigs-2.1.0-py2.6.egg/easybuild/easyconfigs', '--sourcepath=/sw/eb/sources', '--try-toolchain="[\'foss\', \'2015.05\']"', 'OpenFOAM-2.3.1-intel-2015a.eb'],
+    "modules_tool": ('EnvironmentModulesC', '/usr/bin/modulecmd', '3.2.10'),
+    "core_count": 12,
+    "cpu_model": "Intel(R) Xeon(R) CPU E5-2603 v3 @ 1.60GHz",
+    "cpu_speed": 1600.0,
+    "cpu_vendor": "Intel",
+    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/sw/eb/software/GCC/4.9.2-binutils-2.25/libexec/gcc/x86_64-unknown-linux-gnu/4.9.2/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25 --with-local-prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25; Thread model: posix; gcc version 4.9.2 (GCC) ; ",
+    "glibc_version": "2.12",
+    "hostname": "boot-tenova",
+    "os_name": "centos",
+    "os_type": "Linux",
+    "os_version": "6.6",
+    "platform_name": "x86_64-unknown-linux",
+    "python_version": "2.6.6 (r266:84292, Jan 22 2014, 09:42:36) ; [GCC 4.4.7 20120313 (Red Hat 4.4.7-4)]",
+    "system_gcc_path": "/sw/eb/software/GCC/4.9.2-binutils-2.25/bin/gcc",
+    "system_python_path": "/usr/bin/python",
+}]

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015.05.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015.05.eb
@@ -12,4 +12,3 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
 moduleclass = 'lang'
-

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015.05.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015.05.eb
@@ -1,0 +1,53 @@
+# Built with EasyBuild version 2.1.0 on 2015-05-21_15-37-53
+easyblock = 'ConfigureMake'
+
+name = 'libreadline'
+version = '6.3'
+
+homepage = 'http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html'
+description = """The GNU Readline library provides a set of functions for use by applications that
+ allow users to edit command lines as they are typed in. Both Emacs and vi editing modes are available.
+ The Readline library includes additional functions to maintain a list of previously-entered command lines,
+ to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
+
+toolchain = {'name': 'foss', 'version': '2015.05'}
+toolchainopts = {'pic': True}
+
+sources = ['readline-%(version)s.tar.gz']
+source_urls = ['http://ftp.gnu.org/gnu/readline']
+
+dependencies = [('ncurses', '5.9')]
+
+sanity_check_paths = {
+    'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
+              ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',
+                                                   'rlstdc.h', 'rltypedefs.h', 'tilde.h']],
+    'dirs' : [],
+}
+
+moduleclass = 'lib'
+
+# Build statistics
+buildstats = [{
+    "easybuild-framework_version": "2.1.0",
+    "easybuild-easyblocks_version": "2.1.0",
+    "timestamp": 1432215473,
+    "build_time": 17.27,
+    "install_size": 2395805,
+    "command_line": ['--buildpath=/sw/eb/build', '--debug', '--installpath=/sw/eb', '--prefix=/sw/eb', '--repositorypath=/sw/eb/ebfiles_repo', '--robot=/sw/eb/software/EasyBuild/2.1.0/lib/python2.6/site-packages/easybuild_easyconfigs-2.1.0-py2.6.egg/easybuild/easyconfigs', '--sourcepath=/sw/eb/sources', '--try-toolchain="[\'foss\', \'2015.05\']"', 'OpenFOAM-2.3.1-intel-2015a.eb'],
+    "modules_tool": ('EnvironmentModulesC', '/usr/bin/modulecmd', '3.2.10'),
+    "core_count": 12,
+    "cpu_model": "Intel(R) Xeon(R) CPU E5-2603 v3 @ 1.60GHz",
+    "cpu_speed": 1600.0,
+    "cpu_vendor": "Intel",
+    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/sw/eb/software/GCC/4.9.2-binutils-2.25/libexec/gcc/x86_64-unknown-linux-gnu/4.9.2/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25 --with-local-prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25; Thread model: posix; gcc version 4.9.2 (GCC) ; ",
+    "glibc_version": "2.12",
+    "hostname": "boot-tenova",
+    "os_name": "centos",
+    "os_type": "Linux",
+    "os_version": "6.6",
+    "platform_name": "x86_64-unknown-linux",
+    "python_version": "2.6.6 (r266:84292, Jan 22 2014, 09:42:36) ; [GCC 4.4.7 20120313 (Red Hat 4.4.7-4)]",
+    "system_gcc_path": "/sw/eb/software/GCC/4.9.2-binutils-2.25/bin/gcc",
+    "system_python_path": "/usr/bin/python",
+}]

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015.05.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015.05.eb
@@ -25,4 +25,3 @@ sanity_check_paths = {
 }
 
 moduleclass = 'lib'
-

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015.05.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015.05.eb
@@ -1,4 +1,3 @@
-# Built with EasyBuild version 2.1.0 on 2015-05-21_15-37-53
 easyblock = 'ConfigureMake'
 
 name = 'libreadline'
@@ -27,27 +26,3 @@ sanity_check_paths = {
 
 moduleclass = 'lib'
 
-# Build statistics
-buildstats = [{
-    "easybuild-framework_version": "2.1.0",
-    "easybuild-easyblocks_version": "2.1.0",
-    "timestamp": 1432215473,
-    "build_time": 17.27,
-    "install_size": 2395805,
-    "command_line": ['--buildpath=/sw/eb/build', '--debug', '--installpath=/sw/eb', '--prefix=/sw/eb', '--repositorypath=/sw/eb/ebfiles_repo', '--robot=/sw/eb/software/EasyBuild/2.1.0/lib/python2.6/site-packages/easybuild_easyconfigs-2.1.0-py2.6.egg/easybuild/easyconfigs', '--sourcepath=/sw/eb/sources', '--try-toolchain="[\'foss\', \'2015.05\']"', 'OpenFOAM-2.3.1-intel-2015a.eb'],
-    "modules_tool": ('EnvironmentModulesC', '/usr/bin/modulecmd', '3.2.10'),
-    "core_count": 12,
-    "cpu_model": "Intel(R) Xeon(R) CPU E5-2603 v3 @ 1.60GHz",
-    "cpu_speed": 1600.0,
-    "cpu_vendor": "Intel",
-    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/sw/eb/software/GCC/4.9.2-binutils-2.25/libexec/gcc/x86_64-unknown-linux-gnu/4.9.2/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25 --with-local-prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25; Thread model: posix; gcc version 4.9.2 (GCC) ; ",
-    "glibc_version": "2.12",
-    "hostname": "boot-tenova",
-    "os_name": "centos",
-    "os_type": "Linux",
-    "os_version": "6.6",
-    "platform_name": "x86_64-unknown-linux",
-    "python_version": "2.6.6 (r266:84292, Jan 22 2014, 09:42:36) ; [GCC 4.4.7 20120313 (Red Hat 4.4.7-4)]",
-    "system_gcc_path": "/sw/eb/software/GCC/4.9.2-binutils-2.25/bin/gcc",
-    "system_python_path": "/usr/bin/python",
-}]

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-foss-2015.05.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-foss-2015.05.eb
@@ -1,0 +1,48 @@
+# Built with EasyBuild version 2.1.0 on 2015-05-21_15-37-36
+name = 'ncurses'
+version = '5.9'
+
+homepage = 'http://www.gnu.org/software/ncurses/'
+description = """The Ncurses (new curses) library is a free software emulation of curses in System V Release 4.0,
+ and more. It uses Terminfo format, supports pads and color and multiple highlights and forms characters and
+ function-key mapping, and has all the other SYSV-curses enhancements over BSD Curses."""
+
+toolchain = {'name': 'foss', 'version': '2015.05'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+configopts = [
+    # default build, no custom configure options
+    '',
+    # the UTF-8 enabled version (ncursesw)
+    '--enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
+]
+
+moduleclass = 'devel'
+
+# Build statistics
+buildstats = [{
+    "easybuild-framework_version": "2.1.0",
+    "easybuild-easyblocks_version": "2.1.0",
+    "timestamp": 1432215455,
+    "build_time": 80.56,
+    "install_size": 24625439,
+    "command_line": ['--buildpath=/sw/eb/build', '--debug', '--installpath=/sw/eb', '--prefix=/sw/eb', '--repositorypath=/sw/eb/ebfiles_repo', '--robot=/sw/eb/software/EasyBuild/2.1.0/lib/python2.6/site-packages/easybuild_easyconfigs-2.1.0-py2.6.egg/easybuild/easyconfigs', '--sourcepath=/sw/eb/sources', '--try-toolchain="[\'foss\', \'2015.05\']"', 'OpenFOAM-2.3.1-intel-2015a.eb'],
+    "modules_tool": ('EnvironmentModulesC', '/usr/bin/modulecmd', '3.2.10'),
+    "core_count": 12,
+    "cpu_model": "Intel(R) Xeon(R) CPU E5-2603 v3 @ 1.60GHz",
+    "cpu_speed": 1600.0,
+    "cpu_vendor": "Intel",
+    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/sw/eb/software/GCC/4.9.2-binutils-2.25/libexec/gcc/x86_64-unknown-linux-gnu/4.9.2/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25 --with-local-prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25; Thread model: posix; gcc version 4.9.2 (GCC) ; ",
+    "glibc_version": "2.12",
+    "hostname": "boot-tenova",
+    "os_name": "centos",
+    "os_type": "Linux",
+    "os_version": "6.6",
+    "platform_name": "x86_64-unknown-linux",
+    "python_version": "2.6.6 (r266:84292, Jan 22 2014, 09:42:36) ; [GCC 4.4.7 20120313 (Red Hat 4.4.7-4)]",
+    "system_gcc_path": "/sw/eb/software/GCC/4.9.2-binutils-2.25/bin/gcc",
+    "system_python_path": "/usr/bin/python",
+}]

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-foss-2015.05.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-foss-2015.05.eb
@@ -1,4 +1,3 @@
-# Built with EasyBuild version 2.1.0 on 2015-05-21_15-37-36
 name = 'ncurses'
 version = '5.9'
 
@@ -22,27 +21,3 @@ configopts = [
 
 moduleclass = 'devel'
 
-# Build statistics
-buildstats = [{
-    "easybuild-framework_version": "2.1.0",
-    "easybuild-easyblocks_version": "2.1.0",
-    "timestamp": 1432215455,
-    "build_time": 80.56,
-    "install_size": 24625439,
-    "command_line": ['--buildpath=/sw/eb/build', '--debug', '--installpath=/sw/eb', '--prefix=/sw/eb', '--repositorypath=/sw/eb/ebfiles_repo', '--robot=/sw/eb/software/EasyBuild/2.1.0/lib/python2.6/site-packages/easybuild_easyconfigs-2.1.0-py2.6.egg/easybuild/easyconfigs', '--sourcepath=/sw/eb/sources', '--try-toolchain="[\'foss\', \'2015.05\']"', 'OpenFOAM-2.3.1-intel-2015a.eb'],
-    "modules_tool": ('EnvironmentModulesC', '/usr/bin/modulecmd', '3.2.10'),
-    "core_count": 12,
-    "cpu_model": "Intel(R) Xeon(R) CPU E5-2603 v3 @ 1.60GHz",
-    "cpu_speed": 1600.0,
-    "cpu_vendor": "Intel",
-    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/sw/eb/software/GCC/4.9.2-binutils-2.25/libexec/gcc/x86_64-unknown-linux-gnu/4.9.2/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25 --with-local-prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25; Thread model: posix; gcc version 4.9.2 (GCC) ; ",
-    "glibc_version": "2.12",
-    "hostname": "boot-tenova",
-    "os_name": "centos",
-    "os_type": "Linux",
-    "os_version": "6.6",
-    "platform_name": "x86_64-unknown-linux",
-    "python_version": "2.6.6 (r266:84292, Jan 22 2014, 09:42:36) ; [GCC 4.4.7 20120313 (Red Hat 4.4.7-4)]",
-    "system_gcc_path": "/sw/eb/software/GCC/4.9.2-binutils-2.25/bin/gcc",
-    "system_python_path": "/usr/bin/python",
-}]

--- a/easybuild/easyconfigs/n/ncurses/ncurses-5.9-foss-2015.05.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-5.9-foss-2015.05.eb
@@ -20,4 +20,3 @@ configopts = [
 ]
 
 moduleclass = 'devel'
-

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-2.3.1-foss-2015.05.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-2.3.1-foss-2015.05.eb
@@ -1,4 +1,3 @@
-# Built with EasyBuild version 2.1.0 on 2015-05-21_16-18-05
 name = 'OpenFOAM'
 version = '2.3.1'
 
@@ -32,27 +31,3 @@ builddependencies = [('flex', '2.5.39')]
 
 moduleclass = 'cae'
 
-# Build statistics
-buildstats = [{
-    "easybuild-framework_version": "2.1.0",
-    "easybuild-easyblocks_version": "2.1.0",
-    "timestamp": 1432217883,
-    "build_time": 2389.2,
-    "install_size": 1888270856,
-    "command_line": ['--buildpath=/sw/eb/build', '--debug', '--installpath=/sw/eb', '--prefix=/sw/eb', '--repositorypath=/sw/eb/ebfiles_repo', '--robot=/sw/eb/software/EasyBuild/2.1.0/lib/python2.6/site-packages/easybuild_easyconfigs-2.1.0-py2.6.egg/easybuild/easyconfigs', '--sourcepath=/sw/eb/sources', '--try-toolchain="[\'foss\', \'2015.05\']"', 'OpenFOAM-2.3.1-intel-2015a.eb'],
-    "modules_tool": ('EnvironmentModulesC', '/usr/bin/modulecmd', '3.2.10'),
-    "core_count": 12,
-    "cpu_model": "Intel(R) Xeon(R) CPU E5-2603 v3 @ 1.60GHz",
-    "cpu_speed": 1600.0,
-    "cpu_vendor": "Intel",
-    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/sw/eb/software/GCC/4.9.2-binutils-2.25/libexec/gcc/x86_64-unknown-linux-gnu/4.9.2/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25 --with-local-prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25; Thread model: posix; gcc version 4.9.2 (GCC) ; ",
-    "glibc_version": "2.12",
-    "hostname": "boot-tenova",
-    "os_name": "centos",
-    "os_type": "Linux",
-    "os_version": "6.6",
-    "platform_name": "x86_64-unknown-linux",
-    "python_version": "2.6.6 (r266:84292, Jan 22 2014, 09:42:36) ; [GCC 4.4.7 20120313 (Red Hat 4.4.7-4)]",
-    "system_gcc_path": "/sw/eb/software/GCC/4.9.2-binutils-2.25/bin/gcc",
-    "system_python_path": "/usr/bin/python",
-}]

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-2.3.1-foss-2015.05.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-2.3.1-foss-2015.05.eb
@@ -1,0 +1,58 @@
+# Built with EasyBuild version 2.1.0 on 2015-05-21_16-18-05
+name = 'OpenFOAM'
+version = '2.3.1'
+
+homepage = 'http://www.openfoam.com/'
+description = """OpenFOAM is a free, open source CFD software package. 
+ OpenFOAM has an extensive range of features to solve anything from complex fluid flows
+ involving chemical reactions, turbulence and heat transfer, 
+ to solid dynamics and electromagnetics."""
+
+toolchain = {'name': 'foss', 'version': '2015.05'}
+
+source_urls = ['http://downloads.sourceforge.net/foam/%(version)s']
+sources = [
+    SOURCE_TGZ,
+    'ThirdParty-%(version)s.tgz',
+]
+
+patches = [
+    'cleanup-OpenFOAM-%(version)s.patch',
+    'OpenFOAM-2.3.0_libreadline.patch',
+    ('cleanup-ThirdParty-%(version)s.patch', ".."),  # patch should not be applied in OpenFOAM subdir
+]
+
+dependencies = [
+    ('libreadline', '6.3'),
+    ('SCOTCH', '6.0.4'),
+    ('ncurses', '5.9'),
+]
+
+builddependencies = [('flex', '2.5.39')]
+
+moduleclass = 'cae'
+
+# Build statistics
+buildstats = [{
+    "easybuild-framework_version": "2.1.0",
+    "easybuild-easyblocks_version": "2.1.0",
+    "timestamp": 1432217883,
+    "build_time": 2389.2,
+    "install_size": 1888270856,
+    "command_line": ['--buildpath=/sw/eb/build', '--debug', '--installpath=/sw/eb', '--prefix=/sw/eb', '--repositorypath=/sw/eb/ebfiles_repo', '--robot=/sw/eb/software/EasyBuild/2.1.0/lib/python2.6/site-packages/easybuild_easyconfigs-2.1.0-py2.6.egg/easybuild/easyconfigs', '--sourcepath=/sw/eb/sources', '--try-toolchain="[\'foss\', \'2015.05\']"', 'OpenFOAM-2.3.1-intel-2015a.eb'],
+    "modules_tool": ('EnvironmentModulesC', '/usr/bin/modulecmd', '3.2.10'),
+    "core_count": 12,
+    "cpu_model": "Intel(R) Xeon(R) CPU E5-2603 v3 @ 1.60GHz",
+    "cpu_speed": 1600.0,
+    "cpu_vendor": "Intel",
+    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/sw/eb/software/GCC/4.9.2-binutils-2.25/libexec/gcc/x86_64-unknown-linux-gnu/4.9.2/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25 --with-local-prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25; Thread model: posix; gcc version 4.9.2 (GCC) ; ",
+    "glibc_version": "2.12",
+    "hostname": "boot-tenova",
+    "os_name": "centos",
+    "os_type": "Linux",
+    "os_version": "6.6",
+    "platform_name": "x86_64-unknown-linux",
+    "python_version": "2.6.6 (r266:84292, Jan 22 2014, 09:42:36) ; [GCC 4.4.7 20120313 (Red Hat 4.4.7-4)]",
+    "system_gcc_path": "/sw/eb/software/GCC/4.9.2-binutils-2.25/bin/gcc",
+    "system_python_path": "/usr/bin/python",
+}]

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-2.3.1-foss-2015.05.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-2.3.1-foss-2015.05.eb
@@ -30,4 +30,3 @@ dependencies = [
 builddependencies = [('flex', '2.5.39')]
 
 moduleclass = 'cae'
-

--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.4-foss-2015.05.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.4-foss-2015.05.eb
@@ -12,4 +12,3 @@ source_urls = ['http://gforge.inria.fr/frs/download.php/file/34618/']
 sources = ['%(namelower)s_%(version)s.tar.gz']
 
 moduleclass = 'math'
-

--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.4-foss-2015.05.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.4-foss-2015.05.eb
@@ -1,4 +1,3 @@
-# Built with EasyBuild version 2.1.0 on 2015-05-21_15-36-15
 name = 'SCOTCH'
 version = '6.0.4'
 
@@ -14,27 +13,3 @@ sources = ['%(namelower)s_%(version)s.tar.gz']
 
 moduleclass = 'math'
 
-# Build statistics
-buildstats = [{
-    "easybuild-framework_version": "2.1.0",
-    "easybuild-easyblocks_version": "2.1.0",
-    "timestamp": 1432215375,
-    "build_time": 70.85,
-    "install_size": 6501533,
-    "command_line": ['--buildpath=/sw/eb/build', '--debug', '--installpath=/sw/eb', '--prefix=/sw/eb', '--repositorypath=/sw/eb/ebfiles_repo', '--robot=/sw/eb/software/EasyBuild/2.1.0/lib/python2.6/site-packages/easybuild_easyconfigs-2.1.0-py2.6.egg/easybuild/easyconfigs', '--sourcepath=/sw/eb/sources', '--try-toolchain="[\'foss\', \'2015.05\']"', 'OpenFOAM-2.3.1-intel-2015a.eb'],
-    "modules_tool": ('EnvironmentModulesC', '/usr/bin/modulecmd', '3.2.10'),
-    "core_count": 12,
-    "cpu_model": "Intel(R) Xeon(R) CPU E5-2603 v3 @ 1.60GHz",
-    "cpu_speed": 1600.0,
-    "cpu_vendor": "Intel",
-    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/sw/eb/software/GCC/4.9.2-binutils-2.25/libexec/gcc/x86_64-unknown-linux-gnu/4.9.2/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25 --with-local-prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25; Thread model: posix; gcc version 4.9.2 (GCC) ; ",
-    "glibc_version": "2.12",
-    "hostname": "boot-tenova",
-    "os_name": "centos",
-    "os_type": "Linux",
-    "os_version": "6.6",
-    "platform_name": "x86_64-unknown-linux",
-    "python_version": "2.6.6 (r266:84292, Jan 22 2014, 09:42:36) ; [GCC 4.4.7 20120313 (Red Hat 4.4.7-4)]",
-    "system_gcc_path": "/sw/eb/software/GCC/4.9.2-binutils-2.25/bin/gcc",
-    "system_python_path": "/usr/bin/python",
-}]

--- a/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.4-foss-2015.05.eb
+++ b/easybuild/easyconfigs/s/SCOTCH/SCOTCH-6.0.4-foss-2015.05.eb
@@ -1,0 +1,40 @@
+# Built with EasyBuild version 2.1.0 on 2015-05-21_15-36-15
+name = 'SCOTCH'
+version = '6.0.4'
+
+homepage = 'http://gforge.inria.fr/projects/scotch/'
+description = """Software package and libraries for sequential and parallel graph partitioning,
+static mapping, and sparse matrix block ordering, and sequential mesh and hypergraph partitioning."""
+
+toolchain = {'name': 'foss', 'version': '2015.05'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://gforge.inria.fr/frs/download.php/file/34618/']
+sources = ['%(namelower)s_%(version)s.tar.gz']
+
+moduleclass = 'math'
+
+# Build statistics
+buildstats = [{
+    "easybuild-framework_version": "2.1.0",
+    "easybuild-easyblocks_version": "2.1.0",
+    "timestamp": 1432215375,
+    "build_time": 70.85,
+    "install_size": 6501533,
+    "command_line": ['--buildpath=/sw/eb/build', '--debug', '--installpath=/sw/eb', '--prefix=/sw/eb', '--repositorypath=/sw/eb/ebfiles_repo', '--robot=/sw/eb/software/EasyBuild/2.1.0/lib/python2.6/site-packages/easybuild_easyconfigs-2.1.0-py2.6.egg/easybuild/easyconfigs', '--sourcepath=/sw/eb/sources', '--try-toolchain="[\'foss\', \'2015.05\']"', 'OpenFOAM-2.3.1-intel-2015a.eb'],
+    "modules_tool": ('EnvironmentModulesC', '/usr/bin/modulecmd', '3.2.10'),
+    "core_count": 12,
+    "cpu_model": "Intel(R) Xeon(R) CPU E5-2603 v3 @ 1.60GHz",
+    "cpu_speed": 1600.0,
+    "cpu_vendor": "Intel",
+    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/sw/eb/software/GCC/4.9.2-binutils-2.25/libexec/gcc/x86_64-unknown-linux-gnu/4.9.2/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25 --with-local-prefix=/sw/eb/software/GCC/4.9.2-binutils-2.25; Thread model: posix; gcc version 4.9.2 (GCC) ; ",
+    "glibc_version": "2.12",
+    "hostname": "boot-tenova",
+    "os_name": "centos",
+    "os_type": "Linux",
+    "os_version": "6.6",
+    "platform_name": "x86_64-unknown-linux",
+    "python_version": "2.6.6 (r266:84292, Jan 22 2014, 09:42:36) ; [GCC 4.4.7 20120313 (Red Hat 4.4.7-4)]",
+    "system_gcc_path": "/sw/eb/software/GCC/4.9.2-binutils-2.25/bin/gcc",
+    "system_python_path": "/usr/bin/python",
+}]


### PR DESCRIPTION
OpenFOAM built with foss 2015.05 needed for Centos6 on Haswell