### PR TITLE
add custom sanity check paths in scikit-learn easyconfigs

### DIFF
--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.13-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.13-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -1,7 +1,7 @@
-easyblock = "PythonPackage"
+easyblock = 'PythonPackage'
 
-name = "scikit-learn"
-version = "0.13"
+name = 'scikit-learn'
+version = '0.13'
 
 homepage = 'http://scikit-learn.org/stable/index.html'
 description = """Scikit-learn integrates machine learning algorithms in the tightly-knit scientific Python world,
@@ -14,15 +14,20 @@ toolchain = {'version': '1.1.0-no-OFED', 'name': 'goalf'}
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
-python = "Python"
-pythonversion = '2.7.3'
-pythonshortversion = ".".join(pythonversion.split(".")[:2])
+python = 'Python'
+pyver = '2.7.3'
+pyshortver = '.'.join(pyver.split('.')[:2])
 
-versionsuffix = "-%s-%s" % (python, pythonversion)
+versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
-    (python, pythonversion),
+    (python, pyver),
     ('matplotlib', '1.1.1', versionsuffix),
 ]
-options = {'modulename': "sklearn"}
+options = {'modulename': 'sklearn'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.13-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.13-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -16,7 +16,6 @@ sources = [SOURCE_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.3'
-pyshortver = '.'.join(pyver.split('.')[:2])
 
 versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
@@ -25,9 +24,10 @@ dependencies = [
 ]
 options = {'modulename': 'sklearn'}
 
+pyshortver = '.'.join(pyver.split('.')[:2])
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pyshortver],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.13-ictce-4.1.13-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.13-ictce-4.1.13-Python-2.7.3.eb
@@ -16,7 +16,6 @@ sources = [SOURCE_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.3'
-pyshortver = '.'.join(pyver.split('.')[:-1])
 
 versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
@@ -25,9 +24,10 @@ dependencies = [
 ]
 options = {'modulename': 'sklearn'}
 
+pyshortver = '.'.join(pyver.split('.')[:-1])
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pyshortver],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.13-ictce-4.1.13-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.13-ictce-4.1.13-Python-2.7.3.eb
@@ -1,6 +1,7 @@
-easyblock = "PythonPackage"
-name = "scikit-learn"
-version = "0.13"
+easyblock = 'PythonPackage'
+
+name = 'scikit-learn'
+version = '0.13'
 
 homepage = 'http://scikit-learn.org/stable/index.html'
 description = """Scikit-learn integrates machine learning algorithms in the tightly-knit scientific Python world,
@@ -13,15 +14,20 @@ toolchain = {'name': 'ictce', 'version': '4.1.13'}
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
-python = "Python"
-pythonversion = '2.7.3'
-pythonshortversion = ".".join(pythonversion.split(".")[:-1])
+python = 'Python'
+pyver = '2.7.3'
+pyshortver = '.'.join(pyver.split('.')[:-1])
 
-versionsuffix = "-%s-%s" % (python, pythonversion)
+versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
-    (python, pythonversion),
+    (python, pyver),
     ('matplotlib', '1.2.0', versionsuffix),
 ]
-options = {'modulename': "sklearn"}
+options = {'modulename': 'sklearn'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.13-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.13-ictce-5.3.0-Python-2.7.3.eb
@@ -16,7 +16,6 @@ sources = [SOURCE_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.3'
-pyshortver = '.'.join(pyver.split('.')[:-1])
 
 versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
@@ -25,9 +24,10 @@ dependencies = [
 ]
 options = {'modulename': 'sklearn'}
 
+pyshortver = '.'.join(pyver.split('.')[:-1])
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pyshortver],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.13-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.13-ictce-5.3.0-Python-2.7.3.eb
@@ -1,6 +1,7 @@
-easyblock = "PythonPackage"
-name = "scikit-learn"
-version = "0.13"
+easyblock = 'PythonPackage'
+
+name = 'scikit-learn'
+version = '0.13'
 
 homepage = 'http://scikit-learn.org/stable/index.html'
 description = """Scikit-learn integrates machine learning algorithms in the tightly-knit scientific Python world,
@@ -13,15 +14,20 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
-python = "Python"
-pythonversion = '2.7.3'
-pythonshortversion = ".".join(pythonversion.split(".")[:-1])
+python = 'Python'
+pyver = '2.7.3'
+pyshortver = '.'.join(pyver.split('.')[:-1])
 
-versionsuffix = "-%s-%s" % (python, pythonversion)
+versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
-    (python, pythonversion),
+    (python, pyver),
     ('matplotlib', '1.2.0', versionsuffix),
 ]
-options = {'modulename': "sklearn"}
+options = {'modulename': 'sklearn'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.14-ictce-4.1.13-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.14-ictce-4.1.13-Python-2.7.5.eb
@@ -16,7 +16,6 @@ sources = [SOURCE_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.5'
-pyshortver = '.'.join(pyver.split('.')[:-1])
 
 versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
@@ -26,9 +25,10 @@ dependencies = [
 
 options = {'modulename': 'sklearn'}
 
+pyshortver = '.'.join(pyver.split('.')[:-1])
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pyshortver],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.14-ictce-4.1.13-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.14-ictce-4.1.13-Python-2.7.5.eb
@@ -1,7 +1,7 @@
-easyblock = "PythonPackage"
+easyblock = 'PythonPackage'
 
-name = "scikit-learn"
-version = "0.14"
+name = 'scikit-learn'
+version = '0.14'
 
 homepage = 'http://scikit-learn.org/stable/index.html'
 description = """Scikit-learn integrates machine learning algorithms in the tightly-knit scientific Python world,
@@ -14,16 +14,21 @@ toolchain = {'name': 'ictce', 'version': '4.1.13'}
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
-python = "Python"
-pythonversion = '2.7.5'
-pythonshortversion = ".".join(pythonversion.split(".")[:-1])
+python = 'Python'
+pyver = '2.7.5'
+pyshortver = '.'.join(pyver.split('.')[:-1])
 
-versionsuffix = "-%s-%s" % (python, pythonversion)
+versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
-    (python, pythonversion),
+    (python, pyver),
     ('matplotlib', '1.3.0', versionsuffix),
 ]
 
