### PR TITLE
Cufflinks 2.2.1 samtools 0.1.19 goolf 1.7.20

### DIFF
--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.2.1-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.2.1-goolf-1.7.20.eb
@@ -1,0 +1,28 @@
+name = 'Cufflinks'
+version = '2.2.1'
+
+homepage = 'http://cufflinks.cbcb.umd.edu/'
+description = """Transcript assembly, differential expression, and differential regulation for RNA-Seq"""
+
+toolchain = {'name': 'goolf', 'version': '1.7.20'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = ['cufflinks-%(version)s.tar.gz']
+source_urls = ['http://cole-trapnell-lab.github.io/cufflinks/assets/downloads/']
+
+dependencies = [
+    ('Boost', '1.55.0'),
+    ('SAMtools', '0.1.19'),
+    ('Eigen', '3.2.6'),
+    ('zlib', '1.2.8'),
+]
+
+configopts = '--with-boost=$EBROOTBOOST --with-bam-libdir=${EBROOTSAMTOOLS}/lib'
+preconfigopts = 'CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
+
+sanity_check_paths = {
+    'files': ['bin/cufflinks'],
+    'dirs': []
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.2.6-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.2.6-goolf-1.7.20.eb
@@ -1,0 +1,26 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-94.html
+##
+
+name = 'Eigen'
+version = '3.2.6'
+
+homepage = 'http://eigen.tuxfamily.org/index.php?title=Main_Page'
+description = """Eigen is a C++ template library for linear algebra:
+ matrices, vectors, numerical solvers, and related algorithms."""
+
+toolchain = {'name': 'goolf', 'version': '1.7.20'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [BITBUCKET_SOURCE]
+sources = ['%(version)s.tar.bz2']
+
+moduleclass = 'math'


### PR DESCRIPTION
This is an update to Cufflinks to support the goolf-1.7.20 toolchain. It builds successfully on CentOS 7.

It bumps the tool chain version, Boost, Eigen and zlib. The SAMtools version remains the same.

Moved pull request to target develop branch