### PR TITLE
Add snappy support and refer Hadoop to the snappy library.

### DIFF
--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
@@ -19,11 +19,14 @@ builddependencies = [
     ('Maven', '3.2.3'),
     ('protobuf', '2.5.0'),
     ('CMake', '3.1.3'),
+    ('snappy', '1.1.2'),
 ]
 
 dependencies = [(java, javaver)]
 
 build_native_libs = True
+
+extra_native_libs = [(snappy, 'lib/libsnappy.so')]
 
 parallel = 1
 

--- a/easybuild/easyconfigs/s/snappy/snappy-1.1.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/s/snappy/snappy-1.1.2-intel-2015a.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = 'snappy'
+version = '1.1.2'
+
+homepage = 'http://code.google.com/p/snappy/'
+description = """Snappy is a compression/decompression library. It does not aim
+for maximum compression, or compatibility with any other compression library;
+instead, it aims for very high speeds and reasonable compression."""
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+
+source_urls = ['http://code.google.com/p/snappy/']
+sources = [SOURCELOWER_TAR_GZ]
+
+sanity_check_paths = {
+    'files': ['lib/libsnappy.so'],
+    'dirs': ['include', 'lib', 'share']
+}
+
+moduleclass = 'lib'
+


### PR DESCRIPTION
This depends on a forthcoming easyblock update to support 'extra_native_libs'
configuration setting in the Hadoop EasyBlock.