-options = {'modulename': "sklearn"}
+options = {'modulename': 'sklearn'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.14-ictce-5.3.0-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.14-ictce-5.3.0-Python-2.7.5.eb
@@ -1,7 +1,7 @@
-easyblock = "PythonPackage"
+easyblock = 'PythonPackage'
 
-name = "scikit-learn"
-version = "0.14"
+name = 'scikit-learn'
+version = '0.14'
 
 homepage = 'http://scikit-learn.org/stable/index.html'
 description = """Scikit-learn integrates machine learning algorithms in the tightly-knit scientific Python world,
@@ -14,16 +14,21 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
-python = "Python"
-pythonversion = '2.7.5'
-pythonshortversion = ".".join(pythonversion.split(".")[:-1])
+python = 'Python'
+pyver = '2.7.5'
+pyshortver = '.'.join(pyver.split('.')[:-1])
 
-versionsuffix = "-%s-%s" % (python, pythonversion)
+versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
-    (python, pythonversion),
+    (python, pyver),
     ('matplotlib', '1.3.0', versionsuffix),
 ]
 
-options = {'modulename': "sklearn"}
+options = {'modulename': 'sklearn'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.14-ictce-5.3.0-Python-2.7.5.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.14-ictce-5.3.0-Python-2.7.5.eb
@@ -16,7 +16,6 @@ sources = [SOURCE_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.5'
-pyshortver = '.'.join(pyver.split('.')[:-1])
 
 versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
@@ -26,9 +25,10 @@ dependencies = [
 
 options = {'modulename': 'sklearn'}
 
+pyshortver = '.'.join(pyver.split('.')[:-1])
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pyshortver],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.14-ictce-5.5.0-Python-2.7.6.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.14-ictce-5.5.0-Python-2.7.6.eb
@@ -16,7 +16,6 @@ sources = [SOURCE_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.6'
-pyshortver = '.'.join(pyver.split('.')[:-1])
 
 versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
@@ -26,9 +25,10 @@ dependencies = [
 
 options = {'modulename': 'sklearn'}
 
+pyshortver = '.'.join(pyver.split('.')[:-1])
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pyshortver],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.14-ictce-5.5.0-Python-2.7.6.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.14-ictce-5.5.0-Python-2.7.6.eb
@@ -1,7 +1,7 @@
-easyblock = "PythonPackage"
+easyblock = 'PythonPackage'
 
-name = "scikit-learn"
-version = "0.14"
+name = 'scikit-learn'
+version = '0.14'
 
 homepage = 'http://scikit-learn.org/stable/index.html'
 description = """Scikit-learn integrates machine learning algorithms in the tightly-knit scientific Python world,
@@ -14,16 +14,21 @@ toolchain = {'name': 'ictce', 'version': '5.5.0'}
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
-python = "Python"
-pythonversion = '2.7.6'
-pythonshortversion = ".".join(pythonversion.split(".")[:-1])
+python = 'Python'
+pyver = '2.7.6'
+pyshortver = '.'.join(pyver.split('.')[:-1])
 
-versionsuffix = "-%s-%s" % (python, pythonversion)
+versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
-    (python, pythonversion),
+    (python, pyver),
     ('matplotlib', '1.3.1', versionsuffix),
 ]
 
-options = {'modulename': "sklearn"}
+options = {'modulename': 'sklearn'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.16.1-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.16.1-intel-2015a-Python-2.7.9.eb
@@ -15,15 +15,20 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 python = 'Python'
-pythonversion = '2.7.9'
-pythonshortversion = ".".join(pythonversion.split(".")[:-1])
+pyver = '2.7.9'
+pyshortver = '.'.join(pyver.split('.')[:-1])
 
-versionsuffix = "-%s-%s" % (python, pythonversion)
+versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
-    (python, pythonversion),
+    (python, pyver),
     ('matplotlib', '1.4.3', versionsuffix),
 ]
 
-options = {'modulename': "sklearn"}
+options = {'modulename': 'sklearn'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.16.1-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.16.1-intel-2015a-Python-2.7.9.eb
@@ -16,7 +16,6 @@ sources = [SOURCE_TAR_GZ]
 
 python = 'Python'
 pyver = '2.7.9'
-pyshortver = '.'.join(pyver.split('.')[:-1])
 
 versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
@@ -26,9 +25,10 @@ dependencies = [
 
 options = {'modulename': 'sklearn'}
 
+pyshortver = '.'.join(pyver.split('.')[:-1])
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages/sklearn' % pythonshortver],
+    'dirs': ['lib/python%s/site-packages/sklearn' % pyshortver],
 }
 
 moduleclass = 'data'


### PR DESCRIPTION
required because of enabling fallback to default bin/lib sanity check paths due to hpcugent/easybuild-framework#1366