### PR TITLE
fix conflict detection in unit tests

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -149,7 +149,7 @@ class EasyConfigTest(TestCase):
         depmap = {}
         for spec in self.ordered_specs:
             build_deps = map(mk_dep_mod_name, spec['builddependencies'])
-            deps = map(mk_dep_mod_name, spec['dependencies'])
+            deps = map(mk_dep_mod_name, spec['ec'].all_dependencies)
             # separate runtime deps from build deps
             runtime_deps = [d for d in deps if d not in build_deps]
             key = tuple(spec['full_mod_name'].split(os.path.sep))


### PR DESCRIPTION
Conflict detection is currently broken, see for example #1862 and #1780.

This is caused by the change made in #1853, apparently the value for `spec['dependencies']` doesn't include everything after all...

Related: https://github.com/hpcugent/easybuild-framework/pull/1359

note: this requires https://github.com/hpcugent/easybuild-framework/pull/1360