### PR TITLE
Rollback extending list of Python extensions to resolve IPython deps

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015a.eb
@@ -120,22 +120,22 @@ exts_list = [
     ('MarkupSafe', '0.23', {
         'source_urls': ['https://pypi.python.org/packages/source/M/MarkupSafe'],
     }),
-    ('Jinja2', '2.8', {
+    ('Jinja2', '2.7.3', {
         'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2'],
     }),
-    ('jsonpointer', '1.9', {
+    ('jsonpointer', '1.7', {
         'source_urls': ['https://pypi.python.org/packages/source/j/jsonpointer'],
     }),
-    ('jsonschema', '2.5.1', {
+    ('jsonschema', '2.4.0', {
         'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema'],
     }),
-    ('functools32', '3.2.3-2', {
+    ('functools32', '3.2.3-1', {
         'source_urls': ['https://pypi.python.org/packages/source/f/functools32'],
     }),
-    ('mistune', '0.7', {
+    ('mistune', '0.5.1', {
         'source_urls': ['https://pypi.python.org/packages/source/m/mistune'],
     }),
-    ('tornado', '4.2.1', {
+    ('tornado', '4.1', {
         'source_urls': ['https://pypi.python.org/packages/source/t/tornado'],
     }),
     ('Pygments', '2.0.2', {

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015a.eb
@@ -117,30 +117,6 @@ exts_list = [
     ('pandas', '0.16.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
     }),
-    ('MarkupSafe', '0.23', {
-        'source_urls': ['https://pypi.python.org/packages/source/M/MarkupSafe'],
-    }),
-    ('Jinja2', '2.7.3', {
-        'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2'],
-    }),
-    ('jsonpointer', '1.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/j/jsonpointer'],
-    }),
-    ('jsonschema', '2.4.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema'],
-    }),
-    ('functools32', '3.2.3-1', {
-        'source_urls': ['https://pypi.python.org/packages/source/f/functools32'],
-    }),
-    ('mistune', '0.5.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/m/mistune'],
-    }),
-    ('tornado', '4.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/t/tornado'],
-    }),
-    ('Pygments', '2.0.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/P/Pygments'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015a.eb
@@ -120,22 +120,22 @@ exts_list = [
     ('MarkupSafe', '0.23', {
         'source_urls': ['https://pypi.python.org/packages/source/M/MarkupSafe'],
     }),
-    ('Jinja2', '2.8', {
+    ('Jinja2', '2.7.3', {
         'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2'],
     }),
-    ('jsonpointer', '1.9', {
+    ('jsonpointer', '1.7', {
         'source_urls': ['https://pypi.python.org/packages/source/j/jsonpointer'],
     }),
-    ('jsonschema', '2.5.1', {
+    ('jsonschema', '2.4.0', {
         'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema'],
     }),
-    ('functools32', '3.2.3-2', {
+    ('functools32', '3.2.3-1', {
         'source_urls': ['https://pypi.python.org/packages/source/f/functools32'],
     }),
-    ('mistune', '0.7', {
+    ('mistune', '0.5.1', {
         'source_urls': ['https://pypi.python.org/packages/source/m/mistune'],
     }),
-    ('tornado', '4.2.1', {
+    ('tornado', '4.1', {
         'source_urls': ['https://pypi.python.org/packages/source/t/tornado'],
     }),
     ('Pygments', '2.0.2', {

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015a.eb
@@ -117,30 +117,6 @@ exts_list = [
     ('pandas', '0.16.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
     }),
-    ('MarkupSafe', '0.23', {
-        'source_urls': ['https://pypi.python.org/packages/source/M/MarkupSafe'],
-    }),
-    ('Jinja2', '2.7.3', {
-        'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2'],
-    }),
-    ('jsonpointer', '1.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/j/jsonpointer'],
-    }),
-    ('jsonschema', '2.4.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema'],
-    }),
-    ('functools32', '3.2.3-1', {
-        'source_urls': ['https://pypi.python.org/packages/source/f/functools32'],
-    }),
-    ('mistune', '0.5.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/m/mistune'],
-    }),
-    ('tornado', '4.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/t/tornado'],
-    }),
-    ('Pygments', '2.0.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/P/Pygments'],
-    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
@@ -114,6 +114,30 @@ exts_list = [
     ('pandas', '0.16.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
     }),
+    ('MarkupSafe', '0.23', {
+        'source_urls': ['https://pypi.python.org/packages/source/M/MarkupSafe'],
+    }),
+    ('Jinja2', '2.7.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2'],
+    }),
+    ('jsonpointer', '1.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jsonpointer'],
+    }),
+    ('jsonschema', '2.4.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema'],
+    }),
+    ('functools32', '3.2.3-1', {
+        'source_urls': ['https://pypi.python.org/packages/source/f/functools32'],
+    }),
+    ('mistune', '0.5.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mistune'],
+    }),
+    ('tornado', '4.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/t/tornado'],
+    }),
+    ('Pygments', '2.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/P/Pygments'],
+    }),
 ]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
@@ -114,30 +114,6 @@ exts_list = [
     ('pandas', '0.16.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
     }),
-    ('MarkupSafe', '0.23', {
-        'source_urls': ['https://pypi.python.org/packages/source/M/MarkupSafe'],
-    }),
-    ('Jinja2', '2.7.3', {
-        'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2'],
-    }),
-    ('jsonpointer', '1.7', {
-        'source_urls': ['https://pypi.python.org/packages/source/j/jsonpointer'],
-    }),
-    ('jsonschema', '2.4.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema'],
-    }),
-    ('functools32', '3.2.3-1', {
-        'source_urls': ['https://pypi.python.org/packages/source/f/functools32'],
-    }),
-    ('mistune', '0.5.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/m/mistune'],
-    }),
-    ('tornado', '4.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/t/tornado'],
-    }),
-    ('Pygments', '2.0.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/P/Pygments'],
-    }),
 ]
 
 moduleclass = 'lang'


### PR DESCRIPTION
This undoes the changes in #1820, which convolutes the Python easyconfigs too much.

Instead, we should look into installing IPython as a bundle, like we do for GC3Pie.

@ehiggs: thoughts?