### PR TITLE
enable SSL support in most recent CMake easyconfigs

### DIFF
--- a/easybuild/easyconfigs/c/CMake/CMake-3.2.3-foss-2015a.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.2.3-foss-2015a.eb
@@ -14,9 +14,11 @@ sources = [SOURCELOWER_TAR_GZ]
 
 configopts = '-- -DCMAKE_USE_OPENSSL=1'
 
-dependencies = [('ncurses', '5.9'),
-#   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
-#   nice to have an up to date openssl for security reasons
+dependencies = [
+    ('ncurses', '5.9'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    #('OpenSSL', '1.0.1k'),
 ]
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]

--- a/easybuild/easyconfigs/c/CMake/CMake-3.2.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.2.3-intel-2015a.eb
@@ -12,6 +12,8 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
+configopts = '-- -DCMAKE_USE_OPENSSL=1'
+
 dependencies = [('ncurses', '5.9')]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/c/CMake/CMake-3.2.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.2.3-intel-2015a.eb
@@ -14,7 +14,12 @@ sources = [SOURCELOWER_TAR_GZ]
 
 configopts = '-- -DCMAKE_USE_OPENSSL=1'
 
-dependencies = [('ncurses', '5.9')]
+dependencies = [('ncurses', '5.9'),
+#   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
+#   nice to have an up to date openssl for security reasons
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]]
 
 sanity_check_paths = {
     'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],

--- a/easybuild/easyconfigs/c/CMake/CMake-3.2.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.2.3-intel-2015a.eb
@@ -19,7 +19,7 @@ dependencies = [('ncurses', '5.9'),
 #   nice to have an up to date openssl for security reasons
 ]
 
-osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
     'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],

--- a/easybuild/easyconfigs/c/CMake/CMake-3.2.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.2.3-intel-2015a.eb
@@ -14,9 +14,11 @@ sources = [SOURCELOWER_TAR_GZ]
 
 configopts = '-- -DCMAKE_USE_OPENSSL=1'
 
-dependencies = [('ncurses', '5.9'),
-#   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
-#   nice to have an up to date openssl for security reasons
+dependencies = [
+    ('ncurses', '5.9'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    #('OpenSSL', '1.0.1k'),
 ]
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]


### PR DESCRIPTION
wraps around #1751 and #1753 by @ocaisa, fixes some minor style issues