### PR TITLE
add patch for OpenMPI 1.7.x and 1.8.x to fix memalign issue (WIP)

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-GCC-4.8.2.eb
@@ -11,7 +11,10 @@ toolchain = {'name': 'GCC', 'version': '4.8.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
-patches = ['OpenMPI-%(version)s-vt_cupti_events.patch']
+patches = [
+    'OpenMPI-%(version)s-vt_cupti_events.patch',
+    'OpenMPI-1.7_memalign_threshold.patch',
+]
 
 dependencies = [('hwloc', '1.7.2')]
 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-gcccuda-2.6.10.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7.3-gcccuda-2.6.10.eb
@@ -14,6 +14,7 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/d
 patches = [ 
     'OpenMPI-%(version)s_common-cuda-lib.patch',
     'OpenMPI-%(version)s-vt_cupti_events.patch',
+    'OpenMPI-1.7_memalign_threshold.patch',
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7_memalign_threshold.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7_memalign_threshold.patch
@@ -1,0 +1,35 @@
+diff -ru openmpi-1.7.3.orig/ompi/mca/btl/openib/btl_openib_component.c openmpi-1.7.3/ompi/mca/btl/openib/btl_openib_component.c
+--- openmpi-1.7.3.orig/ompi/mca/btl/openib/btl_openib_component.c	2013-09-26 20:23:06.000000000 +0200
++++ openmpi-1.7.3/ompi/mca/btl/openib/btl_openib_component.c	2015-07-15 08:42:50.000000000 +0200
+@@ -2477,7 +2477,9 @@
+        we're most likely going to be using this component). The hook is to be set up
+        as early as possible in this function since we want most of the allocated resources
+        be aligned.*/
+-    if (mca_btl_openib_component.use_memalign > 0) {
++    if (mca_btl_openib_component.use_memalign > 0 &&
++        (opal_mem_hooks_support_level() &
++            (OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_CHUNK_SUPPORT)) != 0) {
+         mca_btl_openib_component.previous_malloc_hook = __malloc_hook;
+         __malloc_hook = btl_openib_malloc_hook; 
+         malloc_hook_set = true;
+diff -ru openmpi-1.7.3.orig/ompi/mca/btl/openib/btl_openib_mca.c openmpi-1.7.3/ompi/mca/btl/openib/btl_openib_mca.c
+--- openmpi-1.7.3.orig/ompi/mca/btl/openib/btl_openib_mca.c	2013-09-26 20:23:06.000000000 +0200
++++ openmpi-1.7.3/ompi/mca/btl/openib/btl_openib_mca.c	2015-07-15 08:42:05.000000000 +0200
+@@ -631,7 +631,7 @@
+                   32, &mca_btl_openib_component.use_memalign,
+                   REGINT_GE_ZERO));
+ 
+-    mca_btl_openib_component.memalign_threshold = mca_btl_openib_component.eager_limit;
++    mca_btl_openib_component.memalign_threshold = mca_btl_openib_module.super.btl_eager_limit;
+     tmp = mca_base_component_var_register(&mca_btl_openib_component.super.btl_version,
+                                           "memalign_threshold",
+                                           "Allocating memory more than btl_openib_memalign_threshhold"
+--- opal/etc/openmpi-mca-params.conf.orig 2015-06-05 16:21:25.535727000 +0200
++++ opal/etc/openmpi-mca-params.conf  2015-06-08 10:36:05.387902000 +0200
+@@ -56,3 +56,6 @@
+ 
+ # See "ompi_info --param all all" for a full listing of Open MPI MCA
+ # parameters available and their default values.
++
++# Fix bug in the initialization of the value when using the infiniband module. (ref: http://www.open-mpi.org/community/lists/users/2015/05/26913.php)
++btl_openib_memalign_threshold=12288

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7_memalign_threshold.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.7_memalign_threshold.patch
@@ -1,3 +1,5 @@
+backfort of fix for default value of btl_openib_memalign_threshold, see https://github.com/open-mpi/ompi/issues/638
+author: Kenneth Hoste
 diff -ru openmpi-1.7.3.orig/ompi/mca/btl/openib/btl_openib_component.c openmpi-1.7.3/ompi/mca/btl/openib/btl_openib_component.c
 --- openmpi-1.7.3.orig/ompi/mca/btl/openib/btl_openib_component.c	2013-09-26 20:23:06.000000000 +0200
 +++ openmpi-1.7.3/ompi/mca/btl/openib/btl_openib_component.c	2015-07-15 08:42:50.000000000 +0200
@@ -24,8 +26,8 @@ diff -ru openmpi-1.7.3.orig/ompi/mca/btl/openib/btl_openib_mca.c openmpi-1.7.3/o
      tmp = mca_base_component_var_register(&mca_btl_openib_component.super.btl_version,
                                            "memalign_threshold",
                                            "Allocating memory more than btl_openib_memalign_threshhold"
---- opal/etc/openmpi-mca-params.conf.orig 2015-06-05 16:21:25.535727000 +0200
-+++ opal/etc/openmpi-mca-params.conf  2015-06-08 10:36:05.387902000 +0200
+--- openmpi-1.7.3.orig/opal/etc/openmpi-mca-params.conf.orig 2015-06-05 16:21:25.535727000 +0200
++++ openmpi-1.7.3/opal/etc/openmpi-mca-params.conf  2015-06-08 10:36:05.387902000 +0200
 @@ -56,3 +56,6 @@
  
  # See "ompi_info --param all all" for a full listing of Open MPI MCA

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.1-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.1-GCC-4.8.3.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'GCC', 'version': '4.8.3'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.7_memalign_threshold.patch']
+
 dependencies = [('hwloc', '1.9')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-GCC-4.9.2.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'GCC', 'version': '4.9.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.7_memalign_threshold.patch']
+
 dependencies = [('hwloc', '1.10.0')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211-no-OFED.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'iccifort', 'version': '2013_sp1.4.211'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.7_memalign_threshold.patch']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --without-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.3-iccifort-2013_sp1.4.211.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'iccifort', 'version': '2013_sp1.4.211'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.7_memalign_threshold.patch']
+
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.8.4.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'GCC', 'version': '4.8.4'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.7_memalign_threshold.patch']
+
 dependencies = [('hwloc', '1.10.1')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-GCC-4.9.2.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'GCC', 'version': '4.9.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.7_memalign_threshold.patch']
+
 dependencies = [('hwloc', '1.10.0')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.1.133-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.1.133-GCC-4.9.2.eb
@@ -11,6 +11,7 @@ toolchain = {'name': 'iccifort', 'version': '2015.1.133-GCC-4.9.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.7_memalign_threshold.patch']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.2.164-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.4-iccifort-2015.2.164-GCC-4.9.2.eb
@@ -11,6 +11,7 @@ toolchain = {'name': 'iccifort', 'version': '2015.2.164-GCC-4.9.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.7_memalign_threshold.patch']
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.5-GNU-4.9.2-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.5-GNU-4.9.2-2.25.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'GNU', 'version': '4.9.2-2.25'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.7_memalign_threshold.patch']
+
 dependencies = [('hwloc', '1.10.1')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '


### PR DESCRIPTION
fixed version of #1785 for OpenMPI 1.7.x and 1.8.x, cfr. #1797 

@besserox: please review?