### PR TITLE
add custom sanity check paths in GraphViz Perl easyconfigs

### DIFF
--- a/easybuild/easyconfigs/g/GraphViz/GraphViz-2.18-intel-2014b-Perl-5.20.0.eb
+++ b/easybuild/easyconfigs/g/GraphViz/GraphViz-2.18-intel-2014b-Perl-5.20.0.eb
@@ -21,7 +21,12 @@ dependencies = [
     ("Graphviz", "2.38.0"),
 ]
 
-
 options = {'modulename': 'GraphViz'}
+
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': ['lib/perl%s/site_perl/%s/GraphViz.pm' % (perlmajver, perlver)],
+    'dirs': ['lib/perl%s/site_perl/%s/GraphViz' % (perlmajver, perlver)],
+}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GraphViz2/GraphViz2-2.33-intel-2014b-Perl-5.20.0.eb
+++ b/easybuild/easyconfigs/g/GraphViz2/GraphViz2-2.33-intel-2014b-Perl-5.20.0.eb
@@ -21,7 +21,12 @@ dependencies = [
     ("Graphviz", "2.38.0"),
 ]
 
-
 options = {'modulename': 'GraphViz2'}
+
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': ['lib/perl%s/site_perl/%s/GraphViz2.pm' % (perlmajver, perlver)],
+    'dirs': ['lib/perl%s/site_perl/%s/GraphViz2' % (perlmajver, perlver)],
+}
 
 moduleclass = 'vis'


### PR DESCRIPTION
required because of enabling fallback to default bin/lib sanity check paths due to hpcugent/easybuild-framework#1366