### PR TITLE
don't use 'beta' in commented out line in hanythingondemand easyconfigs

### DIFF
--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.0-cli.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-3.0.0-cli.eb
@@ -30,8 +30,8 @@ options = {'modulename': 'hod'}
 modextravars = {
     # site-specific settings, hence commented out
     # specify HOD module to use in jobs (*full* HOD installation, not a minimal one)
-    #'HOD_BATCH_HOD_MODULE': 'hanythingondemand/%(version)s-beta-intel-2015b-Python-2.7.10',
-    #'HOD_CREATE_HOD_MODULE': 'hanythingondemand/%(version)s-beta-intel-2015b-Python-2.7.10',
+    #'HOD_BATCH_HOD_MODULE': 'hanythingondemand/%(version)s-intel-2015b-Python-2.7.10',
+    #'HOD_CREATE_HOD_MODULE': 'hanythingondemand/%(version)s-intel-2015b-Python-2.7.10',
     # specify location on shared 'scratch' filesystem for HOD working directories
     #'HOD_BATCH_WORKDIR': '\$VSC_SCRATCH/hod',
     #'HOD_CREATE_WORKDIR': '\$VSC_SCRATCH/hod',


### PR DESCRIPTION
matters little since it's commented out, but we were bitten by this in our local install after just commenting out these lines...