### PR TITLE
add patch for Tk 8.6.4 to fix problem with tk.tcl not being found

### DIFF
--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-GNU-4.9.3-2.25-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-GNU-4.9.3-2.25-no-X11.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'GNU', 'version': '4.9.3-2.25'}
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
 
+patches = ['Tk-%(version)s_different-prefix-with-tcl.patch']
+
 dependencies = [
     ('Tcl', version),
 ]

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2015a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2015a-no-X11.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
 
+patches = ['Tk-%(version)s_different-prefix-with-tcl.patch']
+
 dependencies = [
     ('Tcl', version),
 ]

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2015b-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2015b-no-X11.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'foss', 'version': '2015b'}
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
 
+patches = ['Tk-%(version)s_different-prefix-with-tcl.patch']
+
 dependencies = [
     ('Tcl', version),
 ]

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-goolf-1.4.10-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-goolf-1.4.10-no-X11.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
 
+patches = ['Tk-%(version)s_different-prefix-with-tcl.patch']
+
 dependencies = [
     ('Tcl', version),
 ]

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-goolf-1.7.20-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-goolf-1.7.20-no-X11.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'goolf', 'version': '1.7.20'}
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
 
+patches = ['Tk-%(version)s_different-prefix-with-tcl.patch']
+
 dependencies = [
     ('Tcl', version),
 ]

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-ictce-7.3.5-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-ictce-7.3.5-no-X11.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'ictce', 'version': '7.3.5'}
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
 
+patches = ['Tk-%(version)s_different-prefix-with-tcl.patch']
+
 dependencies = [
     ('Tcl', version),
 ]

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2015a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2015a-no-X11.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
 
+patches = ['Tk-%(version)s_different-prefix-with-tcl.patch']
+
 dependencies = [
     ('Tcl', version),
 ]

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2015b-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2015b-no-X11.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'intel', 'version': '2015b'}
 source_urls = ["http://prdownloads.sourceforge.net/tcl"]
 sources = ['%(namelower)s%(version)s-src.tar.gz']
 
+patches = ['Tk-%(version)s_different-prefix-with-tcl.patch']
+
 dependencies = [
     ('Tcl', version),
 ]

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4_different-prefix-with-tcl.patch
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4_different-prefix-with-tcl.patch
@@ -1,0 +1,27 @@
+fix for:
+    _tkinter.TclError: Can't find a usable tk.tcl in the following directories: ...
+based on https://github.com/NixOS/nixpkgs/commit/decd2feb0a1bc80940e697fa66e3b25383360c30
+see also https://github.com/NixOS/nixpkgs/issues/1479
+author: Kenneth Hoste (HPC-UGent)
+--- tk8.6.4/unix/Makefile.in.orig	2015-10-29 18:57:12.213525347 +0100
++++ tk8.6.4/unix/Makefile.in	2015-10-29 19:06:19.397015702 +0100
+@@ -1029,7 +1029,8 @@
+ 	$(CC) -c $(CC_SWITCHES) $(GENERIC_DIR)/tkVisual.c
+ 
+ tkWindow.o: $(GENERIC_DIR)/tkWindow.c
+-	$(CC) -c $(CC_SWITCHES) $(GENERIC_DIR)/tkWindow.c
++	$(CC) -c $(CC_SWITCHES) -DTK_LIBRARY=\"${TK_LIBRARY}\" \
++       $(GENERIC_DIR)/tkWindow.c
+ 
+ tkButton.o: $(GENERIC_DIR)/tkButton.c
+ 	$(CC) -c $(CC_SWITCHES) $(GENERIC_DIR)/tkButton.c
+--- tk8.6.4/generic/tkWindow.c.orig	2015-10-29 18:57:12.213525347 +0100
++++ tk8.6.4/generic/tkWindow.c	2015-10-29 19:03:30.156190540 +0100
+@@ -988,6 +988,7 @@
+ 
+     Tcl_SetVar2(interp, "tk_patchLevel", NULL, TK_PATCH_LEVEL, TCL_GLOBAL_ONLY);
+     Tcl_SetVar2(interp, "tk_version",    NULL, TK_VERSION,     TCL_GLOBAL_ONLY);
++    Tcl_SetVar2(interp, "tk_library",    NULL, TK_LIBRARY,     TCL_GLOBAL_ONLY);
+ 
+     tsdPtr->numMainWindows++;
+     return tkwin;


### PR DESCRIPTION
fix for

```
    window = Tk.Tk()
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/CO7/haswell-ib/software/Python/2.7.10-intel-2015b/lib/python2.7/lib-tk/Tkinter.py", line 1814, in __init__
    self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
_tkinter.TclError: Can't find a usable tk.tcl in the following directories: 
    /user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/CO7/haswell-ib/software/Tcl/8.6.4-intel-2015b/lib/tcl8.6/tk8.6 /user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/CO7/haswell-ib/software/Tcl/8.6.4-intel-2015b/lib/tk8.6 /user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/CO7/haswell-ib/software/Python/2.7.10-intel-2015b/lib/tk8.6 /user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/CO7/haswell-ib/software/Python/lib/tk8.6 /user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/CO7/haswell-ib/software/Python/2.7.10-intel-2015b/library
```

see also https://github.com/hpcugent/easybuild-easyblocks/issues/728#issuecomment-152257327