### PR TITLE
fix installation prefix for SIP

### DIFF
--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.4-goolf-1.5.14-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.4-goolf-1.5.14-Python-2.7.9.eb
@@ -20,6 +20,14 @@ versionsuffix = '-%s-%s' % (python, pyver)
 
 dependencies = [(python, pyver)]
 
-configopts = "configure.py"
+pyshortver = '.'.join(pyver.split('.')[:2])
+configopts = "configure.py --bindir %%(installdir)s/bin --incdir %%(installdir)s/include/python%s " % pyshortver
+configopts += "--destdir %%(installdir)s/lib/python%s/site-packages" % pyshortver
+
+sanity_check_paths = {
+    'files': ['bin/sip', 'include/python%s/sip.h' % pyshortver] +
+             ['lib/python%s/site-packages/%s' % (pyshortver, x) for x in ['sip.so', 'sipconfig.py', 'sipdistutils.py']],
+    'dirs': [],
+}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.4-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.4-intel-2015a-Python-2.7.9.eb
@@ -20,6 +20,14 @@ versionsuffix = '-%s-%s' % (python, pyver)
 
 dependencies = [(python, pyver)]
 
-configopts = "configure.py"
+pyshortver = '.'.join(pyver.split('.')[:2])
+configopts = "configure.py --bindir %%(installdir)s/bin --incdir %%(installdir)s/include/python%s " % pyshortver
+configopts += "--destdir %%(installdir)s/lib/python%s/site-packages" % pyshortver
+
+sanity_check_paths = {
+    'files': ['bin/sip', 'include/python%s/sip.h' % pyshortver] +
+             ['lib/python%s/site-packages/%s' % (pyshortver, x) for x in ['sip.so', 'sipconfig.py', 'sipdistutils.py']],
+    'dirs': [],
+}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.8-foss-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.8-foss-2015a-Python-2.7.9.eb
@@ -20,6 +20,14 @@ versionsuffix = '-%s-%s' % (python, pyver)
 
 dependencies = [(python, pyver)]
 
-configopts = "configure.py"
+pyshortver = '.'.join(pyver.split('.')[:2])
+configopts = "configure.py --bindir %%(installdir)s/bin --incdir %%(installdir)s/include/python%s " % pyshortver
+configopts += "--destdir %%(installdir)s/lib/python%s/site-packages" % pyshortver
+
+sanity_check_paths = {
+    'files': ['bin/sip', 'include/python%s/sip.h' % pyshortver] +
+             ['lib/python%s/site-packages/%s' % (pyshortver, x) for x in ['sip.so', 'sipconfig.py', 'sipdistutils.py']],
+    'dirs': [],
+}
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/SIP/SIP-4.16.8-intel-2015a-Python-2.7.9.eb
@@ -20,6 +20,14 @@ versionsuffix = '-%s-%s' % (python, pyver)
 
 dependencies = [(python, pyver)]
 
-configopts = "configure.py"
+pyshortver = '.'.join(pyver.split('.')[:2])
+configopts = "configure.py --bindir %%(installdir)s/bin --incdir %%(installdir)s/include/python%s " % pyshortver
+configopts += "--destdir %%(installdir)s/lib/python%s/site-packages" % pyshortver
+
+sanity_check_paths = {
+    'files': ['bin/sip', 'include/python%s/sip.h' % pyshortver] +
+             ['lib/python%s/site-packages/%s' % (pyshortver, x) for x in ['sip.so', 'sipconfig.py', 'sipdistutils.py']],
+    'dirs': [],
+}
 
 moduleclass = 'lang'


### PR DESCRIPTION
Without this, SIP installs into the Python installation directory:

```
$ cd $EASYBUILD_PREFIX/software/Python/2.7.9-intel-2015a 
$ find . -name '*sip*'
./include/python2.7/sip.h
./bin/sip
./lib/python2.7/site-packages/sipdistutils.py
./lib/python2.7/site-packages/sip.so
./lib/python2.7/site-packages/sipconfig.py
```

`>_<`

This went undetected because the default sanity check were not being checked for stuff that is installed with easyblocks that derive from `ExtensionEasyBlock` (for example, `PythonPackage` and freidns) until recently, see https://github.com/hpcugent/easybuild-framework/pull/1366...