### PR TITLE
fix typo in FastTree and fastqz easyconfigs

### DIFF
--- a/easybuild/easyconfigs/f/FastTree/FastTree-2.1.7-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/FastTree/FastTree-2.1.7-goolf-1.4.10.eb
@@ -16,7 +16,7 @@ sources = ['%(name)s-%(version)s.c']
 
 skipsteps = ['source']
 
-cmds_map = [('FastTree.*.c', '$CC -DOPENMP $CFLAGS $LIBS %(source)s -o %(name)s')]
+cmds_map = [('FastTree.*.c', '$CC -DOPENMP $CFLAGS $LIBS %%(source)s -o %(name)s')]
 
 files_to_copy = [(['FastTree'], 'bin')]
 

--- a/easybuild/easyconfigs/f/FastTree/FastTree-2.1.7-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/f/FastTree/FastTree-2.1.7-ictce-5.5.0.eb
@@ -16,7 +16,7 @@ sources = ['%(name)s-%(version)s.c']
 
 skipsteps = ['source']
 
-cmds_map = [('FastTree.*.c', '$CC -DOPENMP $CFLAGS $LIBS %(source)s -o %(name)s')]
+cmds_map = [('FastTree.*.c', '$CC -DOPENMP $CFLAGS $LIBS %%(source)s -o %(name)s')]
 
 files_to_copy = [(['FastTree'], 'bin')]
 

--- a/easybuild/easyconfigs/f/fastqz/fastqz-1.5-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/f/fastqz/fastqz-1.5-GCC-4.8.2.eb
@@ -30,7 +30,7 @@ dependencies = [('ZPAQ', '7.00')]
 skipsteps = ['source']
 
 cmds_map = [
-    ('fastqz%s.cpp' % minver, '$CXX $CFLAGS -lpthread %(source)s $EBROOTZPAQ/include/libzpaq.cpp -o %(name)s'),
+    ('fastqz%s.cpp' % minver, '$CXX $CFLAGS -lpthread %%(source)s $EBROOTZPAQ/include/libzpaq.cpp -o %(name)s'),
     ('fapack.cpp', '$CXX $CFLAGS -s %(source)s -o %(target)s')
 ]
 


### PR DESCRIPTION
`%(source)s` template key needs to be escaped since 'regular' templating of `%(name)s` kicks in first