### PR TITLE
Add BEDTools 2.25.0 for FOSS 2015a

### DIFF
--- a/easybuild/easyconfigs/b/BEDTools/BEDTools-2.25.0-foss-2015a.eb
+++ b/easybuild/easyconfigs/b/BEDTools/BEDTools-2.25.0-foss-2015a.eb
@@ -1,0 +1,33 @@
+# Author: Maxime Schmitt, University of Luxembourg
+# Author: Adam Huffman, The Francis Crick Institute 
+#
+# Based on the work of: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics (SIB)
+# Biozentrum - University of Basel
+
+easyblock = 'MakeCp'
+
+name = 'BEDTools'
+version = '2.25.0'
+
+homepage = "https://github.com/arq5x/bedtools2"
+description = """The BEDTools utilities allow one to address common genomics tasks such as finding feature overlaps
+ and computing coverage. The utilities are largely based on four widely-used file formats: BED, GFF/GTF, VCF,
+ and SAM/BAM."""
+
+toolchain = {'name': 'foss', 'version': '2015a'}
+
+# https://github.com/arq5x/bedtools2/releases/download/v2.25.0/bedtools-2.25.0.tar.gz
+source_urls = ['https://github.com/arq5x/bedtools2/releases/download/v%(version)s/']
+sources = ['bedtools-%(version)s.tar.gz']
+
+buildopts = 'CXX="$CXX"'
+
+files_to_copy = ["bin", "docs", "data", "genomes", "scripts", "test"]
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['bedtools', 'pairToBed', 'mergeBed','bedToBam','fastaFromBed']],
+    'dirs': files_to_copy,
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
Simple port of 2.25.0 BEDTools to the FOSS 2015a toolchain.