### PR TITLE
add custom sanity check paths in vsc-processcontrol and vsc-mympirun-scoop easyconfigs

### DIFF
--- a/easybuild/easyconfigs/v/vsc-mympirun-scoop/vsc-mympirun-scoop-3.3.0-ictce-5.5.0-Python-2.7.6.eb
+++ b/easybuild/easyconfigs/v/vsc-mympirun-scoop/vsc-mympirun-scoop-3.3.0-ictce-5.5.0-Python-2.7.6.eb
@@ -24,4 +24,9 @@ dependencies = [
 
 options = {'modulename': 'vsc.mympirun.scoop'}
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/vsc/mympirun/scoop'],
+}
+
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/v/vsc-processcontrol/vsc-processcontrol-1.0.eb
+++ b/easybuild/easyconfigs/v/vsc-processcontrol/vsc-processcontrol-1.0.eb
@@ -17,4 +17,9 @@ dependencies = [('vsc-base', '1.7.3')]
 
 options = {'modulename': 'sys; print sys.path; import vsc; print vsc.__path__; import vsc.processcontrol'}
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/vsc/processcontrol'],
+}
+
 moduleclass = 'tools'


### PR DESCRIPTION
required because of enabling fallback to default bin/lib sanity check paths due to hpcugent/easybuild-framework#1366