### PR TITLE
Updated CUDA easyconfig

### DIFF
--- a/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
@@ -1,0 +1,20 @@
+name = 'CUDA'
+version = '7.5.18'
+
+homepage = 'https://developer.nvidia.com/cuda-toolkit'
+description = """CUDA (formerly Compute Unified Device Architecture) is a parallel
+ computing platform and programming model created by NVIDIA and implemented by the
+ graphics processing units (GPUs) that they produce. CUDA gives developers access
+ to the virtual instruction set and memory of the parallel computational elements in CUDA GPUs."""
+
+toolchain = {'name': 'iccifort', 'version': '2015.3.187-GNU-4.9.3-2.25'}
+
+source_urls = ['http://developer.download.nvidia.com/compute/cuda/%(version_major_minor)s/Prod/local_installers/']
+
+sources = ['%(namelower)s_%(version)s_linux.run']
+checksums = [('md5', '4b3bcecf0dfc35928a0898793cf3e4c6')]
+
+moduleclass = 'system'
+
+generate_wrapper = True
+default_host_compiler = 'icpc'

--- a/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
@@ -1,8 +1,10 @@
 ##
 # This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
 #
-# Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB, Ghent University
+# Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB, Ghent University,
+# Forschungszentrum Juelich
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>, Kenneth Hoste
+# Damian Alvarez <d.alvarez@fz-juelich.de>
 # License::   MIT/GPL
 # $Id$
 #
@@ -21,20 +23,22 @@ description = """CUDA (formerly Compute Unified Device Architecture) is a parall
  graphics processing units (GPUs) that they produce. CUDA gives developers access
  to the virtual instruction set and memory of the parallel computational elements in CUDA GPUs."""
 
-toolchain = {'name': 'iccifort', 'version': '2015.3.187-GCC-bare-4.9.3'}
+toolchain = {'name': 'iccifort', 'version': '2015.3.187-GNU-4.9.3-2.25'}
 
-# eg. http://developer.download.nvidia.com/compute/cuda/6_5/rel/installers/cuda_6.5.14_linux_64.run
-#source_urls = ['http://developer.download.nvidia.com/compute/cuda/7_5/rel/installers/']
 source_urls = ['http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/']
 
 sources = ['%(namelower)s_%(version)s_linux.run']
-checksums = [('md5', '4b3bcecf0dfc35928a0898793cf3e4c6')]
+checksums = ['4b3bcecf0dfc35928a0898793cf3e4c6']
 
+# Necessary to allow to use a GCC 4.9.3 toolchain, as CUDA by default just supports up to 4.9.2.
+# Tested, but not throughly, so it is not guaranteed to don't cause problems
 installopts = '-override compiler'
-
-moduleclass = 'system'
 
 generate_intel_wrapper = True
 
 # Be careful and have a message consistent with the wrappers present
-modloadmsg = """nvcc uses g++ as the default host compiler. If you want to use icpc as a host compiler you can use invcc, or nvcc -ccbin=icpc"""
+modloadmsg = """nvcc uses g++ as the default host compiler. If you want to use icpc as a host compiler you can use"
++" invcc, or nvcc -ccbin=icpc"""
+
+moduleclass = 'system'
+

--- a/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
@@ -34,11 +34,12 @@ checksums = ['4b3bcecf0dfc35928a0898793cf3e4c6']
 # Tested, but not throughly, so it is not guaranteed to don't cause problems
 installopts = '-override compiler'
 
-generate_intel_wrapper = True
+generate_wrapper = True
+host_compiler = "icpc"
 
 # Be careful and have a message consistent with the wrappers present
-modloadmsg = """nvcc uses g++ as the default host compiler. If you want to use icpc as a host compiler you can use"
-+" invcc, or nvcc -ccbin=icpc"""
+modloadmsg = "nvcc uses g++ as the default host compiler. If you want to use icpc as a host compiler you can use"
+modloadmsg += " nvcc_icpc, or nvcc -ccbin=icpc"
 
 moduleclass = 'system'
 

