### PR TITLE
Update all libreadline easyconfig to link to ncurses

### DIFF
--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmpolf-1.1.6.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmpolf-1.1.6.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9-20130406')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmvolf-1.1.12rc1.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmvolf-1.1.12rc1.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9-20130406')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmvolf-1.2.7.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmvolf-1.2.7.eb
@@ -15,9 +15,10 @@ toolchainopts = {'pic': True}
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']
 
-dependencies = [
-    ('ncurses', '5.9-20130406'),
-]
+dependencies = [('ncurses', '5.9-20130406')]
+
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgoolf-1.1.7.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgoolf-1.1.7.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9-20130406')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmpolf-1.4.8.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmpolf-1.4.8.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmvolf-1.7.12.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmvolf-1.7.12.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9-20130406')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmvolf-1.7.12rc1.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmvolf-1.7.12rc1.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9-20130406')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goalf-1.1.0-no-OFED.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goalf-1.5.12-no-OFED.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goalf-1.5.12-no-OFED.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gompi-1.4.12-no-OFED.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goolf-1.4.10.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goolf-1.5.14.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.0.10.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.0.10.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.0.6.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.1.13.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.2.0.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.3.0.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.5.0.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-intel-2015a.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iomkl-4.6.13.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iomkl-4.6.13.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iqacml-3.7.3.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iqacml-4.4.13.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iqacml-4.4.13.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-CrayGNU-5.1.29.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-CrayGNU-5.1.29.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-CrayGNU-5.2.25.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-CrayGNU-5.2.25.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-CrayGNU-5.2.40.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-CrayGNU-5.2.40.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GCC-4.8.2.eb
@@ -16,6 +16,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GCC-4.9.2.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GNU-4.9.3-2.25.eb
@@ -15,9 +15,10 @@ toolchainopts = {'pic': True}
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']
 
-preconfigopts = " LDFLAGS='-ltinfo' "
-
 dependencies = [('ncurses', '5.9')]
+
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2014b.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2014b.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015.05.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015.05.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015a.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015a.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015b.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015b.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-gimkl-2.11.5.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-gompi-1.5.16.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-gompi-1.5.16.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-goolf-1.4.10.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-goolf-1.5.14.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-goolf-1.7.20.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-6.2.5.eb
@@ -19,6 +19,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +
              ['include/readline/%s' % x for x in

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-6.3.5.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-6.3.5.eb
@@ -19,6 +19,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +
              ['include/readline/%s' % x for x in

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-7.1.2.eb
@@ -15,9 +15,10 @@ toolchainopts = {'pic': True}
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']
 
-preconfigopts = " LDFLAGS='-ltinfo' "
-
 dependencies = [('ncurses', '5.9')]
+
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-7.3.5.eb
@@ -15,9 +15,10 @@ toolchainopts = {'pic': True}
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']
 
-preconfigopts = " LDFLAGS='-ltinfo' "
-
 dependencies = [('ncurses', '5.9')]
+
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2014.06.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2014.06.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2014b.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2014b.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2015a.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2015b.eb
@@ -17,6 +17,9 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 
 dependencies = [('ncurses', '5.9')]
 
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
               ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',


### PR DESCRIPTION
The full explanation for this can be found in issue #1315.

libreadline needs some terminal info. It can get this from libtermcap or
ncurses, which are (as far as I understand it) API but not ABI
compatible. On most (=all the ones I looked at) systems, libtermcap just
gives a redirect to libtinfo. This libraries is created by splitting a
part of the main ncurses library because most program only need this and
not full ncurses. In EB we don't do this and it's one big fat library.
Also, libreadline and ncurses don't mix. It's next to impossible to use
both of them in the same code.

The idea is that, the code that uses libreadline can choose which
termcap library to use, either libtermcap or ncurses. But as said
before, on most distro's the leads to the same library.

So, my proposed solution is: we explicitly link libreadline to ncurses.
This will definitely solve the problem in this PR but I'm not entirely
sure about potential fallout. It seems like most EB stuff already links
to ncurses when using libreadline. I'm still guessing about why this
issue does not pop up in RHEL (and derivates) but on Debian we do hit
it.

Relevant bugreport: https://bugzilla.redhat.com/show_bug.cgi?id=499837