### PR TITLE
reorder sources in ALADIN easyconfigs because of changed patch file

### DIFF
--- a/easybuild/easyconfigs/a/ALADIN/ALADIN-36t1_op2bf1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/a/ALADIN/ALADIN-36t1_op2bf1-goalf-1.1.0-no-OFED.eb
@@ -12,10 +12,10 @@ toolchain = {'name': 'goalf', 'version': '1.1.0-no-OFED'}
 toolchainopts = {'usempi': True}
 
 sources = [
-           'gmkpack.6.5.0.tgz',
-           'auxlibs_installer.2.0.tgz',
-           'cy%s.tgz' % version
-          ]
+    'cy%(version)s.tgz',
+    'gmkpack.6.5.0.tgz',
+    'auxlibs_installer.2.0.tgz',
+]
 
 patches = ['gmkpack_multi-lib.patch']
 

--- a/easybuild/easyconfigs/a/ALADIN/ALADIN-36t1_op2bf1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/a/ALADIN/ALADIN-36t1_op2bf1-goolf-1.4.10.eb
@@ -12,10 +12,10 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 toolchainopts = {'usempi': True}
 
 sources = [
-           'gmkpack.6.5.0.tgz',
-           'auxlibs_installer.2.0.tgz',
-           'cy%s.tgz' % version
-          ]
+    'cy%(version)s.tgz',
+    'gmkpack.6.5.0.tgz',
+    'auxlibs_installer.2.0.tgz',
+]
 
 patches = ['gmkpack_multi-lib.patch']
 

--- a/easybuild/easyconfigs/a/ALADIN/ALADIN-36t1_op2bf1-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/a/ALADIN/ALADIN-36t1_op2bf1-ictce-4.1.13.eb
@@ -12,15 +12,16 @@ toolchain = {'name': 'ictce', 'version': '4.1.13'}
 toolchainopts = {'usempi': False}
 
 sources = [
-           'gmkpack.6.5.0.tgz',
-           'auxlibs_installer.2.0.tgz',
-           'cy%s.tgz' % version
-          ]
+    'cy%(version)s.tgz',
+    'gmkpack.6.5.0.tgz',
+    'auxlibs_installer.2.0.tgz',
+]
 
 patches = [
-           'gmkpack_multi-lib.patch',
-           'ALADIN_ictce-clim_import-export.patch'
-          ]
+    'ALADIN_ictce-clim_import-export.patch',
+    'gmkpack_multi-lib.patch',
+
+]
 
 dependencies = [
     ('JasPer', '1.900.1'),

--- a/easybuild/easyconfigs/a/ALADIN/ALADIN-36t1_op2bf1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/a/ALADIN/ALADIN-36t1_op2bf1-ictce-5.3.0.eb
@@ -13,15 +13,15 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'usempi': False}
 
 sources = [
-           'gmkpack.6.5.0.tgz',
-           'auxlibs_installer.2.0.tgz',
-           'cy%s.tgz' % version
-          ]
+    'cy%(version)s.tgz',
+    'gmkpack.6.5.0.tgz',
+    'auxlibs_installer.2.0.tgz',
+]
 
 patches = [
-           'gmkpack_multi-lib.patch',
-           'ALADIN_ictce-clim_import-export.patch'
-          ]
+    'ALADIN_ictce-clim_import-export.patch',
+    'gmkpack_multi-lib.patch',
+]
 
 dependencies = [
     ('JasPer', '1.900.1'),


### PR DESCRIPTION
changes made to patch file, that were done because newer versions of the `patch` command are not fond of relative paths in patch files, require that the list of sources in ALADIN easyconfigs are reordered 

This is required because the first source file determines the subdir in which the patch is applied.
