### PR TITLE
{perf}[*] Cube update (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/c/Cube/Cube-3.4.3-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/c/Cube/Cube-3.4.3-gompi-1.4.12-no-OFED.eb
@@ -1,11 +1,15 @@
+##
 # This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
-# Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
-# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
-# License::   New BSD
 #
-# This work is based from experiences from the UNITE project
+# Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
 # http://apps.fz-juelich.de/unite/
 ##
+
 easyblock = 'ConfigureMake'
 
 name = "Cube"
@@ -20,9 +24,12 @@ description = """Cube, which is used as performance report explorer for Scalasca
 
 toolchain = {'name': 'gompi', 'version': '1.4.12-no-OFED'}
 
-# http://apps.fz-juelich.de/scalasca/releases/cube/3.4/dist/cube-3.4.3.tar.gz
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://apps.fz-juelich.de/scalasca/releases/cube/3.4/dist']
+source_urls = ['http://apps.fz-juelich.de/scalasca/releases/cube/%(version_major_minor)s/dist']
+
+checksums = [
+    '703d4681851a5abf50946868f05e8f9e',    # cube-3.4.3.tar.gz
+]
 
 dependencies = [('Qt', '4.8.4')]
 

--- a/easybuild/easyconfigs/c/Cube/Cube-4.2-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/c/Cube/Cube-4.2-gompi-1.4.12-no-OFED.eb
@@ -1,12 +1,15 @@
+##
 # This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+#
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
-# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
-# License::   New BSD
+#             Markus Geimer <m.geimer@fz-juelich.de>
+# License::   3-clause BSD
 #
-# This work is based from experiences from the UNITE project
+# This work is based on experiences from the UNITE project
 # http://apps.fz-juelich.de/unite/
 ##
+
 easyblock = 'EB_Score_minus_P'
 
 name = "Cube"
@@ -30,16 +33,22 @@ patches = [
     'Cube-4.2_fix-with-qt-check.patch',
 ]
 
+checksums = [
+    'aa1b1594bacddd3a1931f9a9dea23ce8',    # cube-4.2.tar.gz
+    'da69fe49d347dc7722c30bb785106d96',    # Cube-4.2_fix-Qt-version-check.patch
+    '5a746d4f6f4eb5eb8b464ca355b46891',    # Cube-4.2_fix-with-qt-check.patch
+]
+
 dependencies = [('Qt', '4.8.4')]
 
 # The Cube Java reader is currently only used by TAU, which ships it's own
 # copy as a jar file. If you really want to enable it, make sure to set
-# 'maxparallel=1', as automake's Java support is has difficulties handling
+# 'maxparallel=1', as automake's Java support has difficulties handling
 # parallel builds.
 configopts = "--without-java-reader"
 
 sanity_check_paths = {
-    'files': ["bin/cube", "lib/libcube4.a", "lib/libcube4.so"],
+    'files': ["bin/cube", ("lib/libcube4.a", "lib64/libcube4.a"), ("lib/libcube4.so", "lib64/libcube4.so")],
     'dirs': ["include/cube", "include/cubew"],
 }
 

--- a/easybuild/easyconfigs/c/Cube/Cube-4.2.3-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/c/Cube/Cube-4.2.3-goolf-1.5.14.eb
@@ -21,16 +21,20 @@ toolchain = {'name': 'goolf', 'version': '1.5.14'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://apps.fz-juelich.de/scalasca/releases/cube/%(version_major_minor)s/dist']
 
+checksums = [
+    '8f95b9531f5a8f8134f279c2767c9b20',    # cube-4.2.3.tar.gz
+]
+
 dependencies = [('Qt', '4.8.4')]
 
 # The Cube Java reader is currently only used by TAU, which ships it's own
 # copy as a jar file. If you really want to enable it, make sure to set
-# 'maxparallel=1', as automake's Java support is has difficulties handling
+# 'maxparallel=1', as automake's Java support has difficulties handling
 # parallel builds.
 configopts = "--without-java-reader"
 
 sanity_check_paths = {
-    'files': ["bin/cube", "lib/libcube4.a", "lib/libcube4.so"],
+    'files': ["bin/cube", ("lib/libcube4.a", "lib64/libcube4.a"), ("lib/libcube4.so", "lib64/libcube4.so")],
     'dirs': ["include/cube", "include/cubew"],
 }
 

--- a/easybuild/easyconfigs/c/Cube/Cube-4.3-foss-2015a.eb
+++ b/easybuild/easyconfigs/c/Cube/Cube-4.3-foss-2015a.eb
@@ -1,11 +1,15 @@
+##
 # This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
-# Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
-# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
-# License::   New BSD
 #
-# This work is based from experiences from the UNITE project
+# Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
 # http://apps.fz-juelich.de/unite/
 ##
+
 easyblock = 'EB_Score_minus_P'
 
 name = "Cube"
@@ -29,14 +33,15 @@ checksums = [
 
 dependencies = [('Qt', '4.8.6')]
 
+# The Cube Java reader is currently only used by TAU, which ships it's own
+# copy as a jar file. If you really want to enable it, make sure to set
+# 'maxparallel=1', as automake's Java support has difficulties handling
+# parallel builds.
+configopts = "--without-java-reader"
+
 sanity_check_paths = {
-    'files': ["bin/cube", "lib/libcube4.a", "lib/libcube4.so"],
+    'files': ["bin/cube", ("lib/libcube4.a", "lib64/libcube4.a"), ("lib/libcube4.so", "lib64/libcube4.so")],
     'dirs': ["include/cube", "include/cubew"],
 }
-
-# If all prerequisites for the Cube Java reader are available on the system,
-# parallel builds will fail. Alternatively, disable the Java reader using
-# configopts = "--without-java-reader"
-maxparallel = 1
 
 moduleclass = 'perf'

--- a/easybuild/easyconfigs/c/Cube/Cube-4.3-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/c/Cube/Cube-4.3-gompi-1.4.12-no-OFED.eb
@@ -1,12 +1,15 @@
+##
 # This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+#
 # Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
 # Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
-# Authors::   Markus Geimer <m.geimer@fz-juelich.de>
-# License::   New BSD
+#             Markus Geimer <m.geimer@fz-juelich.de>
+# License::   3-clause BSD
 #
-# This work is based from experiences from the UNITE project
+# This work is based on experiences from the UNITE project
 # http://apps.fz-juelich.de/unite/
 ##
+
 easyblock = 'EB_Score_minus_P'
 
 name = "Cube"
@@ -24,16 +27,20 @@ toolchain = {'name': 'gompi', 'version': '1.4.12-no-OFED'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://apps.fz-juelich.de/scalasca/releases/cube/%(version_major_minor)s/dist']
 
+checksums = [
+    'ed4d6f3647eefa65fc194b5d1a5f4ffe',     # cube-4.3.tar.gz
+]
+
 dependencies = [('Qt', '4.8.4')]
 
 # The Cube Java reader is currently only used by TAU, which ships it's own
 # copy as a jar file. If you really want to enable it, make sure to set
-# 'maxparallel=1', as automake's Java support is has difficulties handling
+# 'maxparallel=1', as automake's Java support has difficulties handling
 # parallel builds.
 configopts = "--without-java-reader"
 
 sanity_check_paths = {
-    'files': ["bin/cube", "lib/libcube4.a", "lib/libcube4.so"],
+    'files': ["bin/cube", ("lib/libcube4.a", "lib64/libcube4.a"), ("lib/libcube4.so", "lib64/libcube4.so")],
     'dirs': ["include/cube", "include/cubew"],
 }
 

--- a/easybuild/easyconfigs/c/Cube/Cube-4.3.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/c/Cube/Cube-4.3.2-foss-2015a.eb
@@ -1,0 +1,41 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2013-2015 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = "Cube"
+version = "4.3.2"
+
+homepage = 'http://www.scalasca.org/software/cube-4.x/download.html'
+description = """Cube, which is used as performance report explorer for Scalasca and
+ Score-P, is a generic tool for displaying a multi-dimensional performance space
+ consisting of the dimensions (i) performance metric, (ii) call path, and (iii) system
+ resource. Each dimension can be represented as a tree, where non-leaf nodes of the tree
+ can be collapsed or expanded to achieve the desired level of granularity."""
+
+toolchain = {'name': 'foss', 'version': '2015a'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://apps.fz-juelich.de/scalasca/releases/cube/%(version_major_minor)s/dist']
+
+checksums = [
+    'a9119524df5a39e7a5bf6dee4de62e30',     # cube-4.3.2.tar.gz
+]
+
+dependencies = [('Qt', '4.8.6')]
+
+sanity_check_paths = {
+    'files': ["bin/cube", ("lib/libcube4.a", "lib64/libcube4.a"), ("lib/libcube4.so", "lib64/libcube4.so")],
+    'dirs': ["include/cube", "include/cubew"],
+}
+
+moduleclass = 'perf'


### PR DESCRIPTION
 * Add easyconfig for latest Cube release which no longer includes the Java reader (now distributed as a separate package) and therefore doesn't require the `configopts` trickery anymore
 * Added checksums
 * Fixed sanity checks for Cube 4.x (lib vs. lib64)
 * Cosmetics