### PR TITLE
{devel} [GCC] GCC made binutils a dependency for GCC instead of a buildependency

### DIFF
--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3-binutils-2.25-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3-binutils-2.25-GCC-4.9.3.eb
@@ -2,7 +2,8 @@ name = "GCC"
 version = '4.9.3'
 
 binutilsver = '2.25'
-versionsuffix = '-binutils-%s' % binutilsver
+binutilsversuffix = '-%s-%s' % (name, version)
+versionsuffix = '-binutils-%s%s' % (binutilsver, binutilsversuffix)
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -25,7 +26,7 @@ sources = [
     'mpc-1.0.2.tar.gz',
 ]
 
-builddependencies = [('binutils', binutilsver)]
+dependencies = [('binutils', binutilsver, binutilsversuffix)]
 
 patches = [('mpfr-%s-allpatches-20141204.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3-binutils-2.25.eb
@@ -25,7 +25,7 @@ sources = [
     'mpc-1.0.2.tar.gz',
 ]
 
-builddependencies = [('binutils', binutilsver)]
+dependencies = [('binutils', binutilsver)]
 
 patches = [('mpfr-%s-allpatches-20141204.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
 


### PR DESCRIPTION
g++ is broken if this binutils isn't loaded
```
-bash-4.1$ cat test.cpp
#include <cstdlib>

int main()
{
return 0;
}
-bash-4.1$ module load GCC
-bash-4.1$ module list
Currently Loaded Modulefiles:
  1) cluster/delcatty(default)   2) GCC/4.9.3-binutils-2.25
-bash-4.1$ g++ test.cpp 
collect2: fatal error: cannot find 'ld'
compilation terminated.
-bash-4.1$ module load binutils
-bash-4.1$ module list
Currently Loaded Modulefiles:
  1) cluster/delcatty(default)               2) GCC/4.9.3-binutils-2.25                 3) binutils/2.25-GCC-4.9.3-binutils-2.25
-bash-4.1$ g++ test.cpp 
```