### PR TITLE
stop using 'unresolved_deps' in easyconfigs unit tests

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -109,9 +109,6 @@ class EasyConfigTest(TestCase):
             for dep in ec['dependencies'][:]:
                 if dep.get('external_module', False):
                     ec['dependencies'].remove(dep)
-            for dep in ec['unresolved_deps'][:]:
-                if dep.get('external_module', False):
-                    ec['unresolved_deps'].remove(dep)
 
         self.ordered_specs = resolve_dependencies(self.parsed_easyconfigs, retain_all_deps=True)
 
@@ -152,7 +149,7 @@ class EasyConfigTest(TestCase):
         depmap = {}
         for spec in self.ordered_specs:
             build_deps = map(mk_dep_mod_name, spec['builddependencies'])
-            deps = map(mk_dep_mod_name, spec['unresolved_deps'])
+            deps = map(mk_dep_mod_name, spec['dependencies'])
             # separate runtime deps from build deps
             runtime_deps = [d for d in deps if d not in build_deps]
             key = tuple(spec['full_mod_name'].split(os.path.sep))


### PR DESCRIPTION
required because of https://github.com/hpcugent/easybuild-framework/pull/1356