### PR TITLE
fix easyconfigs unit tests after making ModulesTool a non-singleton class

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -32,6 +32,7 @@ import copy
 import glob
 import os
 import re
+import shutil
 import sys
 import tempfile
 from distutils.version import LooseVersion
@@ -48,6 +49,7 @@ from easybuild.framework.easyconfig.easyconfig import get_easyblock_class
 from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconfig
 from easybuild.framework.easyconfig.tools import dep_graph, get_paths_for, process_easyconfig
 from easybuild.tools import config
+from easybuild.tools.filetools import write_file
 from easybuild.tools.module_naming_scheme import GENERAL_CLASS
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.modules import modules_tool
@@ -79,10 +81,10 @@ class EasyConfigTest(TestCase):
     config.set_tmpdir()
     del eb_go
 
-    # mock 'exist' and 'load' methods of modules tool, which are used for 'craype' external module
-    modtool = modules_tool()
-    modtool.exist = lambda m: [True]*len(m)
-    modtool.load = lambda m: True
+    # put dummy 'craype-test' module in place, which is required for parsing easyconfigs using Cray* toolchains
+    TMPDIR = tempfile.mkdtemp()
+    os.environ['MODULEPATH'] = TMPDIR
+    write_file(os.path.join(TMPDIR, 'craype-test'), '#%Module\n')
 
     log = fancylogger.getLogger("EasyConfigTest", fname=False)
 
@@ -226,6 +228,10 @@ class EasyConfigTest(TestCase):
                     # only exception: TEMPLATE.eb
                     if not (dirpath.endswith('/easybuild/easyconfigs') and filenames == ['TEMPLATE.eb']):
                         self.assertTrue(False, "List of easyconfig files in %s is empty: %s" % (dirpath, filenames))
+
+    def test_zzz_cleanup(self):
+        """Dummy test to clean up global temporary directory."""
+        shutil.rmtree(self.TMPDIR)
 
 def template_easyconfig_test(self, spec):
     """Tests for an individual easyconfig: parsing, instantiating easyblock, check patches, ..."""


### PR DESCRIPTION
cfr. https://github.com/hpcugent/easybuild-framework/pull/1299