### PR TITLE
New version of MuTect to use Java 1.7.0_80

### DIFF
--- a/easybuild/easyconfigs/m/MuTect/MuTect-1.1.4-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/m/MuTect/MuTect-1.1.4-Java-1.7.0_80.eb
@@ -1,0 +1,36 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics
+# Biozentrum - University of Basel
+
+easyblock = 'Tarball'
+
+name = 'MuTect'
+version = '1.1.4'
+
+homepage = 'http://www.broadinstitute.org/cancer/cga/mutect'
+description = """ MuTect is a method developed at the Broad Institute for the reliable
+ and accurate identification of somatic point mutations in next generation sequencing
+ data of cancer genomes. """
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = ['http://www.broadinstitute.org/cancer/cga/sites/default/files/data/tools/mutect/']
+sources = ['muTect-%(version)s-bin.zip']
+
+java = 'Java'
+javaver = '1.7.0_80'
+versionsuffix = '-%s-%s' % (java, javaver)
+
+dependencies = [(java, javaver)]
+
+sanity_check_paths = {
+    'files': ["muTect-%(version)s.jar"],
+    'dirs': [],
+}
+
+modloadmsg = """
+to execute: java -jar \\$EBROOTMUTECT/muTect-%(version)s.jar
+"""
+
+moduleclass = 'bio'


### PR DESCRIPTION
Allow installation of MuTect with the current release of Java 1.7.