### PR TITLE
don't enable 'static' toolchain option in SuiteSparse 4.4.3 easyconfig

### DIFF
--- a/easybuild/easyconfigs/s/SuiteSparse/SuiteSparse-4.4.3-intel-2015a-ParMETIS-4.0.3.eb
+++ b/easybuild/easyconfigs/s/SuiteSparse/SuiteSparse-4.4.3-intel-2015a-ParMETIS-4.0.3.eb
@@ -5,7 +5,7 @@ homepage = 'http://www.cise.ufl.edu/research/sparse/SuiteSparse/'
 description = """SuiteSparse is a collection of libraries manipulate sparse matrices."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
-toolchainopts = {'opt': True, 'unroll': True, 'pic': True, 'static': True}
+toolchainopts = {'opt': True, 'unroll': True, 'pic': True}
 
 source_urls = ['http://faculty.cse.tamu.edu/davis/SuiteSparse/']
 sources = [SOURCE_TAR_GZ]


### PR DESCRIPTION
enabling `static` toolchain option breaks the build with:

```
icc -static ... -o kludemo ...
ld: dynamic STT_GNU_IFUNC symbol `strcmp' with pointer equality in `/usr/lib/../lib64/libc.a(strcmp.o)' can not be used when making an executable; recompile with -fPIE and rel      ink with -pie 
make[2]: *** [kludemo] Error 1
```

this didn't occur before because `$CFLAGS` wasn't passed down as it should before (this was fixed in https://github.com/hpcugent/easybuild-easyblocks/pull/666)

other/older SuiteSparse versions seem unaffected, no changes needed there

cc @ocaisa