### PR TITLE
New easyconfig for Google Test (gtest) 1.7.0

### DIFF
--- a/easybuild/easyconfigs/g/gtest/gtest-1.7.0-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/gtest/gtest-1.7.0-intel-2015a.eb
@@ -1,0 +1,36 @@
+easyblock = "MakeCp"
+
+name = 'gtest'
+version = '1.7.0'
+
+homepage = 'https://code.google.com/p/googletest/'
+description = "Google's framework for writing C++ tests on a variety of platforms"
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+
+sources = [SOURCE_ZIP]
+source_urls = ['https://googletest.googlecode.com/files']
+
+with_configure = True
+
+so_files = [
+    'lib/.libs/libgtest.so',
+    'lib/.libs/libgtest.so.0',
+    'lib/.libs/libgtest.so.0.0.0',
+    'lib/.libs/libgtest_main.so',
+    'lib/.libs/libgtest_main.so.0',
+    'lib/.libs/libgtest_main.so.0.0.0',
+]
+files_to_copy = ['lib', 'include', (so_files, 'lib')]
+
+sanity_check_paths={
+    'files': ['lib/libgtest.la', 'lib/libgtest_main.la'],
+    'dirs': ['include'],
+}
+
+# Environment variable to help CMake's FindGTest module:
+modextravars = {
+    'GTEST_ROOT': '%(installdir)s'
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
From the commit message:

New easyconfig for Google Test 1.7.0

Some differences from the existing easyconfig for Google Test 1.6.0:

- New version

- GTEST_ROOT environment variable is defined for the Module file such that CMake build scripts automatically pick up the right location of Google Test.

- Shared libraries are installed, in addition to the static link libraries.
