### PR TITLE
{data} [intel-2015a] fixes for mpi enabled h5py (review)

### DIFF
--- a/easybuild/easyconfigs/h/h5py/h5py-2.5.0-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.5.0-intel-2015a-Python-2.7.9.eb
@@ -19,6 +19,9 @@ pyver = '2.7.9'
 pyshortver = '.'.join(pyver.split('.')[0:2])
 versionsuffix = '-%s-%s' % (python, pyver)
 
+# to really use mpi enabled hdf5 we now seem to need a configure step
+prebuildopts = ' python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
+
 dependencies = [
     (python, pyver),
     ('HDF5', '1.8.14'),


### PR DESCRIPTION
this seems to have changed from 2.2 to 2.5

```
== 2015-08-05 10:21:15,214 main.run DEBUG cmd " python setup.py build  --mpi --hdf5=$EBROOTHDF5 " exited with exitcode 1 and output:
zip_safe flag not set; analyzing archive contents...

Installed /dev/shm/h5py/2.5.0/intel-2015a-Python-2.7.9-gpfs/h5py-2.5.0/.eggs/pkgconfig-1.1.0-py2.7.egg
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: option --mpi not recognized
```