### PR TITLE
{chem}[intel/2015a] PSI 4.0b5 w/ higher max. angular momentum + Python 2.7.10, Boost 1.59.0 (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/p/PSI/PSI-4.0b5-intel-2015a-mt-maxam7-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/p/PSI/PSI-4.0b5-intel-2015a-mt-maxam7-Python-2.7.10.eb
@@ -1,7 +1,7 @@
 name = 'PSI'
 version = '4.0b5'
 # 'maxam8': maximum angular momentum increased to 8 via LIBINT_NEW_AM
-versionsuffix = '-mt-maxam8'
+versionsuffix = '-mt-maxam7'
 
 homepage = 'http://www.psicode.org/'
 description = """PSI4 is an open-source suite of ab initio quantum chemistry programs designed for
@@ -32,7 +32,7 @@ dependencies = [
     ('Boost', '1.59.0', pysuff),
 ]
 
-# increase maximum angular momentum to 8 (specified value has to be double of the intended max!)
-configopts = '-DLIBINT_NEW_AM=16'
+# increase maximum angular momentum to 7 (specified value has to be double of the intended max!)
+configopts = '-DLIBINT_OPT_AM=7'
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/p/PSI/PSI-4.0b5-intel-2015a-mt-maxam7-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/p/PSI/PSI-4.0b5-intel-2015a-mt-maxam7-Python-2.7.10.eb
@@ -32,7 +32,7 @@ dependencies = [
     ('Boost', '1.59.0', pysuff),
 ]
 
-# increase maximum angular momentum to 7 (specified value has to be double of the intended max!)
-configopts = '-DLIBINT_OPT_AM=7'
+# increase maximum angular momentum to 7
+configopts = '--with-max-am-eri 7'
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/p/PSI/PSI-4.0b5-intel-2015a-mt-maxam7-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/p/PSI/PSI-4.0b5-intel-2015a-mt-maxam7-Python-2.7.10.eb
@@ -33,6 +33,6 @@ dependencies = [
 ]
 
 # increase maximum angular momentum to 7
-configopts = '--with-max-am-eri 7'
+configopts = '--with-max-am-eri=7'
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/p/PSI/PSI-4.0b5-intel-2015a-mt-maxam7-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/p/PSI/PSI-4.0b5-intel-2015a-mt-maxam7-Python-2.7.10.eb
@@ -1,6 +1,6 @@
 name = 'PSI'
 version = '4.0b5'
-# 'maxam8': maximum angular momentum increased to 8 via LIBINT_NEW_AM
+# 'maxam7': maximum angular momentum increased to 7 via LIBINT_OPT_AM
 versionsuffix = '-mt-maxam7'
 
 homepage = 'http://www.psicode.org/'

--- a/easybuild/easyconfigs/p/PSI/PSI-4.0b5-intel-2015a-mt-maxam8-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/p/PSI/PSI-4.0b5-intel-2015a-mt-maxam8-Python-2.7.10.eb
@@ -1,0 +1,38 @@
+name = 'PSI'
+version = '4.0b5'
+# 'maxam8': maximum angular momentum increased to 8 via LIBINT_NEW_AM
+versionsuffix = '-mt-maxam8'
+
+homepage = 'http://www.psicode.org/'
+description = """PSI4 is an open-source suite of ab initio quantum chemistry programs designed for
+ efficient, high-accuracy simulations of a variety of molecular properties. We can routinely perform
+ computations with more than 2500 basis functions running serially or in parallel."""
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+# not using MPI results in a build relying on multithreaded BLAS solely
+toolchainopts = {'usempi': False}
+
+source_urls = ['http://download.sourceforge.net/psicode/']
+sources = ['%(namelower)s%(version)s.tar.gz']
+
+patches = [
+    'PSI-4.0b5-failed-test.patch',  # the test works but it segfaults on exit
+    'PSI-4.0b5-thread-pool.patch',
+    'PSI-4.0b5-new-plugin.patch',
+    'PSI-%(version)s_python-config.patch',  # workaround for broken python-config due to full path to bin/python being used
+]
+
+python = 'Python'
+pyver = '2.7.10'
+pysuff = '-%s-%s' % (python, pyver)
+versionsuffix += pysuff
+
+dependencies = [
+    (python, pyver),
+    ('Boost', '1.59.0', pysuff),
+]
+
+# increase maximum angular momentum to 8 (specified value has to be double of the intended max!)
+configopts = '-DLIBINT_NEW_AM=16'
+
+moduleclass = 'chem'


### PR DESCRIPTION
requires #1854