### PR TITLE
add custom sanity check paths in various easyconfigs for R libraries

### DIFF
--- a/easybuild/easyconfigs/a/AnalyzeFMRI/AnalyzeFMRI-1.1-15-ictce-4.0.10-R-2.15.2.eb
+++ b/easybuild/easyconfigs/a/AnalyzeFMRI/AnalyzeFMRI-1.1-15-ictce-4.0.10-R-2.15.2.eb
@@ -19,9 +19,14 @@ versionsuffix = '-%s-%s' % (r, rver)
 tcltkver = '8.5.12'
 
 dependencies = [
-                (r, rver),
-                ('Tcl', tcltkver),
-                ('Tk', tcltkver),
-               ]
+    (r, rver),
+    ('Tcl', tcltkver),
+    ('Tk', tcltkver),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['AnalyzeFMRI'],
+}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/a/AnalyzeFMRI/AnalyzeFMRI-1.1-15-ictce-5.3.0-R-2.15.2.eb
+++ b/easybuild/easyconfigs/a/AnalyzeFMRI/AnalyzeFMRI-1.1-15-ictce-5.3.0-R-2.15.2.eb
@@ -20,9 +20,14 @@ versionsuffix = '-%s-%s' % (r, rver)
 tcltkver = '8.5.12'
 
 dependencies = [
-                (r, rver),
-                ('Tcl', tcltkver),
-                ('Tk', tcltkver),
-               ]
+    (r, rver),
+    ('Tcl', tcltkver),
+    ('Tk', tcltkver),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['AnalyzeFMRI'],
+}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/e/evmix/evmix-2.1-intel-2014b-R-3.1.1.eb
+++ b/easybuild/easyconfigs/e/evmix/evmix-2.1-intel-2014b-R-3.1.1.eb
@@ -24,4 +24,9 @@ dependencies = [
     ('gsl', '1.9-10', versionsuffix),
 ]
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['evmix'],
+}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/e/evmix/evmix-2.3-intel-2014b-R-3.1.1.eb
+++ b/easybuild/easyconfigs/e/evmix/evmix-2.3-intel-2014b-R-3.1.1.eb
@@ -24,4 +24,9 @@ dependencies = [
     ('gsl', '1.9-10', versionsuffix),
 ]
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['evmix'],
+}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/f/fmri/fmri-1.4-8-ictce-4.0.10-R-2.15.2.eb
+++ b/easybuild/easyconfigs/f/fmri/fmri-1.4-8-ictce-4.0.10-R-2.15.2.eb
@@ -21,9 +21,14 @@ versionsuffix = '-%s-%s' % (r, rver)
 tcltkver = '8.5.12'
 
 dependencies = [
-                (r, rver),
-                ('Tcl', tcltkver),
-                ('Tk', tcltkver),
-               ]
+    (r, rver),
+    ('Tcl', tcltkver),
+    ('Tk', tcltkver),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['fmri'],
+}
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/f/fmri/fmri-1.4-8-ictce-5.3.0-R-2.15.2.eb
+++ b/easybuild/easyconfigs/f/fmri/fmri-1.4-8-ictce-5.3.0-R-2.15.2.eb
@@ -21,9 +21,14 @@ versionsuffix = '-%s-%s' % (r, rver)
 tcltkver = '8.5.12'
 
 dependencies = [
-                (r, rver),
-                ('Tcl', tcltkver),
-                ('Tk', tcltkver),
-               ]
+    (r, rver),
+    ('Tcl', tcltkver),
+    ('Tk', tcltkver),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['fmri'],
+}
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/f/fmri/fmri-1.5-0-ictce-5.3.0-R-2.15.3.eb
+++ b/easybuild/easyconfigs/f/fmri/fmri-1.5-0-ictce-5.3.0-R-2.15.3.eb
@@ -26,4 +26,9 @@ dependencies = [
     ('Tk', tcltkver),
 ]
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['fmri'],
+}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/g/gsl/gsl-1.9-10-intel-2014b-R-3.1.1.eb
+++ b/easybuild/easyconfigs/g/gsl/gsl-1.9-10-intel-2014b-R-3.1.1.eb
@@ -21,4 +21,9 @@ dependencies = [
     ('GSL', '1.16'),
 ]
 
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['gsl'],
+}
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/r/rjags/rjags-3-13-intel-2014b-R-3.1.1.eb
+++ b/easybuild/easyconfigs/r/rjags/rjags-3-13-intel-2014b-R-3.1.1.eb
@@ -20,7 +20,12 @@ versionsuffix = '-%s-%s' % (r, rver)
 
 dependencies = [
     (r, rver),
-    ("JAGS", "3.4.0"),
+    ('JAGS', '3.4.0'),
 ]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['rjags'],
+}
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/r/runjags/runjags-1.2.1-0-intel-2014b-R-3.1.1.eb
+++ b/easybuild/easyconfigs/r/runjags/runjags-1.2.1-0-intel-2014b-R-3.1.1.eb
@@ -20,7 +20,12 @@ versionsuffix = '-%s-%s' % (r, rver)
 
 dependencies = [
     (r, rver),
-    ("JAGS", "3.4.0"),
+    ('JAGS', '3.4.0'),
 ]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['runjags'],
+}
 
 moduleclass = 'math'


### PR DESCRIPTION
required because of enabling fallback to default bin/lib sanity check paths due to hpcugent/easybuild-framework#1366