### PR TITLE
add patch for OpenMPI 1.6.x to fix memalign issue (WIP)

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.3-iccifort-2011.13.367.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.3-iccifort-2011.13.367.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'iccifort', 'version': '2011.13.367'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.6_memalign_threshold.patch']
+
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-ClangGCC-1.1.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-ClangGCC-1.1.3.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'ClangGCC', 'version': '1.1.3'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.6_memalign_threshold.patch']
+
 dependencies = [('hwloc', '1.6.2')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.6.4.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.6.4.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'GCC', 'version': '4.6.4'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.6_memalign_threshold.patch']
+
 dependencies = [('hwloc', '1.6.2')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2-no-OFED.eb
@@ -12,6 +12,8 @@ toolchain = {'name': 'GCC', 'version': '4.7.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.6_memalign_threshold.patch']
+
 dependencies = [('hwloc', '1.6.2')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --without-openib ' 

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.4-GCC-4.7.2.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'GCC', 'version': '4.7.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.6_memalign_threshold.patch']
+
 dependencies = [('hwloc', '1.6.2')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.2.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'GCC', 'version': '4.7.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.6_memalign_threshold.patch']
+
 dependencies = [
     ('hwloc', '1.6.2'),
     ('libpciaccess', '0.13.1'),

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.3-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.7.3-no-OFED.eb
@@ -13,7 +13,8 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
 patches = [ 
-      'OpenMPI-1.6.5-vt_cupti_events.patch',
+    'OpenMPI-1.6.5-vt_cupti_events.patch',
+    'OpenMPI-1.6_memalign_threshold.patch',
 ]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --without-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1-no-OFED.eb
@@ -13,7 +13,8 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
 patches = [ 
-      'OpenMPI-1.6.5-vt_cupti_events.patch',
+    'OpenMPI-1.6.5-vt_cupti_events.patch',
+    'OpenMPI-1.6_memalign_threshold.patch',
 ]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --without-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.1.eb
@@ -12,7 +12,8 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
 patches = [ 
-      'OpenMPI-1.6.5-vt_cupti_events.patch',
+    'OpenMPI-1.6.5-vt_cupti_events.patch',
+    'OpenMPI-1.6_memalign_threshold.patch',
 ]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2-no-OFED.eb
@@ -13,7 +13,8 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
 patches = [ 
-      'OpenMPI-1.6.5-vt_cupti_events.patch',
+    'OpenMPI-1.6.5-vt_cupti_events.patch',
+    'OpenMPI-1.6_memalign_threshold.patch',
 ]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --without-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.2.eb
@@ -12,7 +12,8 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
 patches = [ 
-      'OpenMPI-1.6.5-vt_cupti_events.patch',
+    'OpenMPI-1.6.5-vt_cupti_events.patch',
+    'OpenMPI-1.6_memalign_threshold.patch',
 ]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-GCC-4.8.3.eb
@@ -12,7 +12,8 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
 patches = [ 
-      'OpenMPI-1.6.5-vt_cupti_events.patch',
+    'OpenMPI-1.6.5-vt_cupti_events.patch',
+    'OpenMPI-1.6_memalign_threshold.patch',
 ]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.2.144.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.2.144.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'iccifort', 'version': '2013_sp1.2.144'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.6_memalign_threshold.patch']
+
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211-no-OFED.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211-no-OFED.eb
@@ -12,6 +12,8 @@ toolchain = {'name': 'iccifort', 'version': '2013_sp1.4.211'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.6_memalign_threshold.patch']
+
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --without-openib '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6.5-iccifort-2013_sp1.4.211.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'iccifort', 'version': '2013_sp1.4.211'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
+patches = ['OpenMPI-1.6_memalign_threshold.patch']
+
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-openib '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6_memalign_threshold.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6_memalign_threshold.patch
@@ -1,0 +1,43 @@
+diff -ru openmpi-1.6.3.orig/ompi/mca/btl/openib/btl_openib_component.c openmpi-1.6.3/ompi/mca/btl/openib/btl_openib_component.c
+--- openmpi-1.6.3.orig/ompi/mca/btl/openib/btl_openib_component.c	2012-07-27 13:41:24.000000000 +0200
++++ openmpi-1.6.3/ompi/mca/btl/openib/btl_openib_component.c	2015-07-15 08:37:09.000000000 +0200
+@@ -2495,7 +2495,9 @@
+        we're most likely going to be using this component). The hook is to be set up 
+        as early as possible in this function since we want most of the allocated resources 
+        be aligned.*/ 
+-    if (mca_btl_openib_component.use_memalign > 0) { 
++    if (mca_btl_openib_component.use_memalign > 0 &&
++        (opal_mem_hooks_support_level() &
++            (OPAL_MEMORY_FREE_SUPPORT | OPAL_MEMORY_CHUNK_SUPPORT)) != 0) { 
+         mca_btl_openib_component.previous_malloc_hook = __malloc_hook; 
+         __malloc_hook = btl_openib_malloc_hook;  
+         malloc_hook_set = true; 
+diff -ru openmpi-1.6.3.orig/ompi/mca/btl/openib/btl_openib_mca.c openmpi-1.6.3/ompi/mca/btl/openib/btl_openib_mca.c
+--- openmpi-1.6.3.orig/ompi/mca/btl/openib/btl_openib_mca.c	2012-09-07 17:48:03.000000000 +0200
++++ openmpi-1.6.3/ompi/mca/btl/openib/btl_openib_mca.c	2015-07-15 08:35:17.000000000 +0200
+@@ -636,14 +636,14 @@
+             "Allocating memory more than btl_openib_memalign_threshhold"
+             "bytes will automatically be algined to the value of btl_openib_memalign bytes."
+             "memalign_threshhold defaults to the same value as mca_btl_openib_eager_limit.",
+-            mca_btl_openib_component.eager_limit,
++            mca_btl_openib_module.super.btl_eager_limit,
+             &ival,
+             REGINT_GE_ZERO);
+     if (ival < 0){
+         orte_show_help("help-mpi-btl-openib.txt", "invalid mca param value",
+                        true, "btl_openib_memalign_threshold must be positive",
+                        "btl_openib_memalign_threshold is reset to btl_openib_eager_limit");
+-        ival = mca_btl_openib_component.eager_limit;
++        ival = mca_btl_openib_module.super.btl_eager_limit;
+     }
+     mca_btl_openib_component.memalign_threshold = (size_t)ival;
+ #endif
+--- opal/etc/openmpi-mca-params.conf.orig 2015-06-05 16:21:25.535727000 +0200
++++ opal/etc/openmpi-mca-params.conf  2015-06-08 10:36:05.387902000 +0200
+@@ -56,3 +56,6 @@
+ 
+ # See "ompi_info --param all all" for a full listing of Open MPI MCA
+ # parameters available and their default values.
++
++# Fix bug in the initialization of the value when using the infiniband module. (ref: http://www.open-mpi.org/community/lists/users/2015/05/26913.php)
++btl_openib_memalign_threshold=12288

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6_memalign_threshold.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.6_memalign_threshold.patch
@@ -1,3 +1,5 @@
+backfort of fix for default value of btl_openib_memalign_threshold, see https://github.com/open-mpi/ompi/issues/638
+author: Kenneth Hoste
 diff -ru openmpi-1.6.3.orig/ompi/mca/btl/openib/btl_openib_component.c openmpi-1.6.3/ompi/mca/btl/openib/btl_openib_component.c
 --- openmpi-1.6.3.orig/ompi/mca/btl/openib/btl_openib_component.c	2012-07-27 13:41:24.000000000 +0200
 +++ openmpi-1.6.3/ompi/mca/btl/openib/btl_openib_component.c	2015-07-15 08:37:09.000000000 +0200
@@ -32,8 +34,8 @@ diff -ru openmpi-1.6.3.orig/ompi/mca/btl/openib/btl_openib_mca.c openmpi-1.6.3/o
      }
      mca_btl_openib_component.memalign_threshold = (size_t)ival;
  #endif
---- opal/etc/openmpi-mca-params.conf.orig 2015-06-05 16:21:25.535727000 +0200
-+++ opal/etc/openmpi-mca-params.conf  2015-06-08 10:36:05.387902000 +0200
+--- openmpi-1.6.3.orig/opal/etc/openmpi-mca-params.conf.orig 2015-06-05 16:21:25.535727000 +0200
++++ openmpi-1.6.3/opal/etc/openmpi-mca-params.conf  2015-06-08 10:36:05.387902000 +0200
 @@ -56,3 +56,6 @@
  
  # See "ompi_info --param all all" for a full listing of Open MPI MCA


### PR DESCRIPTION
fixed version of #1785 for OpenMPI 1.6.x, cfr. #1797 

@besserox: please review?