### PR TITLE
Add snappy support and refer Hadoop to the snappy library.

### DIFF
--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
@@ -19,7 +19,7 @@ builddependencies = [
     ('Maven', '3.2.3'),
     ('protobuf', '2.5.0'),
     ('CMake', '3.1.3'),
-    ('snappy', '1.1.2'),
+    ('snappy', '1.1.2', '-intel-2015a'),
 ]
 
 dependencies = [(java, javaver)]

--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
@@ -19,7 +19,7 @@ builddependencies = [
     ('Maven', '3.2.3'),
     ('protobuf', '2.5.0'),
     ('CMake', '3.1.3'),
-    ('snappy', '1.1.2', '-intel-2015a'),
+    ('snappy', '1.1.2', '', ('GCC', '4.9.2')),
 ]
 
 dependencies = [(java, javaver)]

--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
@@ -26,7 +26,7 @@ dependencies = [(java, javaver)]
 
 build_native_libs = True
 
-extra_native_libs = [(snappy, 'lib/libsnappy.so')]
+extra_native_libs = [('snappy', 'lib/libsnappy.so')]
 
 parallel = 1
 

--- a/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
+++ b/easybuild/easyconfigs/h/Hadoop/Hadoop-2.5.0-cdh5.3.1-native.eb
@@ -19,11 +19,14 @@ builddependencies = [
     ('Maven', '3.2.3'),
     ('protobuf', '2.5.0'),
     ('CMake', '3.1.3'),
+    ('snappy', '1.1.2'),
 ]
 
 dependencies = [(java, javaver)]
 
 build_native_libs = True
+
+extra_native_libs = [(snappy, 'lib/libsnappy.so')]
 
 parallel = 1
 

--- a/easybuild/easyconfigs/s/snappy/snappy-1.1.2-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/s/snappy/snappy-1.1.2-GCC-4.9.2.eb
@@ -13,7 +13,7 @@ description = """Snappy is a compression/decompression library. It does not aim
 for maximum compression, or compatibility with any other compression library;
 instead, it aims for very high speeds and reasonable compression."""
 
-toolchain = {'name': 'intel', 'version': '2015a'}
+toolchain = {'name': 'GCC', 'version': '4.9.2'}
 
 source_urls = ['https://github.com/google/snappy/archive']
 sources = ['%s.tar.gz' % commit]

--- a/easybuild/easyconfigs/s/snappy/snappy-1.1.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/s/snappy/snappy-1.1.2-intel-2015a.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = 'snappy'
+version = '1.1.2'
+
+homepage = 'http://code.google.com/p/snappy/'
+description = """Snappy is a compression/decompression library. It does not aim
+for maximum compression, or compatibility with any other compression library;
+instead, it aims for very high speeds and reasonable compression."""
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+
+source_urls = ['http://code.google.com/p/snappy/']
+sources = [SOURCELOWER_TAR_GZ]
+
+sanity_check_paths = {
+    'files': ['lib/libsnappy.so'],
+    'dirs': ['include', 'lib', 'share']
+}
+
+moduleclass = 'lib'
+

--- a/easybuild/easyconfigs/s/snappy/snappy-1.1.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/s/snappy/snappy-1.1.2-intel-2015a.eb
@@ -2,6 +2,10 @@ easyblock = 'ConfigureMake'
 
 name = 'snappy'
 version = '1.1.2'
+
+# snappy was migrated from code.google.com to github.com and this commit
+# corresponds to release 1.1.2 (which they haven't tagged). 
+# see https://github.com/google/snappy/commit/1ff9be9
 commit = '1ff9be9'
 
 homepage = 'http://code.google.com/p/snappy/'
@@ -13,6 +17,8 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 
 source_urls = ['https://github.com/google/snappy/archive']
 sources = ['%s.tar.gz' % commit]
+
+preconfigopts = "./autogen.sh && "
 
 sanity_check_paths = {
     'files': ['lib/libsnappy.so'],

--- a/easybuild/easyconfigs/s/snappy/snappy-1.1.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/s/snappy/snappy-1.1.2-intel-2015a.eb
@@ -15,8 +15,7 @@ sources = [SOURCELOWER_TAR_GZ]
 
 sanity_check_paths = {
     'files': ['lib/libsnappy.so'],
-    'dirs': ['include', 'lib', 'share']
+    'dirs': ['include', 'share']
 }
 
 moduleclass = 'lib'
-

--- a/easybuild/easyconfigs/s/snappy/snappy-1.1.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/s/snappy/snappy-1.1.2-intel-2015a.eb
@@ -2,6 +2,7 @@ easyblock = 'ConfigureMake'
 
 name = 'snappy'
 version = '1.1.2'
+commit = '1ff9be9'
 
 homepage = 'http://code.google.com/p/snappy/'
 description = """Snappy is a compression/decompression library. It does not aim
@@ -10,8 +11,8 @@ instead, it aims for very high speeds and reasonable compression."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
 
-source_urls = ['http://code.google.com/p/snappy/']
-sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://github.com/google/snappy/archive']
+sources = ['%s.tar.gz' % commit]
 
 sanity_check_paths = {
     'files': ['lib/libsnappy.so'],


### PR DESCRIPTION
This depends on a forthcoming easyblock update to support 'extra_native_libs'
configuration setting in the Hadoop EasyBlock.

edit (by @boegel): requires ~~https://github.com/hpcugent/easybuild-easyblocks/pull/632~~