### PR TITLE
{chem} [ictce-7.3.5] QuantumESPRESSO 5.1.2 (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.1.2-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.1.2-ictce-7.3.5.eb
@@ -1,0 +1,40 @@
+name = 'QuantumESPRESSO'
+version = '5.1.2'
+
+homepage = 'http://www.pwscf.org/'
+description = """Quantum ESPRESSO  is an integrated suite of computer codes
+for electronic-structure calculations and materials modeling at the nanoscale.
+It is based on density-functional theory, plane waves, and pseudopotentials
+(both norm-conserving and ultrasoft)."""
+
+toolchain = {'name': 'ictce', 'version': '7.3.5'}
+toolchainopts = {'usempi': True}
+
+sources = [
+    'espresso-%(version)s.tar.gz',
+    'atomic-%(version)s.tar.gz',
+    'neb-%(version)s.tar.gz',
+    'PHonon-%(version)s.tar.gz',
+    'pwcond-%(version)s.tar.gz',
+    'tddfpt-%(version)s.tar.gz',
+    'xspectra-%(version)s.tar.gz',
+    'GWW-%(version)s.tar.gz',
+]
+
+source_urls = [
+    'http://www.qe-forge.org/gf/download/frsrelease/185/753/',  # espresso-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/752/',  # atomic-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/754/',  # GWW-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/755/',  # PHonon-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/756/',  # pwcond-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/757/',  # xspectra-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/758/',  # tddfpt-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/760/',  # neb-5.1.2.tar.gz
+]
+
+buildopts = 'all plumed w90 want gipaw'
+
+# parallel build tends to fail
+parallel = 1
+
+moduleclass = 'chem'


### PR DESCRIPTION
Hi, here is the latest QuantumESPRESSO built with the latest ictce toolchain.

We have it built on our side on Debian, please tell us if there are things to change.