### PR TITLE
fix dev version to follow PEP-440, which setuptools basically jams down our throat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,13 @@ from distutils import log
 
 # note: release candidates should be versioned as a pre-release, e.g. "1.1rc1"
 # 1.1-rc1 would indicate a post-release, i.e., and update of 1.1, so beware!
-VERSION = '2.4.0dev'
+#
+# important note: dev versions should follow the 'X.Y.Z.dev0' format
+# see https://www.python.org/dev/peps/pep-0440/#developmental-releases
+# recent setuptools versions will *TRANSFORM* something like 'X.Y.Zdev' into 'X.Y.Z.dev0', with a warning like
+#   UserWarning: Normalizing '2.4.0dev' to '2.4.0.dev0'
+# This causes problems further up the dependency chain...
+VERSION = '2.4.0.dev0'
 
 API_VERSION = VERSION.split('.')[0]
 EB_VERSION = '.'.join(VERSION.split('.')[0:2])

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,11 @@ rc_regexp = re.compile("^.*(rc[0-9]*)$")
 res = rc_regexp.search(str(VERSION))
 if res:
     suff = res.group(1)
-dev_regexp = re.compile("^.*[0-9]dev$")
-if dev_regexp.match(VERSION):
-    suff = 'dev'
+
+dev_regexp = re.compile("^.*[0-9](.?dev[0-9])$")
+res = dev_regexp.search(VERSION)
+if res:
+    suff = res.group(1)
 
 API_VERSION += suff
 EB_VERSION += suff


### PR DESCRIPTION
see also https://bitbucket.org/pypa/setuptools/pull-requests/118/remove-warning-on-normalization