### PR TITLE
{lib} libreadline: Fails with missing 'UP' symbol on Debian 7

### DIFF
--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2015a.eb
@@ -17,6 +17,8 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+preconfigopts = "LDFLAGS='-ltinfo'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',


### PR DESCRIPTION
On Debian 7, software using libreadline fails with a missing symbol `UP`. This fixes that.