### PR TITLE
add custom sanity check paths in Perl XML easyconfigs

### DIFF
--- a/easybuild/easyconfigs/x/XML-Dumper/XML-Dumper-0.81-intel-2014b-Perl-5.20.0.eb
+++ b/easybuild/easyconfigs/x/XML-Dumper/XML-Dumper-0.81-intel-2014b-Perl-5.20.0.eb
@@ -23,4 +23,10 @@ dependencies = [
 
 options = {'modulename': 'XML::Dumper'}
 
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': ['lib/perl%s/site_perl/%s/XML/Dumper.pm' % (perlmajver, perlver)],
+    'dirs': [],
+}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/x/XML-Parser/XML-Parser-2.41-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/x/XML-Parser/XML-Parser-2.41-goolf-1.4.10-Perl-5.16.3.eb
@@ -21,4 +21,10 @@ dependencies = [
 
 options = {'modulename': 'XML::Parser'}
 
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/XML' % (perlmajver, perlver)],
+}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/x/XML-Parser/XML-Parser-2.41-intel-2014b-Perl-5.20.0.eb
+++ b/easybuild/easyconfigs/x/XML-Parser/XML-Parser-2.41-intel-2014b-Perl-5.20.0.eb
@@ -21,4 +21,10 @@ dependencies = [
 
 options = {'modulename': 'XML::Parser'}
 
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/XML' % (perlmajver, perlver)],
+}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/x/XML-Twig/XML-Twig-3.48-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/x/XML-Twig/XML-Twig-3.48-goolf-1.4.10-Perl-5.16.3.eb
@@ -21,4 +21,10 @@ dependencies = [
 
 options = {'modulename': 'XML::Twig'}
 
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': ['bin/xml_grep', 'bin/xml_merge', 'bin/xml_pp', 'bin/xml_spellcheck', 'bin/xml_split'],
+    'dirs': ['lib/perl%s/site_perl/%s/XML/Twig' % (perlmajver, perlver)],
+}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/x/XML-Twig/XML-Twig-3.48-intel-2014b-Perl-5.20.0.eb
+++ b/easybuild/easyconfigs/x/XML-Twig/XML-Twig-3.48-intel-2014b-Perl-5.20.0.eb
@@ -21,4 +21,10 @@ dependencies = [
 
 options = {'modulename': 'XML::Twig'}
 
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': ['bin/xml_grep', 'bin/xml_merge', 'bin/xml_pp', 'bin/xml_spellcheck', 'bin/xml_split'],
+    'dirs': ['lib/perl%s/site_perl/%s/XML/Twig' % (perlmajver, perlver)],
+}
+
 moduleclass = 'data'


### PR DESCRIPTION
required because of enabling fallback to default bin/lib sanity check paths due to hpcugent/easybuild-framework#1366