### PR TITLE
put dummy template values in place to make comparison with dumped easyconfig more robust

### DIFF
--- a/easybuild/easyconfigs/f/FastTree/FastTree-2.1.7-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/FastTree/FastTree-2.1.7-goolf-1.4.10.eb
@@ -16,7 +16,7 @@ sources = ['%(name)s-%(version)s.c']
 
 skipsteps = ['source']
 
-cmds_map = [('FastTree.*.c', '$CC -DOPENMP $CFLAGS $LIBS %(source)s -o FastTree')]
+cmds_map = [('FastTree.*.c', '$CC -DOPENMP $CFLAGS $LIBS %(source)s -o %(name)s')]
 
 files_to_copy = [(['FastTree'], 'bin')]
 

--- a/easybuild/easyconfigs/f/FastTree/FastTree-2.1.7-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/f/FastTree/FastTree-2.1.7-ictce-5.5.0.eb
@@ -16,7 +16,7 @@ sources = ['%(name)s-%(version)s.c']
 
 skipsteps = ['source']
 
-cmds_map = [('FastTree.*.c', '$CC -DOPENMP $CFLAGS $LIBS %(source)s -o FastTree')]
+cmds_map = [('FastTree.*.c', '$CC -DOPENMP $CFLAGS $LIBS %(source)s -o %(name)s')]
 
 files_to_copy = [(['FastTree'], 'bin')]
 

--- a/easybuild/easyconfigs/f/fastqz/fastqz-1.5-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/f/fastqz/fastqz-1.5-GCC-4.8.2.eb
@@ -30,7 +30,7 @@ dependencies = [('ZPAQ', '7.00')]
 skipsteps = ['source']
 
 cmds_map = [
-    ('fastqz%s.cpp' % minver, '$CXX $CFLAGS -lpthread %(source)s $EBROOTZPAQ/include/libzpaq.cpp -o fastqz'),
+    ('fastqz%s.cpp' % minver, '$CXX $CFLAGS -lpthread %(source)s $EBROOTZPAQ/include/libzpaq.cpp -o %(name)s'),
     ('fapack.cpp', '$CXX $CFLAGS -s %(source)s -o %(target)s')
 ]
 

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -311,6 +311,14 @@ def template_easyconfig_test(self, spec):
     dumped_ec = EasyConfig(test_ecfile)
     os.remove(test_ecfile)
 
+    # inject dummy values for templates that are only known at a later stage
+    dummy_template_values = {
+        'builddir': '/dummy/builddir',
+        'installdir': '/dummy/installdir',
+    }
+    ec.template_values.update(dummy_template_values)
+    dumped_ec.template_values.update(dummy_template_values)
+
     for key in sorted(ec._config):
         self.assertEqual(ec[key], dumped_ec[key])
 


### PR DESCRIPTION
This is required once https://github.com/hpcugent/easybuild-framework/pull/1345 is merged to make the dump aspect of the easyconfig unit tests pass, unless more easyconfigs are tweaked to use templates like `%(name)s` and/or `%(namelower)s`.

For easyconfigs using the `CmdCp` easyblock, it's a bit more tricky since there additional templates (`%(source)s` and `%(target)s`) are supported by the `CmdCp` easyblock itself, which get in the way when trying to resolve templates (since they're not defined (yet) after just parsing the easyconfig).

That's not too big of an issue, it just means that the unit tests are a bit strict w.r.t. template values for these easyconfigs, and may require that templates like `%(name)s` is used (where applicable) in strings where `%(source)s` and/or `%(target)s` are used as well.

A couple of easyconfigs using `CmdCp` are tweaked to deal with this.