### PR TITLE
add custom sanity check paths in mpi4py easyconfigs

### DIFF
--- a/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -23,4 +23,10 @@ dependencies = [
     (python, pyver),
 ]
 
+pyshortver = '.'.join(pyver.split('.')[:2])
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/mpi4py' % pyshortver],
+}
+
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-goolf-1.4.10-Python-2.7.3.eb
@@ -23,4 +23,10 @@ dependencies = [
     (python, pyver),
 ]
 
+pyshortver = '.'.join(pyver.split('.')[:2])
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/mpi4py' % pyshortver],
+}
+
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-goolf-1.4.10-Python-3.2.3.eb
+++ b/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-goolf-1.4.10-Python-3.2.3.eb
@@ -24,4 +24,10 @@ dependencies = [
     (python, pyver),
 ]
 
+pyshortver = '.'.join(pyver.split('.')[:2])
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/mpi4py' % pyshortver],
+}
+
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-ictce-4.0.6-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-ictce-4.0.6-Python-2.7.3.eb
@@ -23,4 +23,10 @@ dependencies = [
     (python, pyver),
 ]
 
+pyshortver = '.'.join(pyver.split('.')[:2])
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/mpi4py' % pyshortver],
+}
+
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-ictce-4.1.13-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-ictce-4.1.13-Python-2.7.3.eb
@@ -23,4 +23,10 @@ dependencies = [
     (python, pyver),
 ]
 
+pyshortver = '.'.join(pyver.split('.')[:2])
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/mpi4py' % pyshortver],
+}
+
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-ictce-5.3.0-Python-2.7.3.eb
@@ -21,4 +21,10 @@ versionsuffix = '-%s-%s' % (python, pyver)
 
 dependencies = [(python, pyver)]
 
+pyshortver = '.'.join(pyver.split('.')[:2])
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/mpi4py' % pyshortver],
+}
+
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-ictce-5.5.0-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/m/mpi4py/mpi4py-1.3-ictce-5.5.0-Python-2.7.5.eb
@@ -21,4 +21,10 @@ versionsuffix = '-%s-%s' % (python, pyver)
 
 dependencies = [(python, pyver)]
 
+pyshortver = '.'.join(pyver.split('.')[:2])
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/mpi4py' % pyshortver],
+}
+
 moduleclass = 'mpi'


### PR DESCRIPTION
required because of enabling fallback to default `bin`/`lib` sanity check paths due to https://github.com/hpcugent/easybuild-framework/pull/1366