### PR TITLE
Drop GNU

### DIFF
--- a/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-GCC-4.9.3-binutils-2.25.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'Autoconf'
+version = '2.69'
+
+homepage = 'http://www.gnu.org/software/autoconf/'
+description = """Autoconf is an extensible package of M4 macros that produce shell scripts
+ to automatically configure software source code packages. These scripts can adapt the
+ packages to many kinds of UNIX-like systems without manual user intervention. Autoconf
+ creates a configuration script for a package from a template file that lists the
+ operating system features that the package can use, in the form of M4 macro calls."""
+
+toolchain = {'name': 'GCC', 'version': '4.9.3-binutils-2.25'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('M4', '1.4.17')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["autoconf", "autoheader", "autom4te", "autoreconf", "autoscan",
+                                     "autoupdate", "ifnames"]],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GCC-4.9.3-binutils-2.25.eb
@@ -1,0 +1,33 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'Automake'
+version = "1.15"
+
+homepage = 'http://www.gnu.org/software/automake/automake.html'
+description = "Automake: GNU Standards-compliant Makefile generator"
+
+toolchain = {'name': 'GCC', 'version': '4.9.3-binutils-2.25'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('Autoconf', '2.69')]
+
+sanity_check_paths = {
+    'files': ['bin/automake', 'bin/aclocal'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Autotools/Autotools-20150215-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/a/Autotools/Autotools-20150215-GCC-4.9.3-binutils-2.25.eb
@@ -1,0 +1,17 @@
+easyblock = 'Bundle'
+
+name = 'Autotools'
+version = '20150215'  # date of the most recent change
+
+homepage = 'http://autotools.io'
+description = """This bundle collect the standard GNU build tools: Autoconf, Automake and libtool"""
+
+toolchain = {'name': 'GCC', 'version': '4.9.3-binutils-2.25'}
+
+dependencies = [
+    ('Autoconf', '2.69'), # 20120424
+    ('Automake', '1.15'), # 20150105
+    ('libtool', '2.4.6'), # 20150215
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/f/foss/foss-2015b.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2015b.eb
@@ -29,9 +29,8 @@ comp_mpi_tc = (comp_mpi_tc_name, comp_mpi_tc_ver)
 # For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
 dependencies = [
     ('GCC', gccver, '-binutils-%s' % binutilsver),
-    ('binutils', binutilsver, '', ('GCC', tcver)),
-    ('OpenMPI', '1.8.8', '', ('GNU', '%s-%s' % (gccver, binutilsver))),
-    (blaslib, blasver, blassuff, ('GNU', '%s-%s' % (gccver, binutilsver))),
+    ('OpenMPI', '1.8.8', '', ('GCC', tcver)),
+    (blaslib, blasver, blassuff, ('GCC', tcver)),
     ('FFTW', '3.3.4', '', comp_mpi_tc),
     ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc),
 ]

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3-binutils-2.25.eb
@@ -25,7 +25,7 @@ sources = [
     'mpc-1.0.2.tar.gz',
 ]
 
-builddependencies = [('binutils', binutilsver)]
+dependencies = [('binutils', binutilsver)]
 
 patches = [('mpfr-%s-allpatches-20141204.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
 

--- a/easybuild/easyconfigs/g/GNU/GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/g/GNU/GNU-4.9.3-2.25.eb
@@ -14,7 +14,7 @@ dependencies = [
     # GCC built on top of (dummy-built) binutils
     ('GCC', gccver, '-binutils-%s' % binutilsver),
     # binutils built with system GCC, this is also loaded via a dependency in GCC
-    ('binutils', binutilsver, '', ('dummy', '')),
+    ('binutils', binutilsver, '', ('dummy', 'dummy')),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/GNU/GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/g/GNU/GNU-4.9.3-2.25.eb
@@ -13,8 +13,8 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 dependencies = [
     # GCC built on top of (dummy-built) binutils
     ('GCC', gccver, '-binutils-%s' % binutilsver),
-    # binutils built on top of GCC, which was built on top of (dummy-built) binutils
-    ('binutils', binutilsver, '', ('GCC', '%s-binutils-%s' % (gccver, binutilsver))),
+    # binutils built with system GCC, this is also loaded via a dependency in GCC
+    ('binutils', binutilsver, '', ('dummy', '')),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2015b.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2015b.eb
@@ -16,8 +16,7 @@ tcver = '%s-binutils-%s' % (gccver, binutilsver)
 # compiler toolchain dependencies
 dependencies = [
     ('GCC', gccver, '-binutils-%s' % binutilsver),
-    ('binutils', binutilsver, '', ('GCC', tcver)),
-    ('OpenMPI', '1.8.8', '', ('GNU', '%s-%s' % (gccver, binutilsver))),
+    ('OpenMPI', '1.8.8', '', ('GCC', tcver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.0-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.0-GCC-4.9.3-binutils-2.25.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'hwloc'
+version = '1.11.0'
+
+homepage = 'http://www.open-mpi.org/projects/hwloc/'
+description = """The Portable Hardware Locality (hwloc) software package provides a portable abstraction
+ (across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including
+ NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading. It also gathers various
+ system attributes such as cache and memory information as well as the locality of I/O devices such as
+ network interfaces, InfiniBand HCAs or GPUs. It primarily aims at helping applications with gathering
+ information about modern computing hardware so as to exploit it accordingly and efficiently."""
+
+toolchain = {'name': 'GCC', 'version': '4.9.3-binutils-2.25'}
+
+dependencies = [('numactl', '2.0.10')]
+
+configopts = "--enable-libnuma=$EBROOTNUMACTL"
+  
+source_urls = ['http://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/']
+sources = [SOURCE_TAR_GZ]
+
+moduleclass = 'system'

--- a/easybuild/easyconfigs/i/icc/icc-2015.3.187-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2015.3.187-GCC-4.9.3-binutils-2.25.eb
@@ -1,0 +1,24 @@
+name = 'icc'
+version = '2015.3.187'
+
+homepage = 'http://software.intel.com/en-us/intel-compilers/'
+description = "C and C++ compiler from Intel"
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = ['l_ccompxe_%(version)s.tgz']
+
+gnu = 'GCC'
+gnuver = '4.9.3-binutils-2.25'
+versionsuffix = '-%s-%s' % (gnu, gnuver)
+
+dependencies = [(gnu, gnuver)]
+
+dontcreateinstalldir = 'True'
+
+# license file
+import os
+license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+
+moduleclass = 'compiler'
+

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2015.3.187-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2015.3.187-GCC-4.9.3-binutils-2.25.eb
@@ -1,0 +1,17 @@
+easyblock = "Toolchain"
+
+name = 'iccifort'
+version = '2015.3.187'
+versionsuffix = '-GCC-4.9.3-binutils-2.25'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Intel C, C++ and Fortran compilers"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+dependencies = [
+    ('icc', version, versionsuffix),
+    ('ifort', version, versionsuffix),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/ifort/ifort-2015.3.187-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2015.3.187-GCC-4.9.3-binutils-2.25.eb
@@ -1,0 +1,23 @@
+name = 'ifort'
+version = '2015.3.187'
+
+homepage = 'http://software.intel.com/en-us/intel-compilers/'
+description = "Fortran compiler from Intel"
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = ['l_fcompxe_%(version)s.tgz']
+
+gnu = 'GCC'
+gnuver = '4.9.3-binutils-2.25'
+versionsuffix = '-%s-%s' % (gnu, gnuver)
+
+dependencies = [(gnu, gnuver)]
+
+dontcreateinstalldir = 'True'
+
+# license file
+import os
+license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/i/iimpi/iimpi-7.3.5-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-7.3.5-GCC-4.9.3-binutils-2.25.eb
@@ -1,0 +1,21 @@
+easyblock = "Toolchain"
+
+name = 'iimpi'
+version = '7.3.5'
+versionsuffix = '-GCC-4.9.3-binutils-2.25'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+suff = '3.187'
+compver = '2015.%s' % suff
+
+dependencies = [
+    ('icc', compver, versionsuffix),
+    ('ifort', compver, versionsuffix),
+    ('impi', '5.0.3.048', '', ('iccifort', '%s%s' % (compver, versionsuffix))),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.2.3.187-iimpi-7.3.5-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.2.3.187-iimpi-7.3.5-GCC-4.9.3-binutils-2.25.eb
@@ -1,0 +1,22 @@
+name = 'imkl'
+version = '11.2.3.187'
+
+homepage = 'http://software.intel.com/en-us/intel-mkl/'
+description = """Intel Math Kernel Library is a library of highly optimized,
+ extensively threaded math routines for science, engineering, and financial
+ applications that require maximum performance. Core math functions include
+ BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
+
+toolchain = {'name': 'iimpi', 'version': '7.3.5-GCC-4.9.3-binutils-2.25'}
+
+sources = ['l_mkl_%(version)s.tgz']
+
+dontcreateinstalldir = 'True'
+
+# license file
+import os
+license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+
+interfaces = True
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/i/impi/impi-5.0.3.048-iccifort-2015.3.187-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.0.3.048-iccifort-2015.3.187-GCC-4.9.3-binutils-2.25.eb
@@ -1,0 +1,22 @@
+name = 'impi'
+version = '5.0.3.048'
+
+homepage = 'http://software.intel.com/en-us/intel-mpi-library/'
+description = """The Intel(R) MPI Library for Linux* OS is a multi-fabric message
+ passing library based on ANL MPICH2 and OSU MVAPICH2. The Intel MPI Library for
+ Linux OS implements the Message Passing Interface, version 2 (MPI-2) specification."""
+
+toolchain = {'name': 'iccifort', 'version': '2015.3.187-GCC-4.9.3-binutils-2.25'}
+
+sources = ['l_mpi_p_%(version)s.tgz']
+
+dontcreateinstalldir = 'True'
+
+# license file
+import os
+license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+
+# set up all the mpi wrappers to work as expected with intel compilers (e.g. mpicc wraps icc not the default gcc)
+# set_mpi_wrappers_all = 'True' 
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/i/intel/intel-2015b.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2015b.eb
@@ -9,7 +9,7 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 compver = '2015.3.187'
-gccsuff = '-GNU-4.9.3-2.25'
+gccsuff = '-GCC-4.9.3-binutils-2.25'
 
 dependencies = [
     ('icc', compver, gccsuff),

--- a/easybuild/easyconfigs/l/libtool/libtool-2.4.6-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/l/libtool/libtool-2.4.6-GCC-4.9.3-binutils-2.25.eb
@@ -1,0 +1,17 @@
+easyblock = 'ConfigureMake'
+
+name = 'libtool'
+version = '2.4.6'
+
+homepage = 'http://www.gnu.org/software/libtool'
+description = """GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries
+ behind a consistent, portable interface."""
+
+toolchain = {'name': 'GCC', 'version': '4.9.3-binutils-2.25'} 
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [('M4', '1.4.17')]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/numactl/numactl-2.0.10-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/n/numactl/numactl-2.0.10-GCC-4.9.3-binutils-2.25.eb
@@ -1,0 +1,27 @@
+easyblock = 'ConfigureMake'
+
+name = 'numactl'
+version = '2.0.10'
+
+checksums = ['682c38305b2596967881f3d77bc3fc9c']
+
+homepage = 'http://oss.sgi.com/projects/libnuma/'
+description = """The numactl program allows you to run your application program on specific cpu's and memory nodes.
+ It does this by supplying a NUMA memory policy to the operating system before running your program.
+ The libnuma library provides convenient ways for you to add NUMA memory policies into your own program."""
+
+toolchain = {'name': 'GCC', 'version': '4.9.3-binutils-2.25'}
+
+source_urls = ['ftp://oss.sgi.com/www/projects/libnuma/download/']
+sources = [SOURCE_TAR_GZ]
+
+builddependencies = [('Autotools', '20150215')]
+
+preconfigopts = './autogen.sh && '
+
+sanity_check_paths = {
+    'files': ['bin/numactl', 'bin/numastat', 'lib/libnuma.so', 'lib/libnuma.a'],
+    'dirs': ['share/man', 'include']
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GCC-4.9.3-binutils-2.25-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.14-GCC-4.9.3-binutils-2.25-LAPACK-3.5.0.eb
@@ -1,0 +1,51 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenBLAS'
+version = '0.2.14'
+
+lapackver = '3.5.0'
+versionsuffix = '-LAPACK-%s' % lapackver
+
+homepage = 'http://xianyi.github.com/OpenBLAS/'
+description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
+
+toolchain = {'name': 'GCC', 'version': '4.9.3-binutils-2.25'}
+
+lapack_src = 'lapack-%s.tgz' % lapackver
+large_src = 'large.tgz'
+timing_src = 'timing.tgz'
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
+source_urls = [
+    # order matters, trying to download the LAPACK tarball from GitHub causes trouble
+    "http://www.netlib.org/lapack/",
+    "http://www.netlib.org/lapack/timing/",
+    "https://github.com/xianyi/OpenBLAS/archive/",
+]
+
+patches = [
+    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    (large_src, '.'),
+    (timing_src, '.'),
+]
+
+skipsteps = ['configure']
+
+buildopts = 'BINARY=64 USE_THREAD=1 CC="$CC" FC="$F77" NO_AFFINITY=1'
+installopts = "USE_THREAD=1 PREFIX=%(installdir)s"
+
+# extensive testing can be enabled by uncommenting the line below
+#runtest = 'PATH=.:$PATH lapack-timing'
+
+sanity_check_paths = {
+    'files': ['include/cblas.h', 'include/f77blas.h', 'include/lapacke_config.h', 'include/lapacke.h',
+              'include/lapacke_mangling.h', 'include/lapacke_utils.h', 'include/openblas_config.h',
+              'lib/libopenblas.a', 'lib/libopenblas.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.8.8-GCC-4.9.3-binutils-2.25.eb
@@ -1,0 +1,32 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '1.8.8'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'GCC', 'version': '4.9.3-binutils-2.25'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+
+dependencies = [('hwloc', '1.11.0')]
+
+configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+
+# needed for --with-verbs
+osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+
+libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2015b-OpenBLAS-0.2.14-LAPACK-3.5.0.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2015b-OpenBLAS-0.2.14-LAPACK-3.5.0.eb
@@ -17,7 +17,7 @@ blassuff = '-LAPACK-3.5.0'
 
 versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
 
-dependencies = [(blaslib, blasver, blassuff, ('GNU', '4.9.3-2.25'))]
+dependencies = [(blaslib, blasver, blassuff, ('GCC', '4.9.3-binutils-2.25'))]
 
 ## parallel build tends to fail, so disabling it
 parallel = 1


### PR DESCRIPTION
The argument goes (from @geimer originally) that since `binutils` uses machine code, it doesn't matter how you build binutils. In that case, there's no need to introduce the obfuscation layer `GNU`, simply explicitly list `binutils` as a dependency of `GCC`. 

This allows the `GCC` module to work out-of-the-box when building arch-optimised code.