### PR TITLE
remove exts_filter definition from Python 3.4.3 easyconfig, as it can cause problems

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.4.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.3-intel-2015a.eb
@@ -27,7 +27,6 @@ osdependencies = [('openssl-devel', 'libssl-dev')]
 
 # order is important!
 # package versions updated Jan 19th 2015
-exts_filter = ('PYTHONPATH="%(installdir)s:$PYTHONPATH python -c "import %(ext_name)s"', '')
 exts_list = [
     ('setuptools', '15.2', {
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],


### PR DESCRIPTION
cfr. https://github.com/hpcugent/easybuild-framework/issues/1313#event-347367190

It's unclear to me why this is even there, especially since this is the only Python 3.x easyconfig that has this.
@JensTimmerman: the original easyconfig is yours (see #1598), any idea why this is there?

It's not unlikely this also fixes https://github.com/hpcugent/easybuild-easyblocks/issues/609.