### PR TITLE
add GMP as missing dep in Python 2.7.10 easyconfigs (required for pycrypto extension)

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015a.eb
@@ -22,6 +22,7 @@ dependencies = [
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
     ('Tk', '8.6.4', '-no-X11'),
+    ('GMP', '6.0.0a', '', ('GCC', '4.9.2')),  # required for pycrypto
 #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
 #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015a.eb
@@ -22,6 +22,7 @@ dependencies = [
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
     ('Tk', '8.6.4', '-no-X11'),
+    ('GMP', '6.0.0a', '', ('GCC', '4.9.2')),  # required for pycrypto
 #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
 #   nice to have an up to date openssl for security reasons
 ]


### PR DESCRIPTION
I'm not very happy with including GMP as a dep to Python itself, since it's only required for the `pycrypto` extension being installed, but it seems like the path of least resistance...

cc @wpoely86 (see https://github.com/hpcugent/easybuild-easyconfigs/pull/1854#issuecomment-131034861)