### PR TITLE
add custom sanity check paths in various easyconfigs for Perl modules

### DIFF
--- a/easybuild/easyconfigs/d/DBD-Pg/DBD-Pg-3.4.1-intel-2014b-Perl-5.20.0.eb
+++ b/easybuild/easyconfigs/d/DBD-Pg/DBD-Pg-3.4.1-intel-2014b-Perl-5.20.0.eb
@@ -22,4 +22,10 @@ dependencies = [
 
 options = {'modulename': 'DBD::Pg'}
 
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/DBD/Pg.pm' % (perlmajver, perlver)],
+    'dirs': [],
+}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/d/DBD-SQLite/DBD-SQLite-1.42-intel-2014b-Perl-5.20.0.eb
+++ b/easybuild/easyconfigs/d/DBD-SQLite/DBD-SQLite-1.42-intel-2014b-Perl-5.20.0.eb
@@ -23,4 +23,10 @@ dependencies = [
 
 options = {'modulename': 'DBD::SQLite'}
 
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/DBD/SQLite.pm' % (perlmajver, perlver)],
+    'dirs': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/DBD/SQLite' % (perlmajver, perlver)],
+}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/d/DBD-mysql/DBD-mysql-4.028-intel-2014b-Perl-5.20.0.eb
+++ b/easybuild/easyconfigs/d/DBD-mysql/DBD-mysql-4.028-intel-2014b-Perl-5.20.0.eb
@@ -22,4 +22,10 @@ dependencies = [
 
 options = {'modulename': 'DBD::mysql'}
 
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/DBD/mysql.pm' % (perlmajver, perlver)],
+    'dirs': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/DBD/mysql' % (perlmajver, perlver)],
+}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/d/DB_File/DB_File-1.831-ictce-5.5.0-Perl-5.18.2.eb
+++ b/easybuild/easyconfigs/d/DB_File/DB_File-1.831-ictce-5.5.0-Perl-5.18.2.eb
@@ -21,4 +21,10 @@ dependencies = [
     (perl, perlver),
 ]
 
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/DB_File.pm' % (perlmajver, perlver)],
+    'dirs': [],
+}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/d/DB_File/DB_File-1.831-ictce-5.5.0-Perl-5.20.0.eb
+++ b/easybuild/easyconfigs/d/DB_File/DB_File-1.831-ictce-5.5.0-Perl-5.20.0.eb
@@ -21,4 +21,10 @@ dependencies = [
     (perl, perlver),
 ]
 
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/DB_File.pm' % (perlmajver, perlver)],
+    'dirs': [],
+}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/g/GSSAPI/GSSAPI-0.28-intel-2014b-Perl-5.20.0.eb
+++ b/easybuild/easyconfigs/g/GSSAPI/GSSAPI-0.28-intel-2014b-Perl-5.20.0.eb
@@ -23,4 +23,10 @@ dependencies = [
 
 options = {'modulename': 'GSSAPI'}
 
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/GSSAPI.pm' % (perlmajver, perlver)],
+    'dirs': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/GSSAPI' % (perlmajver, perlver)],
+}
+
 moduleclass = 'system'

--- a/easybuild/easyconfigs/n/NetLibIDN/Net-LibIDN-0.12-intel-2014b-Perl-5.20.0.eb
+++ b/easybuild/easyconfigs/n/NetLibIDN/Net-LibIDN-0.12-intel-2014b-Perl-5.20.0.eb
@@ -23,5 +23,10 @@ dependencies = [
 
 options = {'modulename': 'Net::LibIDN'}
 
-moduleclass = 'system'
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/Net/LibIDN.pm' % (perlmajver, perlver)],
+    'dirs': [],
+}
 
+moduleclass = 'system'

--- a/easybuild/easyconfigs/p/Parallel-ForkManager/Parallel-ForkManager-1.06-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/p/Parallel-ForkManager/Parallel-ForkManager-1.06-goolf-1.4.10-Perl-5.16.3.eb
@@ -30,4 +30,10 @@ dependencies = [
 
 options = {'modulename': 'Parallel::ForkManager'}
 
+perlmajver = perlver.split('.')[0]
+sanity_check_paths = {
+    'files': ['lib/perl%s/site_perl/%s/Parallel/ForkManager.pm' % (perlmajver, perlver)],
+    'dirs': [],
+}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/s/SOBAcl/SOBAcl-r18-intel-2014b-Perl-5.20.0.eb
+++ b/easybuild/easyconfigs/s/SOBAcl/SOBAcl-r18-intel-2014b-Perl-5.20.0.eb
@@ -19,4 +19,9 @@ versionsuffix = '-%s-%s' % (perl, perlver)
 
 dependencies = [('GraphViz', '2.18', versionsuffix)]
 
+sanity_check_paths = {
+    'files': ['bin/SOBAcl', 'bin/so_tree', 'lib/Bundle/SOBA.pm', 'lib/SOBA/Base.pm', 'lib/SOBA/Run.pm'],
+    'dirs': [],
+}
+
 moduleclass = 'bio'


### PR DESCRIPTION
required because of enabling fallback to default bin/lib sanity check paths due to hpcugent/easybuild-framework#1366