--- a/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
@@ -1,3 +1,17 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB, Ghent University
+# Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>, Kenneth Hoste
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-99.html
+##
+
+#easyblock = 'ConfigureMake'
+
 name = 'CUDA'
 version = '7.5.18'
 
@@ -7,14 +21,20 @@ description = """CUDA (formerly Compute Unified Device Architecture) is a parall
  graphics processing units (GPUs) that they produce. CUDA gives developers access
  to the virtual instruction set and memory of the parallel computational elements in CUDA GPUs."""
 
-toolchain = {'name': 'iccifort', 'version': '2015.3.187-GNU-4.9.3-2.25'}
+toolchain = {'name': 'iccifort', 'version': '2015.3.187-GCC-bare-4.9.3'}
 
-source_urls = ['http://developer.download.nvidia.com/compute/cuda/%(version_major_minor)s/Prod/local_installers/']
+# eg. http://developer.download.nvidia.com/compute/cuda/6_5/rel/installers/cuda_6.5.14_linux_64.run
+#source_urls = ['http://developer.download.nvidia.com/compute/cuda/7_5/rel/installers/']
+source_urls = ['http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/']
 
 sources = ['%(namelower)s_%(version)s_linux.run']
 checksums = [('md5', '4b3bcecf0dfc35928a0898793cf3e4c6')]
 
+installopts = '-override compiler'
+
 moduleclass = 'system'
 
-generate_wrapper = True
-default_host_compiler = 'icpc'
+generate_intel_wrapper = True
+
+# Be careful and have a message consistent with the wrappers present
+modloadmsg = """nvcc uses g++ as the default host compiler. If you want to use icpc as a host compiler you can use invcc, or nvcc -ccbin=icpc"""

--- a/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
@@ -41,4 +41,3 @@ modloadmsg = "nvcc uses g++ as the default host compiler. If you want to use icp
 modloadmsg += " nvcc_icpc, or nvcc -ccbin=icpc. Likewise, a g++ wrapper called nvcc_g++ has been also created."
 
 moduleclass = 'system'
-

--- a/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
@@ -4,7 +4,7 @@
 # Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB, Ghent University,
 # Forschungszentrum Juelich
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>, Kenneth Hoste
-# Damian Alvarez <d.alvarez@fz-juelich.de>
+# Authors::   Damian Alvarez <d.alvarez@fz-juelich.de>
 # License::   MIT/GPL
 # $Id$
 #

--- a/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
@@ -25,7 +25,7 @@ description = """CUDA (formerly Compute Unified Device Architecture) is a parall
 
 toolchain = {'name': 'iccifort', 'version': '2015.3.187-GNU-4.9.3-2.25'}
 
-source_urls = ['http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/']
+source_urls = ['http://developer.download.nvidia.com/compute/cuda/%(version_major_minor)s/Prod/local_installers/']
 
 sources = ['%(namelower)s_%(version)s_linux.run']
 checksums = ['4b3bcecf0dfc35928a0898793cf3e4c6']

--- a/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-7.5.18-iccifort-2015.3.187-GNU-4.9.3-2.25.eb
@@ -34,12 +34,11 @@ checksums = ['4b3bcecf0dfc35928a0898793cf3e4c6']
 # Tested, but not throughly, so it is not guaranteed to don't cause problems
 installopts = '-override compiler'
 
-generate_wrapper = True
-host_compiler = "icpc"
+host_compilers = ["icpc", "g++"]
 
-# Be careful and have a message consistent with the wrappers present
+# Be careful and have a message consistent with the generated wrappers
 modloadmsg = "nvcc uses g++ as the default host compiler. If you want to use icpc as a host compiler you can use"
-modloadmsg += " nvcc_icpc, or nvcc -ccbin=icpc"
+modloadmsg += " nvcc_icpc, or nvcc -ccbin=icpc. Likewise, a g++ wrapper called nvcc_g++ has been also created."
 
 moduleclass = 'system'
 


### PR DESCRIPTION
This PR include an easyconfig for CUDA+iccifort. It creates a wrapper for nvcc using the Intel compiler. It requires the changes made in ~~hpcugent/easybuild-easyblocks/pull/758~~