### PR TITLE
{math}[dummy] Eigen3: 3.2.5 & 3.2.6

### DIFF
--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.2.5.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.2.5.eb
@@ -1,0 +1,18 @@
+name = 'Eigen'
+version = '3.2.5'
+
+homepage = 'http://eigen.tuxfamily.org/index.php?title=Main_Page'
+description = """Eigen is a C++ template library for linear algebra:
+ matrices, vectors, numerical solvers, and related algorithms."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [BITBUCKET_SOURCE]
+sources = ['%(version)s.tar.bz2']
+
+checksums = [
+    '21a928f6e0f1c7f24b6f63ff823593f5'
+]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.2.6.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.2.6.eb
@@ -1,0 +1,18 @@
+name = 'Eigen'
+version = '3.2.6'
+
+homepage = 'http://eigen.tuxfamily.org/index.php?title=Main_Page'
+description = """Eigen is a C++ template library for linear algebra:
+ matrices, vectors, numerical solvers, and related algorithms."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [BITBUCKET_SOURCE]
+sources = ['%(version)s.tar.bz2']
+
+checksums = [
+    '87274966745d2d3e7964fcc654d0a24b'
+]
+
+moduleclass = 'math'


### PR DESCRIPTION
recent Eigen3 releases 3.2.5 and 3.2.6

Side question: why are there any compiler/toolchain specific versions of Eigen3? Eigen3 is header-only and only the test suite requires a compiler (which isn't used in the Eigen easyblock).