### PR TITLE
revert #1785, patch for OpenMPI is incomplete and causes segfaults

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.3-iccifort-2011.13.367.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.3-iccifort-2011.13.367.eb
@@ -20,10 +20,6 @@ dependencies = [('hwloc', '1.6')]
 # needed for --with-openib
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [
-    'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mca_common_sm", "mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal",
         "otfaux", "otf", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-ClangGCC-1.1.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-ClangGCC-1.1.3.eb
@@ -21,10 +21,6 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 # needed for --with-openib
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [ 
-    'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.6.4.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.6.4.eb
@@ -21,10 +21,6 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 # needed for --with-openib
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [ 
-    'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2-no-OFED.eb
@@ -19,10 +19,6 @@ configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in 
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 
-patches = [ 
-    'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2.eb
@@ -21,10 +21,6 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 # needed for --with-openib
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [ 
-    'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.2.eb
@@ -24,10 +24,6 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 # needed for --with-openib
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [ 
-    'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.3-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.3-no-OFED.eb
@@ -13,7 +13,6 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
 patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
       'OpenMPI-1.6.5-vt_cupti_events.patch',
 ]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1-no-OFED.eb
@@ -13,7 +13,6 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
 patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
       'OpenMPI-1.6.5-vt_cupti_events.patch',
 ]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1.eb
@@ -12,7 +12,6 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
 patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
       'OpenMPI-1.6.5-vt_cupti_events.patch',
 ]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2-no-OFED.eb
@@ -13,7 +13,6 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
 patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
       'OpenMPI-1.6.5-vt_cupti_events.patch',
 ]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2.eb
@@ -12,7 +12,6 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
 patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
       'OpenMPI-1.6.5-vt_cupti_events.patch',
 ]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.3.eb
@@ -12,7 +12,6 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
 patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
       'OpenMPI-1.6.5-vt_cupti_events.patch',
 ]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.2.144.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.2.144.eb
@@ -20,10 +20,6 @@ dependencies = [('hwloc', '1.8.1')]
 # needed for --with-openib
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211-no-OFED.eb
@@ -18,10 +18,6 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 
 dependencies = [('hwloc', '1.9')]
 
-patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211.eb
@@ -20,10 +20,6 @@ dependencies = [('hwloc', '1.9')]
 # needed for --with-openib
 osdependencies = [('libibverbs-dev','libibverbs-devel')]
 
-patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_f77", "mpi_f90", "mpi", "ompitrace", "open-pal", "open-rte",
         "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-GCC-4.8.2.eb
@@ -23,10 +23,6 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {
     'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-gcccuda-2.6.10.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-gcccuda-2.6.10.eb
@@ -12,7 +12,6 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
 patches = [ 
-    'openmpi-mca-params.conf-pre-1.8.6.patch',
     'OpenMPI-%(version)s_common-cuda-lib.patch',
     'OpenMPI-%(version)s-vt_cupti_events.patch',
 ]

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.1-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.1-GCC-4.8.3.eb
@@ -21,10 +21,6 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {
     'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-GCC-4.9.2.eb
@@ -21,10 +21,6 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {
     'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211-no-OFED.eb
@@ -20,10 +20,6 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 
 dependencies = [('hwloc', '1.9')]
 
-patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {
     'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211.eb
@@ -11,7 +11,6 @@ toolchain = {'name': 'iccifort', 'version': '2013_sp1.4.211'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
-
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
@@ -21,10 +20,6 @@ dependencies = [('hwloc', '1.9')]
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
-
-patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.8.4.eb
@@ -21,10 +21,6 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {
     'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.9.2.eb
@@ -21,10 +21,6 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {
     'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.1.133-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.1.133-GCC-4.9.2.eb
@@ -22,10 +22,6 @@ dependencies = [('hwloc', '1.10.0')]
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {
     'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.2.164-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.2.164-GCC-4.9.2.eb
@@ -23,10 +23,6 @@ dependencies = [('hwloc', '1.10.0')]
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {
     'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.5-GNU-4.9.2-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.5-GNU-4.9.2-2.25.eb
@@ -21,10 +21,6 @@ configopts += '--disable-dlopen '  # statically link component, don't do dynamic
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-patches = [ 
-      'openmpi-mca-params.conf-pre-1.8.6.patch',
-]
-
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {
     'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +

--- a/easybuild/easyconfigs/o/OpenMPI/openmpi-mca-params.conf-pre-1.8.6.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/openmpi-mca-params.conf-pre-1.8.6.patch
@@ -1,9 +1,0 @@
---- opal/etc/openmpi-mca-params.conf.orig 2015-06-05 16:21:25.535727000 +0200
-+++ opal/etc/openmpi-mca-params.conf  2015-06-08 10:36:05.387902000 +0200
-@@ -56,3 +56,6 @@
- 
- # See "ompi_info --param all all" for a full listing of Open MPI MCA
- # parameters available and their default values.
-+
-+# Fix bug in the initialization of the value when using the infiniband module. (ref: http://www.open-mpi.org/community/lists/users/2015/05/26913.php)
-+btl_openib_memalign_threshold=12288


### PR DESCRIPTION
The OpenMPI patch included in #1785 is incomplete, and causes segfaults.

See discussion in #1797 and https://github.com/open-mpi/ompi/issues/638.

It's possible that the patch can be enhanced to make it work, but that will be for an EasyBuild version later than v2.2.0

cc @ULHPC, @sylmarien, @besserox