### PR TITLE
Update IRanges to 2.2.7 for Bioconductor bundle

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.1-goolf-1.7.20-R-3.2.0.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.1-goolf-1.7.20-R-3.2.0.eb
@@ -43,7 +43,7 @@ exts_list = [
     ('BiocGenerics', '0.14.0', bioconductor_options),
     ('Biobase', '2.28.0', bioconductor_options),
     ('S4Vectors', '0.6.3', bioconductor_options),
-    ('IRanges', '2.2.5', bioconductor_options),
+    ('IRanges', '2.2.7', bioconductor_options),
     ('GenomeInfoDb', '1.4.1', bioconductor_options),
     ('AnnotationDbi', '1.30.1', bioconductor_options),
     ('XVector', '0.8.0', bioconductor_options),

--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.1-intel-2015a-R-3.2.1.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.1-intel-2015a-R-3.2.1.eb
@@ -43,7 +43,7 @@ exts_list = [
     ('BiocGenerics', '0.14.0', bioconductor_options),
     ('Biobase', '2.28.0', bioconductor_options),
     ('S4Vectors', '0.6.3', bioconductor_options),
-    ('IRanges', '2.2.5', bioconductor_options),
+    ('IRanges', '2.2.7', bioconductor_options),
     ('GenomeInfoDb', '1.4.1', bioconductor_options),
     ('AnnotationDbi', '1.30.1', bioconductor_options),
     ('XVector', '0.8.0', bioconductor_options),


### PR DESCRIPTION
This updates the golf and intel Bioconductor bundles to the latest release of IRanges. (I mistakenly named the branch ivectors - please ignore that).

Fixing this manually on my test instance worked. 