### PR TITLE
add custom sanity check paths in YAML-Syck easyconfigs

### DIFF
--- a/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-goolf-1.4.10-Perl-5.16.3.eb
@@ -32,9 +32,10 @@ dependencies = [
 
 options = {'modulename': 'YAML::Syck'}
 
+perlmajver = perlver.split('.')[0]
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/perl5/site_perl/5.16.3/x86_64-linux-thread-multi/YAML'],
+    'dirs': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/YAML' % (perlmajver, perlver)],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-goolf-1.4.10-Perl-5.16.3.eb
@@ -32,4 +32,9 @@ dependencies = [
 
 options = {'modulename': 'YAML::Syck'}
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/perl5/site_perl/5.16.3/x86_64-linux-thread-multi/YAML'],
+}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-4.1.13-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-4.1.13-Perl-5.16.3.eb
@@ -32,9 +32,10 @@ dependencies = [
 
 options = {'modulename': 'YAML::Syck'}
 
+perlmajver = perlver.split('.')[0]
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/perl5/site_perl/5.16.3/x86_64-linux-thread-multi/YAML'],
+    'dirs': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/YAML' % (perlmajver, perlver)],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-4.1.13-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-4.1.13-Perl-5.16.3.eb
@@ -32,4 +32,9 @@ dependencies = [
 
 options = {'modulename': 'YAML::Syck'}
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/perl5/site_perl/5.16.3/x86_64-linux-thread-multi/YAML'],
+}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-5.3.0-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-5.3.0-Perl-5.16.3.eb
@@ -32,9 +32,10 @@ dependencies = [
 
 options = {'modulename': 'YAML::Syck'}
 
+perlmajver = perlver.split('.')[0]
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/perl5/site_perl/5.16.3/x86_64-linux-thread-multi/YAML'],
+    'dirs': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/YAML' % (perlmajver, perlver)],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-5.3.0-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-5.3.0-Perl-5.16.3.eb
@@ -32,4 +32,9 @@ dependencies = [
 
 options = {'modulename': 'YAML::Syck'}
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/perl5/site_perl/5.16.3/x86_64-linux-thread-multi/YAML'],
+}
+
 moduleclass = 'data'


### PR DESCRIPTION
required because of enabling fallback to default `bin`/`lib` sanity check paths due to hpcugent/easybuild-framework#1366