### PR TITLE
add custom sanity check paths in ncdf + ncdf4 R easyconfigs

### DIFF
--- a/easybuild/easyconfigs/n/ncdf/ncdf-1.6.6-ictce-5.3.0-R-2.15.3.eb
+++ b/easybuild/easyconfigs/n/ncdf/ncdf-1.6.6-ictce-5.3.0-R-2.15.3.eb
@@ -26,4 +26,9 @@ dependencies = [
     ('netCDF', '4.2.1.1', '-zlib-1.2.5'),
 ]
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['ncdf'],
+}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/n/ncdf4/ncdf4-1.10-ictce-5.3.0-R-2.15.3.eb
+++ b/easybuild/easyconfigs/n/ncdf4/ncdf4-1.10-ictce-5.3.0-R-2.15.3.eb
@@ -26,4 +26,9 @@ dependencies = [
     ('netCDF', '4.2.1.1', '-zlib-1.2.5'),
 ]
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['ncdf4'],
+}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/n/ncdf4/ncdf4-1.10-ictce-5.3.0-R-3.0.2-bare.eb
+++ b/easybuild/easyconfigs/n/ncdf4/ncdf4-1.10-ictce-5.3.0-R-3.0.2-bare.eb
@@ -27,4 +27,9 @@ dependencies = [
     ('netCDF', '4.2.1.1'),
 ]
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['ncdf4'],
+}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/n/ncdf4/ncdf4-1.10-ictce-5.3.0-R-3.0.2.eb
+++ b/easybuild/easyconfigs/n/ncdf4/ncdf4-1.10-ictce-5.3.0-R-3.0.2.eb
@@ -26,4 +26,9 @@ dependencies = [
     ('netCDF', '4.2.1.1'),
 ]
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['ncdf4'],
+}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/n/ncdf4/ncdf4-1.13-intel-2014b-R-3.1.1.eb
+++ b/easybuild/easyconfigs/n/ncdf4/ncdf4-1.13-intel-2014b-R-3.1.1.eb
@@ -24,4 +24,9 @@ dependencies = [
     ('cURL', '7.37.1'),
 ]
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['ncdf4'],
+}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/n/ncdf4/ncdf4-1.6.1-ictce-5.3.0-R-3.0.2-bare.eb
+++ b/easybuild/easyconfigs/n/ncdf4/ncdf4-1.6.1-ictce-5.3.0-R-3.0.2-bare.eb
@@ -27,4 +27,9 @@ dependencies = [
     ('netCDF', '4.2.1.1'),
 ]
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['ncdf4'],
+}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/n/ncdf4/ncdf4-1.6.1-ictce-5.3.0-R-3.0.2.eb
+++ b/easybuild/easyconfigs/n/ncdf4/ncdf4-1.6.1-ictce-5.3.0-R-3.0.2.eb
@@ -26,4 +26,9 @@ dependencies = [
     ('netCDF', '4.2.1.1'),
 ]
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['ncdf4'],
+}
+
 moduleclass = 'math'


### PR DESCRIPTION
required because of enabling fallback to default bin/lib sanity check paths due to hpcugent/easybuild-framework#1366