### PR TITLE
Minimal example easyconfig for SystemCompiler easyblock

### DIFF
--- a/easybuild/easyconfigs/g/GCC/GCC-system.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-system.eb
@@ -11,8 +11,9 @@ easyblock = 'SystemCompiler'
 name = "GCC"
 version = "system"
 
-homepage = "<will be defined by the SystemCompiler easyblock>"
-description = ""   # will be defined by the SystemCompiler easyblock when left empty or provide a custom description
+homepage = "http://gcc.gnu.org/"
+description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
+ as well as libraries for these languages (libstdc++, libgcj,...)."""
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 

--- a/easybuild/easyconfigs/g/GCC/GCC-system.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-system.eb
@@ -1,0 +1,19 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2015 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+# License::   3-clause BSD
+##
+
+easyblock = 'SystemCompiler'
+
+name = "GCC"
+version = "system"
+
+homepage = "<will be defined by the SystemCompiler easyblock>"
+description = ""   # will be defined by the SystemCompiler easyblock when left empty or provide a custom description
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+moduleclass = 'compiler'


### PR DESCRIPTION
This is an accompanying easyconfig for https://github.com/hpcugent/easybuild-easyblocks/pull/633.  It can be used to create a 'GCC/system' module wrapping a system-provided GCC compiler.