### PR TITLE
{devel}[dummy,GCC/5.2.0] Boost 1.59.0 with full icu support

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.59.0-GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.59.0-GCC-5.2.0.eb
@@ -1,0 +1,25 @@
+name = 'Boost'
+version = '1.59.0'
+
+homepage = 'http://www.boost.org/'
+description = """Boost provides free peer-reviewed portable C++ source libraries."""
+
+toolchain = {'name': 'GCC', 'version': '5.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
+
+dependencies = [('bzip2', '1.0.6')]
+
+boost_mpi = False
+
+configopts = '--without-libraries=python --with-icu'
+
+toolset = 'gcc'
+
+osdependencies = [('zlib-devel', 'zlib1g-dev'), ('libicu-devel', 'icu-devel', 'libicu-dev')]
+
+parallel = 8
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCC-5.2.0.eb
@@ -1,0 +1,19 @@
+name = 'bzip2'
+version = '1.0.6'
+
+homepage = 'http://www.bzip.org/'
+description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically 
+compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical 
+compressors), whilst being around twice as fast at compression and six times faster at decompression."""
+
+toolchain = {'name': 'GCC', 'version': '5.2.0'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.bzip.org/%(version)s/']
+
+import os
+os.environ['CC'] = 'gcc'
+os.environ['CFLAGS'] = '-O3 -fPIC'
+
+moduleclass = 'tools'


### PR DESCRIPTION
The 'parallel' option is matching an addition in the Boost easyblock (see hpcugent/easybuild-easyblocks#701).

Also had to add an update for the bzip2 config.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hpcugent/easybuild-easyconfigs/1996)
<!-- Reviewable:end -->
