### PR TITLE
{chem}[intel/2015b] QuantumESPRESSO 5.2.1 (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.2.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.2.1-intel-2015b.eb
@@ -1,0 +1,65 @@
+name = 'QuantumESPRESSO'
+version = '5.2.1'
+
+homepage = 'http://www.pwscf.org/'
+description = """Quantum ESPRESSO  is an integrated suite of computer codes
+ for electronic-structure calculations and materials modeling at the nanoscale.
+ It is based on density-functional theory, plane waves, and pseudopotentials
+  (both norm-conserving and ultrasoft)."""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+toolchainopts = {'usempi': True}
+
+# major part of this list was determined from espresso/install/plugins_list
+sources = [
+    'espresso-%(version)s.tar.gz',
+    'wannier90-1.2.tar.gz',
+    'atomic-%(version)s.tar.gz',
+    'neb-%(version)s.tar.gz',
+    'PHonon-%(version)s.tar.gz',
+    # must be downloaded manually from
+    # http://qe-forge.org/gf/project/q-e/scmsvn/?action=browse&path=%2F%2Acheckout%2A%2Ftags%2FQE-5.2.1%2Fespresso%2Farchive%2Fplumed-1.3-qe.tar.gz&revision=11758
+    # gets updated without changes to filename, cfr. http://qe-forge.org/pipermail/q-e-commits/2015-June/007359.html
+    'plumed-1.3-qe-r11758.tar.gz',
+    'pwcond-%(version)s.tar.gz',
+    'tddfpt-%(version)s.tar.gz',
+    'want-2.5.1-base.tar.gz',
+    'yambo-3.4.1-rev61.tgz',
+    'xspectra-%(version)s.tar.gz',
+]
+missing_sources = [
+    'sax-2.0.3.tar.gz',  # nowhere to be found
+]
+source_urls = [
+    'http://files.qe-forge.org/index.php?file=',  # all sources, except espresso*.tar.gz
+    'http://qe-forge.org/gf/download/frsrelease/199/855/',  # espresso-5.2.1.tar.gz
+    'http://qe-forge.org/gf/download/frsrelease/153/618/',  # want-2.5.1-base.tar.gz
+    'http://qe-forge.org/gf/download/frsrelease/184/723/',  # yambo-3.4.1-rev61.tgz
+]
+
+patches = [
+    'QuantumESPRESSO-%(version)s_yambo-fixes.patch',
+]
+
+# source checksums
+checksums = [
+    'da3ec5302e4343804e65de60f6004c2d',  # espresso-5.2.1.tar.gz
+    'a1e9611b9a82941c23426028d112186e',  # wannier90-1.2.tar.gz
+    '6f6ce6f9b73d521340e7f6d60dce5e1c',  # atomic-5.2.1.tar.gz
+    '586906007c57fff33c0ee2193998eb4d',  # neb-5.2.1.tar.gz
+    '9549d79f294f5b5f1a7b504858b4b587',  # PHonon-5.2.1.tar.gz
+    'f094031c6d13a0e00022daf4d7c847c7',  # plumed-1.3-qe-r11758.tar.gz
+    '4ec8075f78dfa606812c911ca22cad01',  # pwcond-5.2.1.tar.gz
+    'cca5b395001067e5a521e6d58e7ad7b0',  # tddfpt-5.2.1.tar.gz
+    'ac365daebbe380bf4019235eacf71079',  # want-2.5.1-base.tar.gz
+    '03ea2fda7a2f34f7d8ee6130fca23817',  # yambo-3.4.1-rev61.tgz
+    '406b0573fbb695c0bb5d33e85a424d37',  # xspectra-5.2.1.tar.gz
+]
+
+# gipaw excluded due to: configure: error: Cannot compile against this version of Quantum-Espresso
+buildopts = 'all w90 want yambo plumed xspectra'
+
+# parallel build tends to fail
+parallel = 1
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.2.1_yambo-fixes.patch
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.2.1_yambo-fixes.patch
@@ -1,0 +1,57 @@
+--- espresso-5.2.1/install/plugins_makefile.orig	2015-09-24 09:26:40.000000000 +0200
++++ espresso-5.2.1/install/plugins_makefile	2015-10-15 11:36:46.256246443 +0200
+@@ -289,6 +289,7 @@
+ 	./configure \
+ 	--with-blas="$(BLAS_LIBS)" \
+ 	--with-lapack="$(LAPACK_LIBS) $(BLAS_LIBS)" \
++	--with-fftw=$(FFT_LIB_DIR) --with-fftw-lib="$(FFT_LIBS)" \
+ 	--with-iotk="$(TOPDIR)/iotk" \
+ 	PFC="$(MPIF90)" \
+ 	FC="$(MPIF90)" \
+--- yambo-3.4.1-rev61/configure.orig	2015-02-04 17:54:55.000000000 +0100
++++ yambo-3.4.1-rev61/configure	2015-10-21 17:01:45.655105316 +0200
+@@ -6077,7 +6077,7 @@
+     UFFLAGS="-O0 -mtune=native"
+     FCMFLAG=""
+     ;;
+-  *ifort*)
++  *ifort*|*mpif90*)
+     CPU_FLAG=""
+     case "${FCVERSION}" in
+       *11* | *12* | *13* )
+@@ -6116,7 +6116,7 @@
+     UFFLAGS="-O0 -fno-second-underscore"
+     FCMFLAG=""
+     ;;
+-  *ifort*)
++  *ifort*|*mpif90*)
+     CPU_FLAG=""
+     case "${FCVERSION}" in
+       *1*)
+@@ -6159,7 +6159,7 @@
+     SYSFLAGS="-O3 -w"
+     UFFLAGS="-O0 -w"
+     ;;
+-  *ifort*)
++  *ifort*|*mpif90*)
+     CPU_FLAG=""
+     case "${FCVERSION}" in
+       *1*)
+@@ -6212,7 +6212,7 @@
+     SYSFLAGS="-O3 -w -tpp2"
+     UFFLAGS="-O0 -w -tpp2"
+     ;;
+-  *ifort*)
++  *ifort*|*mpif90*)
+     CPU_FLAG=""
+     case "${FCVERSION}" in
+       *11* | *12* | *13* )
+@@ -7316,7 +7316,7 @@
+ 
+ if ! test -s conftest.er1 || test -n "`grep successful conftest.er1`"  ; then
+  eval $CPP $CPPFLAGS conftest.F > conftest.${F90SUFFIX}
+- eval $FC $FCFLAGS -c conftest.${F90SUFFIX} 2> conftest.er2
++ eval $FC $FCFLAGS -c conftest.${F90SUFFIX} | grep -v "ifort: command line remark" 2> conftest.er2
+  if test -s conftest.er2 ; then
+   if ! test -n "`grep successful conftest.er2`"  ; then
+    acx_F90_ok=no ;

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.2.1_yambo-fixes.patch
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.2.1_yambo-fixes.patch
@@ -1,3 +1,7 @@
+* add --with-fftw* configure options such that EasyBuild provided FFTW is picked up
+* make sure -nofor_main is also used when $FC is defined as mpif90 for yambo
+* fix check in yambo configure script w.r.t. preprocessing Fortran code by ignoring harmless warning in stderr output
+author: Kenneth Hoste (HPC-UGent)
 --- espresso-5.2.1/install/plugins_makefile.orig	2015-09-24 09:26:40.000000000 +0200
 +++ espresso-5.2.1/install/plugins_makefile	2015-10-15 11:36:46.256246443 +0200
 @@ -289,6 +289,7 @@


### PR DESCRIPTION
requires https://github.com/hpcugent/easybuild-easyblocks/pull/714

Because the QE source URLs are sort of broken (don't yield a 404 on missing sources), the source files for QE need to be downloaded manually for now.

This shouldn't block this PR though. I made very sure that the right sources are being used by including checksums for all of them.