### PR TITLE
{math}[intel/2015a] sympy 0.7.6 w/ Python 2.7.10 (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/s/sympy/sympy-0.7.6-intel-2015a-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/s/sympy/sympy-0.7.6-intel-2015a-Python-2.7.10.eb
@@ -24,7 +24,7 @@ versionsuffix = "-%s-%s" % (python, pyver)
 
 dependencies = [(python, pyver)]
 
-runtest = 'CPATH=$EBROOTPYTHON/lib/python%s/site-packages/numpy/core/include:$CPATH python setup.py test' % pyshortver
+runtest = 'python setup.py test'
 
 sanity_check_paths = {
     'files': [],

--- a/easybuild/easyconfigs/s/sympy/sympy-0.7.6-intel-2015a-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/s/sympy/sympy-0.7.6-intel-2015a-Python-2.7.10.eb
@@ -1,0 +1,34 @@
+easyblock = 'PythonPackage'
+
+name = 'sympy'
+version = '0.7.6'
+
+homepage = 'http://sympy.org/'
+description = """SymPy is a Python library for symbolic mathematics. It aims to
+ become a full-featured computer algebra system (CAS) while keeping the code as
+ simple as possible in order to be comprehensible and easily extensible. SymPy
+ is written entirely in Python and does not require any external libraries."""
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+
+source_urls = ['https://github.com/sympy/sympy/releases/download/sympy-%(version)s/']
+sources = [SOURCE_TAR_GZ]
+
+patches = ['sympy-%(version)s_fix-numpy-include.patch']
+
+python = 'Python'
+pyver = '2.7.10'
+pyshortver = '.'.join(pyver.split('.')[:-1])
+
+versionsuffix = "-%s-%s" % (python, pyver)
+
+dependencies = [(python, pyver)]
+
+runtest = 'CPATH=$EBROOTPYTHON/lib/python%s/site-packages/numpy/core/include:$CPATH python setup.py test' % pyshortver
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/sympy' % pyshortver],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/s/sympy/sympy-0.7.6-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/s/sympy/sympy-0.7.6-intel-2015a-Python-2.7.9.eb
@@ -14,6 +14,8 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 source_urls = ['https://github.com/sympy/sympy/releases/download/sympy-%(version)s/']
 sources = [SOURCE_TAR_GZ]
 
+patches = ['sympy-%(version)s_fix-numpy-include.patch']
+
 python = "Python"
 pythonversion = '2.7.9'
 pythonshortversion = '.'.join(pythonversion.split('.')[:-1])

--- a/easybuild/easyconfigs/s/sympy/sympy-0.7.6_fix-numpy-include.patch
+++ b/easybuild/easyconfigs/s/sympy/sympy-0.7.6_fix-numpy-include.patch
@@ -1,0 +1,98 @@
+see https://github.com/sympy/sympy/pull/8848
+
+From 1615390dff374f67fe12a13a424435e2725f3e79 Mon Sep 17 00:00:00 2001
+From: "Jason K. Moore" <moorepants@gmail.com>
+Date: Mon, 19 Jan 2015 09:48:48 -0800
+Subject: [PATCH] Added np.get_include() to Cython autowrapper, fixes #8847.
+
+- Made CodeWrapper a new style class.
+- Moved _need_numpy into __init__ so it doesn't pollute other instances.
+- Optionally include numpy include directories in Cython setup.py.
+---
+ sympy/utilities/autowrap.py | 51 ++++++++++++++++++++++++++++-----------------
+ 1 file changed, 32 insertions(+), 19 deletions(-)
+
+diff --git a/sympy/utilities/autowrap.py b/sympy/utilities/autowrap.py
+index bed39ef..8af7fbf 100644
+--- a/sympy/utilities/autowrap.py
++++ b/sympy/utilities/autowrap.py
+@@ -93,7 +93,7 @@ class CodeWrapError(Exception):
+     pass
+ 
+ 
+-class CodeWrapper:
++class CodeWrapper(object):
+     """Base Class for code wrappers"""
+     _filename = "wrapped_code"
+     _module_basename = "wrapper_module"
+@@ -211,30 +211,35 @@ class CythonCodeWrapper(CodeWrapper):
+     """Wrapper that uses Cython"""
+ 
+     setup_template = (
+-            "from distutils.core import setup\n"
+-            "from distutils.extension import Extension\n"
+-            "from Cython.Distutils import build_ext\n"
+-            "\n"
+-            "setup(\n"
+-            "    cmdclass = {{'build_ext': build_ext}},\n"
+-            "    ext_modules = [Extension({ext_args}, extra_compile_args=['-std=c99'])]\n"
+-            "        )")
++        "from distutils.core import setup\n"
++        "from distutils.extension import Extension\n"
++        "from Cython.Distutils import build_ext\n"
++        "{np_import}"
++        "\n"
++        "setup(\n"
++        "    cmdclass = {{'build_ext': build_ext}},\n"
++        "    ext_modules = [Extension({ext_args},\n"
++        "                             extra_compile_args=['-std=c99'])],\n"
++        "{np_includes}"
++        "        )")
+ 
+     pyx_imports = (
+-            "import numpy as np\n"
+-            "cimport numpy as np\n\n")
++        "import numpy as np\n"
++        "cimport numpy as np\n\n")
+ 
+     pyx_header = (
+-            "cdef extern from '{header_file}.h':\n"
+-            "    {prototype}\n\n")
++        "cdef extern from '{header_file}.h':\n"
++        "    {prototype}\n\n")
+ 
+     pyx_func = (
+-            "def {name}_c({arg_string}):\n"
+-            "\n"
+-            "{declarations}"
+-            "{body}")
++        "def {name}_c({arg_string}):\n"
++        "\n"
++        "{declarations}"
++        "{body}")
+ 
+-    _need_numpy = False
++    def __init__(self, *args, **kwargs):
++        super(CythonCodeWrapper, self).__init__(*args, **kwargs)
++        self._need_numpy = False
+ 
+     @property
+     def command(self):
+@@ -251,8 +256,16 @@ def _prepare_files(self, routine):
+ 
+         # setup.py
+         ext_args = [repr(self.module_name), repr([pyxfilename, codefilename])]
++        if self._need_numpy:
++            np_import = 'import numpy as np\n'
++            np_includes = '    include_dirs = [np.get_include()],\n'
++        else:
++            np_import = ''
++            np_includes = ''
+         with open('setup.py', 'w') as f:
+-            f.write(self.setup_template.format(ext_args=", ".join(ext_args)))
++            f.write(self.setup_template.format(ext_args=", ".join(ext_args),
++                                               np_import=np_import,
++                                               np_includes=np_includes))
+ 
+     @classmethod
+     def _get_wrapped_function(cls, mod, name):


### PR DESCRIPTION
For some reason unclear to me, making sympy pass the test suite on top of Python 2.7.10 on CentOS 7 requires the patch included, while it's not required on SL6...