### PR TITLE
{geo}[intel/2015b] ALADIN 36t1_op2bf1 (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/a/ALADIN/ALADIN-36t1_op2bf1-intel-2015b.eb
+++ b/easybuild/easyconfigs/a/ALADIN/ALADIN-36t1_op2bf1-intel-2015b.eb
@@ -1,0 +1,33 @@
+name = 'ALADIN'
+version = '36t1_op2bf1'
+
+homepage = 'http://www.cnrm.meteo.fr/aladin/'
+description = """ALADIN was entirely built on the notion of compatibility with its mother system, IFS/ARPEG.
+ The latter, a joint development between the European Centre for Medium-Range Weather Forecasts (ECMWF) and
+ Meteo-France, was only meant to consider global Numerical Weather Prediction applications; hence the idea,
+ for ALADIN, to complement the IFS/ARPEGE project with a limited area model (LAM) version, while keeping the
+ differences between the two softwares as small as possible."""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+toolchainopts = {'usempi': False}
+
+sources = [
+    'cy%(version)s.tgz',
+    'gmkpack.6.5.0.tgz',
+    'auxlibs_installer.2.0.tgz',
+]
+
+patches = [
+    'ALADIN_ictce-clim_import-export.patch',
+    'gmkpack_multi-lib.patch',
+]
+
+dependencies = [
+    ('JasPer', '1.900.1'),
+    ('grib_api', '1.14.4'),
+    ('netCDF', '4.3.3.1'),
+    ('netCDF-Fortran', '4.4.2'),
+]
+builddependencies = [('Bison', '3.0.4')]
+
+moduleclass = 'geo'

--- a/easybuild/easyconfigs/a/ALADIN/ALADIN-36t1_op2bf1-intel-2015b.eb
+++ b/easybuild/easyconfigs/a/ALADIN/ALADIN-36t1_op2bf1-intel-2015b.eb
@@ -9,7 +9,7 @@ description = """ALADIN was entirely built on the notion of compatibility with i
  differences between the two softwares as small as possible."""
 
 toolchain = {'name': 'intel', 'version': '2015b'}
-toolchainopts = {'usempi': False}
+toolchainopts = {'usempi': True}
 
 sources = [
     'cy%(version)s.tgz',
@@ -29,5 +29,8 @@ dependencies = [
     ('netCDF-Fortran', '4.4.2'),
 ]
 builddependencies = [('Bison', '3.0.4')]
+
+# too parallel makes the build very slow
+maxparallel = 3
 
 moduleclass = 'geo'

--- a/easybuild/easyconfigs/a/ALADIN/ALADIN_ictce-clim_import-export.patch
+++ b/easybuild/easyconfigs/a/ALADIN/ALADIN_ictce-clim_import-export.patch
@@ -1,8 +1,8 @@
 patch out unreachable code that yields linking problems (CLIM_IMPORT and CLIM_EXPORT are not available)
 CPHAN is hard coded to 'SIPC' in arp/module/yom_oas.F90
 this code is optimized out by gfortran, but not by ifort
---- ../arp/climate/updcpl.F90.orig	2012-12-29 09:58:32.004452610 +0100
-+++ ../arp/climate/updcpl.F90	2012-12-29 09:58:53.836681331 +0100
+--- arp/climate/updcpl.F90.orig	2012-12-29 09:58:32.004452610 +0100
++++ arp/climate/updcpl.F90	2012-12-29 09:58:53.836681331 +0100
 @@ -311,16 +311,16 @@
  
          CALL SIPC_READ_MODEL(JV,NGPTOTG,CLJOBNAM_R,INFOS,ZFIELDBUF)
@@ -30,8 +30,8 @@ this code is optimized out by gfortran, but not by ifort
        ENDIF
  
        CALL DISGRID_SEND(1,ZFIELDBUF,INUM,ZFIELD(:,JV))
---- ../arp/ocean/wrcpl.F90.orig	2012-12-29 10:02:50.736177120 +0100
-+++ ../arp/ocean/wrcpl.F90	2012-12-29 10:02:53.733208569 +0100
+--- arp/ocean/wrcpl.F90.orig	2012-12-29 10:02:50.736177120 +0100
++++ arp/ocean/wrcpl.F90	2012-12-29 10:02:53.733208569 +0100
 @@ -183,9 +183,9 @@
        IF (CPHAN == 'SIPC') THEN
          CALL SIPC_WRITE_MODEL(INDEX1,IDIMG,INFOS,ZREALG)

--- a/easybuild/easyconfigs/g/grib_api/grib_api-1.14.4-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/grib_api/grib_api-1.14.4-intel-2015b.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = 'grib_api'
+version = '1.14.4'
+
+homepage = 'https://software.ecmwf.int/wiki/display/GRIB/Home'
+description = """The ECMWF GRIB API is an application program interface accessible from C, FORTRAN and Python
+ programs developed for encoding and decoding WMO FM-92 GRIB edition 1 and edition 2 messages. A useful set of
+ command line tools is also provided to give quick access to GRIB messages."""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+
+source_urls = ['https://software.ecmwf.int/wiki/download/attachments/3473437/']
+sources = ['grib_api-%(version)s-Source.tar.gz']
+
+dependencies = [
+    ('JasPer', '1.900.1'),
+]
+
+configopts = '--with-jasper=$EBROOTJASPER'
+
+parallel = 1
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/j/JasPer/JasPer-1.900.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/j/JasPer/JasPer-1.900.1-intel-2015b.eb
@@ -1,0 +1,21 @@
+easyblock = 'ConfigureMake'
+
+name = 'JasPer'
+version = '1.900.1'
+
+homepage = 'http://www.ece.uvic.ca/~frodo/jasper/'
+description = """The JasPer Project is an open-source initiative to provide a free
+ software-based reference implementation of the codec specified in the JPEG-2000 Part-1 standard."""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_ZIP]
+source_urls = ['http://www.ece.uvic.ca/~frodo/jasper/software/']
+
+sanity_check_paths = {
+    'files': ["bin/jasper", "lib/libjasper.a"],
+    'dirs': ["include"],
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
requires ~~#2203~~

requires https://github.com/hpcugent/easybuild-easyblocks/pull/764

patch files was updated because recent versions of `patch` commands flag relative paths like `../arp/climate/updcpl.F90` potentially harmful, and refuse to apply the patch file