### PR TITLE
{bundle}[dummy] GCC-4.9.3-2.25: bundle of GCCcore 4.9.3 and binutils 2.25

### DIFF
--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.4-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.4-GCCcore-4.9.3.eb
@@ -1,0 +1,27 @@
+easyblock = 'ConfigureMake'
+
+name = 'Bison'
+version = '3.0.4'
+
+homepage = 'http://www.gnu.org/software/bison'
+description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
+ into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+builddependencies = [
+    ('M4', '1.4.17'),
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.25', '', True),
+]
+
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["bison", "yacc"]] + ["lib/liby.a"],
+    'dirs': [],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCCcore-4.9.3.eb
@@ -1,0 +1,40 @@
+easyblock = 'ConfigureMake'
+
+name = 'binutils'
+version = '2.25'
+
+homepage = 'http://directory.fsf.org/project/binutils/'
+description = "binutils: GNU binary utilities"
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+builddependencies = [
+    ('flex', '2.5.39'),
+    ('Bison', '3.0.4'),
+    # zlib required, but being linked instatically, so not a runtime dep
+    ('zlib', '1.2.8'),
+    # use same binutils version that was used when building GCC toolchain, to 'bootstrap' this binutils
+    ('binutils', version, '', True)
+]
+
+# statically link with zlib, to avoid runtime dependency on zlib
+preconfigopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+
+# make sure that system libraries are also considered by ld and ld.gold is also built
+# --enable-plugins should be used whenever --enable-gold is used, see http://llvm.org/docs/GoldPlugin.html
+configopts = '--with-sysroot=/ --enable-gold --enable-ld=default --enable-plugins'
+
+binlist = ['addr2line', 'ar', 'as', 'c++filt', 'elfedit', 'gprof', 'ld', 'ld.bfd', 'ld.gold', 'nm',
+           'objcopy', 'objdump', 'ranlib', 'readelf', 'size', 'strings', 'strip' ]
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in binlist] + ['lib/libbfd.a', 'lib/libopcodes.a'] +
+             ['include/%s' % x for x in ['ansidecl.h', 'bfd.h', 'bfdlink.h', 'dis-asm.h', 'symcat.h']],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCCcore-4.9.3.eb
@@ -26,13 +26,14 @@ prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
 
 # make sure that system libraries are also considered by ld and ld.gold is also built
 # --enable-plugins should be used whenever --enable-gold is used, see http://llvm.org/docs/GoldPlugin.html
-configopts = '--with-sysroot=/ --enable-gold --enable-ld=default --enable-plugins'
+configopts = '--with-sysroot=/ --enable-gold --enable-ld=default --enable-plugins  --enable-shared --enable-static'
 
 binlist = ['addr2line', 'ar', 'as', 'c++filt', 'elfedit', 'gprof', 'ld', 'ld.bfd', 'ld.gold', 'nm',
            'objcopy', 'objdump', 'ranlib', 'readelf', 'size', 'strings', 'strip' ]
 
 sanity_check_paths = {
-    'files': ['bin/%s' % x for x in binlist] + ['lib/libbfd.a', 'lib/libopcodes.a'] +
+    'files': ['bin/%s' % x for x in binlist] +
+             ['lib/lib%s.%s' % (l, x) for l in ['bfd', 'opcodes'] for x in ['a', SHLIB_EXT]] +
              ['include/%s' % x for x in ['ansidecl.h', 'bfd.h', 'bfdlink.h', 'dis-asm.h', 'symcat.h']],
     'dirs': [],
 }

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCCcore-4.9.3.eb
@@ -1,0 +1,18 @@
+easyblock = 'ConfigureMake'
+
+name = 'flex'
+version = '2.5.39'
+
+homepage = 'http://flex.sourceforge.net/'
+description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners. A scanner,
+ sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.25', '', True)]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3-2.25.eb
@@ -1,0 +1,22 @@
+easyblock = 'Bundle'
+
+name = 'GCC'
+version = '4.9.3'
+
+binutilsver = '2.25'
+versionsuffix = '-binutils-%s' % binutilsver
+
+homepage = 'http://gcc.gnu.org/'
+description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
+ as well as libraries for these languages (libstdc++, libgcj,...)."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+dependencies = [
+    ('GCCcore', version),
+    # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
+    ('binutils', binutilsver, '', ('GCCcore', version)),
+]
+
+# this bundle serves as a compiler-only toolchain, so it should be marked as compiler (important for HMNS)
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3-2.25.eb
@@ -4,7 +4,7 @@ name = 'GCC'
 version = '4.9.3'
 
 binutilsver = '2.25'
-versionsuffix = '-binutils-%s' % binutilsver
+versionsuffix = '-%s' % binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3-2.25.eb
@@ -10,13 +10,16 @@ homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
  as well as libraries for these languages (libstdc++, libgcj,...)."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
     ('binutils', binutilsver, '', ('GCCcore', version)),
 ]
+
+altroot = 'GCCcore'
+altversion = 'GCCcore'
 
 # this bundle serves as a compiler-only toolchain, so it should be marked as compiler (important for HMNS)
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.3.eb
@@ -1,0 +1,45 @@
+easyblock = 'EB_GCC'
+
+name = 'GCCcore'
+version = '4.9.3'
+
+homepage = 'http://gcc.gnu.org/'
+description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
+ as well as libraries for these languages (libstdc++, libgcj,...)."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+mpfr_version = '3.1.2'
+gcc_name = 'GCC'
+
+source_urls = [
+    'http://ftpmirror.gnu.org/%s/%s-%s' % (gcc_name.lower(), gcc_name.lower(), version),  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://www.multiprecision.org/mpc/download',  # MPC official
+]
+sources = [
+    '%s-%s.tar.bz2' % (gcc_name.lower(), version),
+    'gmp-6.0.0a.tar.bz2',
+    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpc-1.0.2.tar.gz',
+]
+
+builddependencies = [('binutils', '2.25')]
+
+patches = [('mpfr-%s-allpatches-20141204.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+
+checksums = [
+    '6f831b4d251872736e8e9cc09746f327',     # gcc-4.9.3.tar.bz2
+    'b7ff2d88cae7f8085bd5006096eed470',     # gmp-6.0.0a.tar.bz2
+    '181aa7bb0e452c409f2788a4a7f38476',     # mpfr-3.1.2.tar.gz
+    '68fadff3358fb3e7976c7a398a0af4c3',     # mpc-1.0.2.tar.gz
+    '58aec98d15982f9744a043d2f1c5af82',     # mpfr-3.1.2-allpatches-20141204.patch
+]
+
+languages = ['c', 'c++', 'fortran']
+
+# building GCC sometimes fails if make parallelism is too high, so let's limit it
+maxparallel = 4
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/mpfr-3.1.2-allpatches-20141204.patch
+++ b/easybuild/easyconfigs/g/GCCcore/mpfr-3.1.2-allpatches-20141204.patch
@@ -1,0 +1,1628 @@
+# All mpfr patches as of 2014-12-04
+# taken from their website: http://www.mpfr.org/mpfr-current/#download
+diff -Naurd mpfr-3.1.2-a/PATCHES mpfr-3.1.2-b/PATCHES
+--- mpfr-3.1.2-a/PATCHES	2013-09-26 10:52:52.000000000 +0000
++++ mpfr-3.1.2-b/PATCHES	2013-09-26 10:52:52.000000000 +0000
+@@ -0,0 +1 @@
++exp_2
+diff -Naurd mpfr-3.1.2-a/VERSION mpfr-3.1.2-b/VERSION
+--- mpfr-3.1.2-a/VERSION	2013-03-13 15:37:28.000000000 +0000
++++ mpfr-3.1.2-b/VERSION	2013-09-26 10:52:52.000000000 +0000
+@@ -1 +1 @@
+-3.1.2
++3.1.2-p1
+diff -Naurd mpfr-3.1.2-a/src/exp_2.c mpfr-3.1.2-b/src/exp_2.c
+--- mpfr-3.1.2-a/src/exp_2.c	2013-03-13 15:37:28.000000000 +0000
++++ mpfr-3.1.2-b/src/exp_2.c	2013-09-26 10:52:52.000000000 +0000
+@@ -204,7 +204,7 @@
+           for (k = 0; k < K; k++)
+             {
+               mpz_mul (ss, ss, ss);
+-              exps <<= 1;
++              exps *= 2;
+               exps += mpz_normalize (ss, ss, q);
+             }
+           mpfr_set_z (s, ss, MPFR_RNDN);
+diff -Naurd mpfr-3.1.2-a/src/mpfr.h mpfr-3.1.2-b/src/mpfr.h
+--- mpfr-3.1.2-a/src/mpfr.h	2013-03-13 15:37:37.000000000 +0000
++++ mpfr-3.1.2-b/src/mpfr.h	2013-09-26 10:52:52.000000000 +0000
+@@ -27,7 +27,7 @@
+ #define MPFR_VERSION_MAJOR 3
+ #define MPFR_VERSION_MINOR 1
+ #define MPFR_VERSION_PATCHLEVEL 2
+-#define MPFR_VERSION_STRING "3.1.2"
++#define MPFR_VERSION_STRING "3.1.2-p1"
+ 
+ /* Macros dealing with MPFR VERSION */
+ #define MPFR_VERSION_NUM(a,b,c) (((a) << 16L) | ((b) << 8) | (c))
+diff -Naurd mpfr-3.1.2-a/src/version.c mpfr-3.1.2-b/src/version.c
+--- mpfr-3.1.2-a/src/version.c	2013-03-13 15:37:34.000000000 +0000
++++ mpfr-3.1.2-b/src/version.c	2013-09-26 10:52:52.000000000 +0000
+@@ -25,5 +25,5 @@
+ const char *
+ mpfr_get_version (void)
+ {
+-  return "3.1.2";
++  return "3.1.2-p1";
+ }
+diff -Naurd mpfr-3.1.2-a/PATCHES mpfr-3.1.2-b/PATCHES
+--- mpfr-3.1.2-a/PATCHES	2013-09-26 10:56:55.000000000 +0000
++++ mpfr-3.1.2-b/PATCHES	2013-09-26 10:56:55.000000000 +0000
+@@ -0,0 +1 @@
++fits-smallneg
+diff -Naurd mpfr-3.1.2-a/VERSION mpfr-3.1.2-b/VERSION
+--- mpfr-3.1.2-a/VERSION	2013-09-26 10:52:52.000000000 +0000
++++ mpfr-3.1.2-b/VERSION	2013-09-26 10:56:55.000000000 +0000
+@@ -1 +1 @@
+-3.1.2-p1
++3.1.2-p2
+diff -Naurd mpfr-3.1.2-a/src/fits_u.h mpfr-3.1.2-b/src/fits_u.h
+--- mpfr-3.1.2-a/src/fits_u.h	2013-03-13 15:37:35.000000000 +0000
++++ mpfr-3.1.2-b/src/fits_u.h	2013-09-26 10:56:55.000000000 +0000
+@@ -32,17 +32,20 @@
+   int res;
+ 
+   if (MPFR_UNLIKELY (MPFR_IS_SINGULAR (f)))
+-    /* Zero always fit */
+-    return MPFR_IS_ZERO (f) ? 1 : 0;
+-  else if (MPFR_IS_NEG (f))
+-    /* Negative numbers don't fit */
+-    return 0;
+-  /* now it fits if
+-     (a) f <= MAXIMUM
+-     (b) round(f, prec(slong), rnd) <= MAXIMUM */
++    return MPFR_IS_ZERO (f) ? 1 : 0;  /* Zero always fits */
+ 
+   e = MPFR_GET_EXP (f);
+ 
++  if (MPFR_IS_NEG (f))
++    return e >= 1 ? 0  /* f <= -1 does not fit */
++      : rnd != MPFR_RNDN ? MPFR_IS_LIKE_RNDU (rnd, -1)  /* directed mode */
++      : e < 0 ? 1  /* f > -1/2 fits in MPFR_RNDN */
++      : mpfr_powerof2_raw(f);  /* -1/2 fits, -1 < f < -1/2 don't */
++
++  /* Now it fits if
++     (a) f <= MAXIMUM
++     (b) round(f, prec(slong), rnd) <= MAXIMUM */
++
+   /* first compute prec(MAXIMUM); fits in an int */
+   for (s = MAXIMUM, prec = 0; s != 0; s /= 2, prec ++);
+ 
+diff -Naurd mpfr-3.1.2-a/src/fits_uintmax.c mpfr-3.1.2-b/src/fits_uintmax.c
+--- mpfr-3.1.2-a/src/fits_uintmax.c	2013-03-13 15:37:33.000000000 +0000
++++ mpfr-3.1.2-b/src/fits_uintmax.c	2013-09-26 10:56:55.000000000 +0000
+@@ -27,51 +27,19 @@
+ #include "mpfr-intmax.h"
+ #include "mpfr-impl.h"
+ 
+-#ifdef _MPFR_H_HAVE_INTMAX_T
+-
+-/* We can't use fits_u.h <= mpfr_cmp_ui */
+-int
+-mpfr_fits_uintmax_p (mpfr_srcptr f, mpfr_rnd_t rnd)
+-{
+-  mpfr_exp_t e;
+-  int prec;
+-  uintmax_t s;
+-  mpfr_t x;
+-  int res;
+-
+-  if (MPFR_UNLIKELY (MPFR_IS_SINGULAR (f)))
+-    /* Zero always fit */
+-    return MPFR_IS_ZERO (f) ? 1 : 0;
+-  else if (MPFR_IS_NEG (f))
+-    /* Negative numbers don't fit */
+-    return 0;
+-  /* now it fits if
+-     (a) f <= MAXIMUM
+-     (b) round(f, prec(slong), rnd) <= MAXIMUM */
+-
+-  e = MPFR_GET_EXP (f);
+-
+-  /* first compute prec(MAXIMUM); fits in an int */
+-  for (s = MPFR_UINTMAX_MAX, prec = 0; s != 0; s /= 2, prec ++);
+-
+-  /* MAXIMUM needs prec bits, i.e. MAXIMUM = 2^prec - 1 */
+-
+-  /* if e <= prec - 1, then f < 2^(prec-1) < MAXIMUM */
+-  if (e <= prec - 1)
+-    return 1;
++/* Note: though mpfr-impl.h is included in fits_u.h, we also include it
++   above so that it gets included even when _MPFR_H_HAVE_INTMAX_T is not
++   defined; this is necessary to avoid an empty translation unit, which
++   is forbidden by ISO C. Without this, a failing test can be reproduced
++   by creating an invalid stdint.h somewhere in the default include path
++   and by compiling MPFR with "gcc -ansi -pedantic-errors". */
+ 
+-  /* if e >= prec + 1, then f >= 2^prec > MAXIMUM */
+-  if (e >= prec + 1)
+-    return 0;
++#ifdef _MPFR_H_HAVE_INTMAX_T
+ 
+-  MPFR_ASSERTD (e == prec);
++#define FUNCTION   mpfr_fits_uintmax_p
++#define MAXIMUM    MPFR_UINTMAX_MAX
++#define TYPE       uintmax_t
+ 
+-  /* hard case: first round to prec bits, then check */
+-  mpfr_init2 (x, prec);
+-  mpfr_set (x, f, rnd);
+-  res = MPFR_GET_EXP (x) == e;
+-  mpfr_clear (x);
+-  return res;
+-}
++#include "fits_u.h"
+ 
+ #endif
+diff -Naurd mpfr-3.1.2-a/src/mpfr.h mpfr-3.1.2-b/src/mpfr.h
+--- mpfr-3.1.2-a/src/mpfr.h	2013-09-26 10:52:52.000000000 +0000
++++ mpfr-3.1.2-b/src/mpfr.h	2013-09-26 10:56:55.000000000 +0000
+@@ -27,7 +27,7 @@
+ #define MPFR_VERSION_MAJOR 3
+ #define MPFR_VERSION_MINOR 1
+ #define MPFR_VERSION_PATCHLEVEL 2
+-#define MPFR_VERSION_STRING "3.1.2-p1"
++#define MPFR_VERSION_STRING "3.1.2-p2"
+ 
+ /* Macros dealing with MPFR VERSION */
+ #define MPFR_VERSION_NUM(a,b,c) (((a) << 16L) | ((b) << 8) | (c))
+diff -Naurd mpfr-3.1.2-a/src/version.c mpfr-3.1.2-b/src/version.c
+--- mpfr-3.1.2-a/src/version.c	2013-09-26 10:52:52.000000000 +0000
++++ mpfr-3.1.2-b/src/version.c	2013-09-26 10:56:55.000000000 +0000
+@@ -25,5 +25,5 @@
+ const char *
+ mpfr_get_version (void)
+ {
+-  return "3.1.2-p1";
++  return "3.1.2-p2";
+ }
+diff -Naurd mpfr-3.1.2-a/tests/tfits.c mpfr-3.1.2-b/tests/tfits.c
+--- mpfr-3.1.2-a/tests/tfits.c	2013-03-13 15:37:45.000000000 +0000
++++ mpfr-3.1.2-b/tests/tfits.c	2013-09-26 10:56:55.000000000 +0000
+@@ -33,155 +33,176 @@
+ #include "mpfr-intmax.h"
+ #include "mpfr-test.h"
+ 
+-#define ERROR1 { printf("Initial error for x="); mpfr_dump(x); exit(1); }
+-#define ERROR2 { printf("Error for x="); mpfr_dump(x); exit(1); }
++#define ERROR1(N)                                               \
++  do                                                            \
++    {                                                           \
++      printf("Error %d for rnd = %s and x = ", N,               \
++             mpfr_print_rnd_mode ((mpfr_rnd_t) r));             \
++      mpfr_dump(x);                                             \
++      exit(1);                                                  \
++    }                                                           \
++  while (0)
+ 
+ static void check_intmax (void);
+ 
+ int
+ main (void)
+ {
+-  mpfr_t x;
++  mpfr_t x, y;
++  int i, r;
+ 
+   tests_start_mpfr ();
+ 
+   mpfr_init2 (x, 256);
++  mpfr_init2 (y, 8);
+ 
+-  /* Check NAN */
+-  mpfr_set_nan (x);
+-  if (mpfr_fits_ulong_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_slong_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_uint_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_sint_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_ushort_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_sshort_p (x, MPFR_RNDN))
+-    ERROR1;
++  RND_LOOP (r)
++    {
+ 
+-  /* Check INF */
+-  mpfr_set_inf (x, 1);
+-  if (mpfr_fits_ulong_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_slong_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_uint_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_sint_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_ushort_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_sshort_p (x, MPFR_RNDN))
+-    ERROR1;
++      /* Check NAN */
++      mpfr_set_nan (x);
++      if (mpfr_fits_ulong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (1);
++      if (mpfr_fits_slong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (2);
++      if (mpfr_fits_uint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (3);
++      if (mpfr_fits_sint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (4);
++      if (mpfr_fits_ushort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (5);
++      if (mpfr_fits_sshort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (6);
+ 
+-  /* Check Zero */
+-  MPFR_SET_ZERO (x);
+-  if (!mpfr_fits_ulong_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_slong_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_uint_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_sint_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_ushort_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_sshort_p (x, MPFR_RNDN))
+-    ERROR2;
++      /* Check INF */
++      mpfr_set_inf (x, 1);
++      if (mpfr_fits_ulong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (7);
++      if (mpfr_fits_slong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (8);
++      if (mpfr_fits_uint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (9);
++      if (mpfr_fits_sint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (10);
++      if (mpfr_fits_ushort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (11);
++      if (mpfr_fits_sshort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (12);
+ 
+-  /* Check small op */
+-  mpfr_set_str1 (x, "1@-1");
+-  if (!mpfr_fits_ulong_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_slong_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_uint_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_sint_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_ushort_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_sshort_p (x, MPFR_RNDN))
+-    ERROR2;
++      /* Check Zero */
++      MPFR_SET_ZERO (x);
++      if (!mpfr_fits_ulong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (13);
++      if (!mpfr_fits_slong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (14);
++      if (!mpfr_fits_uint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (15);
++      if (!mpfr_fits_sint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (16);
++      if (!mpfr_fits_ushort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (17);
++      if (!mpfr_fits_sshort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (18);
+ 
+-  /* Check 17 */
+-  mpfr_set_ui (x, 17, MPFR_RNDN);
+-  if (!mpfr_fits_ulong_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_slong_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_uint_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_sint_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_ushort_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_sshort_p (x, MPFR_RNDN))
+-    ERROR2;
++      /* Check small positive op */
++      mpfr_set_str1 (x, "1@-1");
++      if (!mpfr_fits_ulong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (19);
++      if (!mpfr_fits_slong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (20);
++      if (!mpfr_fits_uint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (21);
++      if (!mpfr_fits_sint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (22);
++      if (!mpfr_fits_ushort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (23);
++      if (!mpfr_fits_sshort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (24);
+ 
+-  /* Check all other values */
+-  mpfr_set_ui (x, ULONG_MAX, MPFR_RNDN);
+-  mpfr_mul_2exp (x, x, 1, MPFR_RNDN);
+-  if (mpfr_fits_ulong_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_slong_p (x, MPFR_RNDN))
+-    ERROR1;
+-  mpfr_mul_2exp (x, x, 40, MPFR_RNDN);
+-  if (mpfr_fits_ulong_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_uint_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_sint_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_ushort_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_sshort_p (x, MPFR_RNDN))
+-    ERROR1;
++      /* Check 17 */
++      mpfr_set_ui (x, 17, MPFR_RNDN);
++      if (!mpfr_fits_ulong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (25);
++      if (!mpfr_fits_slong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (26);
++      if (!mpfr_fits_uint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (27);
++      if (!mpfr_fits_sint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (28);
++      if (!mpfr_fits_ushort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (29);
++      if (!mpfr_fits_sshort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (30);
+ 
+-  mpfr_set_ui (x, ULONG_MAX, MPFR_RNDN);
+-  if (!mpfr_fits_ulong_p (x, MPFR_RNDN))
+-    ERROR2;
+-  mpfr_set_ui (x, LONG_MAX, MPFR_RNDN);
+-  if (!mpfr_fits_slong_p (x, MPFR_RNDN))
+-    ERROR2;
+-  mpfr_set_ui (x, UINT_MAX, MPFR_RNDN);
+-  if (!mpfr_fits_uint_p (x, MPFR_RNDN))
+-    ERROR2;
+-  mpfr_set_ui (x, INT_MAX, MPFR_RNDN);
+-  if (!mpfr_fits_sint_p (x, MPFR_RNDN))
+-    ERROR2;
+-  mpfr_set_ui (x, USHRT_MAX, MPFR_RNDN);
+-  if (!mpfr_fits_ushort_p (x, MPFR_RNDN))
+-    ERROR2;
+-  mpfr_set_ui (x, SHRT_MAX, MPFR_RNDN);
+-  if (!mpfr_fits_sshort_p (x, MPFR_RNDN))
+-    ERROR2;
++      /* Check all other values */
++      mpfr_set_ui (x, ULONG_MAX, MPFR_RNDN);
++      mpfr_mul_2exp (x, x, 1, MPFR_RNDN);
++      if (mpfr_fits_ulong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (31);
++      if (mpfr_fits_slong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (32);
++      mpfr_mul_2exp (x, x, 40, MPFR_RNDN);
++      if (mpfr_fits_ulong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (33);
++      if (mpfr_fits_uint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (34);
++      if (mpfr_fits_sint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (35);
++      if (mpfr_fits_ushort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (36);
++      if (mpfr_fits_sshort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (37);
+ 
+-  mpfr_set_si (x, 1, MPFR_RNDN);
+-  if (!mpfr_fits_sint_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_sshort_p (x, MPFR_RNDN))
+-    ERROR2;
++      mpfr_set_ui (x, ULONG_MAX, MPFR_RNDN);
++      if (!mpfr_fits_ulong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (38);
++      mpfr_set_ui (x, LONG_MAX, MPFR_RNDN);
++      if (!mpfr_fits_slong_p (x, (mpfr_rnd_t) r))
++        ERROR1 (39);
++      mpfr_set_ui (x, UINT_MAX, MPFR_RNDN);
++      if (!mpfr_fits_uint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (40);
++      mpfr_set_ui (x, INT_MAX, MPFR_RNDN);
++      if (!mpfr_fits_sint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (41);
++      mpfr_set_ui (x, USHRT_MAX, MPFR_RNDN);
++      if (!mpfr_fits_ushort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (42);
++      mpfr_set_ui (x, SHRT_MAX, MPFR_RNDN);
++      if (!mpfr_fits_sshort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (43);
+ 
+-  /* Check negative value */
+-  mpfr_set_si (x, -1, MPFR_RNDN);
+-  if (!mpfr_fits_sint_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_sshort_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_slong_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (mpfr_fits_uint_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_ushort_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_ulong_p (x, MPFR_RNDN))
+-    ERROR1;
++      mpfr_set_si (x, 1, MPFR_RNDN);
++      if (!mpfr_fits_sint_p (x, (mpfr_rnd_t) r))
++        ERROR1 (44);
++      if (!mpfr_fits_sshort_p (x, (mpfr_rnd_t) r))
++        ERROR1 (45);
++
++      /* Check negative op */
++      for (i = 1; i <= 4; i++)
++        {
++          int inv;
++
++          mpfr_set_si_2exp (x, -i, -2, MPFR_RNDN);
++          mpfr_rint (y, x, (mpfr_rnd_t) r);
++          inv = MPFR_NOTZERO (y);
++          if (!mpfr_fits_ulong_p (x, (mpfr_rnd_t) r) ^ inv)
++            ERROR1 (46);
++          if (!mpfr_fits_slong_p (x, (mpfr_rnd_t) r))
++            ERROR1 (47);
++          if (!mpfr_fits_uint_p (x, (mpfr_rnd_t) r) ^ inv)
++            ERROR1 (48);
++          if (!mpfr_fits_sint_p (x, (mpfr_rnd_t) r))
++            ERROR1 (49);
++          if (!mpfr_fits_ushort_p (x, (mpfr_rnd_t) r) ^ inv)
++            ERROR1 (50);
++          if (!mpfr_fits_sshort_p (x, (mpfr_rnd_t) r))
++            ERROR1 (51);
++        }
++    }
+ 
+   mpfr_clear (x);
++  mpfr_clear (y);
+ 
+   check_intmax ();
+ 
+@@ -189,85 +210,98 @@
+   return 0;
+ }
+ 
+-static void check_intmax (void)
++static void
++check_intmax (void)
+ {
+ #ifdef _MPFR_H_HAVE_INTMAX_T
+-  mpfr_t x;
++  mpfr_t x, y;
++  int i, r;
+ 
+-  mpfr_init2 (x, sizeof (uintmax_t)*CHAR_BIT);
++  mpfr_init2 (x, sizeof (uintmax_t) * CHAR_BIT);
++  mpfr_init2 (y, 8);
+ 
+-  /* Check NAN */
+-  mpfr_set_nan (x);
+-  if (mpfr_fits_uintmax_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_intmax_p (x, MPFR_RNDN))
+-    ERROR1;
++  RND_LOOP (r)
++    {
++      /* Check NAN */
++      mpfr_set_nan (x);
++      if (mpfr_fits_uintmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (52);
++      if (mpfr_fits_intmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (53);
+ 
+-  /* Check INF */
+-  mpfr_set_inf (x, 1);
+-  if (mpfr_fits_uintmax_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_intmax_p (x, MPFR_RNDN))
+-    ERROR1;
++      /* Check INF */
++      mpfr_set_inf (x, 1);
++      if (mpfr_fits_uintmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (54);
++      if (mpfr_fits_intmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (55);
+ 
+-  /* Check Zero */
+-  MPFR_SET_ZERO (x);
+-  if (!mpfr_fits_uintmax_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_intmax_p (x, MPFR_RNDN))
+-    ERROR2;
++      /* Check Zero */
++      MPFR_SET_ZERO (x);
++      if (!mpfr_fits_uintmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (56);
++      if (!mpfr_fits_intmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (57);
+ 
+-  /* Check small op */
+-  mpfr_set_str1 (x, "1@-1");
+-  if (!mpfr_fits_uintmax_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_intmax_p (x, MPFR_RNDN))
+-    ERROR2;
++      /* Check positive small op */
++      mpfr_set_str1 (x, "1@-1");
++      if (!mpfr_fits_uintmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (58);
++      if (!mpfr_fits_intmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (59);
+ 
+-  /* Check 17 */
+-  mpfr_set_ui (x, 17, MPFR_RNDN);
+-  if (!mpfr_fits_uintmax_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (!mpfr_fits_intmax_p (x, MPFR_RNDN))
+-    ERROR2;
++      /* Check 17 */
++      mpfr_set_ui (x, 17, MPFR_RNDN);
++      if (!mpfr_fits_uintmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (60);
++      if (!mpfr_fits_intmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (61);
+ 
+-  /* Check hugest */
+-  mpfr_set_ui_2exp (x, 42, sizeof (uintmax_t) * 32, MPFR_RNDN);
+-  if (mpfr_fits_uintmax_p (x, MPFR_RNDN))
+-    ERROR1;
+-  if (mpfr_fits_intmax_p (x, MPFR_RNDN))
+-    ERROR1;
++      /* Check hugest */
++      mpfr_set_ui_2exp (x, 42, sizeof (uintmax_t) * 32, MPFR_RNDN);
++      if (mpfr_fits_uintmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (62);
++      if (mpfr_fits_intmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (63);
+ 
+-  /* Check all other values */
+-  mpfr_set_uj (x, MPFR_UINTMAX_MAX, MPFR_RNDN);
+-  mpfr_add_ui (x, x, 1, MPFR_RNDN);
+-  if (mpfr_fits_uintmax_p (x, MPFR_RNDN))
+-    ERROR1;
+-  mpfr_set_uj (x, MPFR_UINTMAX_MAX, MPFR_RNDN);
+-  if (!mpfr_fits_uintmax_p (x, MPFR_RNDN))
+-    ERROR2;
+-  mpfr_set_sj (x, MPFR_INTMAX_MAX, MPFR_RNDN);
+-  mpfr_add_ui (x, x, 1, MPFR_RNDN);
+-  if (mpfr_fits_intmax_p (x, MPFR_RNDN))
+-    ERROR1;
+-  mpfr_set_sj (x, MPFR_INTMAX_MAX, MPFR_RNDN);
+-  if (!mpfr_fits_intmax_p (x, MPFR_RNDN))
+-    ERROR2;
+-  mpfr_set_sj (x, MPFR_INTMAX_MIN, MPFR_RNDN);
+-  if (!mpfr_fits_intmax_p (x, MPFR_RNDN))
+-    ERROR2;
+-  mpfr_sub_ui (x, x, 1, MPFR_RNDN);
+-  if (mpfr_fits_intmax_p (x, MPFR_RNDN))
+-    ERROR1;
++      /* Check all other values */
++      mpfr_set_uj (x, MPFR_UINTMAX_MAX, MPFR_RNDN);
++      mpfr_add_ui (x, x, 1, MPFR_RNDN);
++      if (mpfr_fits_uintmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (64);
++      mpfr_set_uj (x, MPFR_UINTMAX_MAX, MPFR_RNDN);
++      if (!mpfr_fits_uintmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (65);
++      mpfr_set_sj (x, MPFR_INTMAX_MAX, MPFR_RNDN);
++      mpfr_add_ui (x, x, 1, MPFR_RNDN);
++      if (mpfr_fits_intmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (66);
++      mpfr_set_sj (x, MPFR_INTMAX_MAX, MPFR_RNDN);
++      if (!mpfr_fits_intmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (67);
++      mpfr_set_sj (x, MPFR_INTMAX_MIN, MPFR_RNDN);
++      if (!mpfr_fits_intmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (68);
++      mpfr_sub_ui (x, x, 1, MPFR_RNDN);
++      if (mpfr_fits_intmax_p (x, (mpfr_rnd_t) r))
++        ERROR1 (69);
+ 
+-  /* Check negative value */
+-  mpfr_set_si (x, -1, MPFR_RNDN);
+-  if (!mpfr_fits_intmax_p (x, MPFR_RNDN))
+-    ERROR2;
+-  if (mpfr_fits_uintmax_p (x, MPFR_RNDN))
+-    ERROR1;
++      /* Check negative op */
++      for (i = 1; i <= 4; i++)
++        {
++          int inv;
++
++          mpfr_set_si_2exp (x, -i, -2, MPFR_RNDN);
++          mpfr_rint (y, x, (mpfr_rnd_t) r);
++          inv = MPFR_NOTZERO (y);
++          if (!mpfr_fits_uintmax_p (x, (mpfr_rnd_t) r) ^ inv)
++            ERROR1 (70);
++          if (!mpfr_fits_intmax_p (x, (mpfr_rnd_t) r))
++            ERROR1 (71);
++        }
++    }
+ 
+   mpfr_clear (x);
++  mpfr_clear (y);
+ #endif
+ }
+-
+diff -Naurd mpfr-3.1.2-a/PATCHES mpfr-3.1.2-b/PATCHES
+--- mpfr-3.1.2-a/PATCHES	2013-10-09 13:34:21.000000000 +0000
++++ mpfr-3.1.2-b/PATCHES	2013-10-09 13:34:21.000000000 +0000
+@@ -0,0 +1 @@
++clang-divby0
+diff -Naurd mpfr-3.1.2-a/VERSION mpfr-3.1.2-b/VERSION
+--- mpfr-3.1.2-a/VERSION	2013-09-26 10:52:52.000000000 +0000
++++ mpfr-3.1.2-b/VERSION	2013-10-09 13:34:21.000000000 +0000
+@@ -1 +1 @@
+-3.1.2-p2
++3.1.2-p3
+diff -Naurd mpfr-3.1.2-a/src/mpfr-impl.h mpfr-3.1.2-b/src/mpfr-impl.h
+--- mpfr-3.1.2-a/src/mpfr-impl.h	2013-03-13 15:37:36.000000000 +0000
++++ mpfr-3.1.2-b/src/mpfr-impl.h	2013-10-09 13:34:21.000000000 +0000
+@@ -468,8 +468,16 @@
+ #define MPFR_LIMBS_PER_FLT ((IEEE_FLT_MANT_DIG-1)/GMP_NUMB_BITS+1)
+ 
+ /* Visual C++ doesn't support +1.0/0.0, -1.0/0.0 and 0.0/0.0
+-   at compile time. */
+-#if defined(_MSC_VER) && defined(_WIN32) && (_MSC_VER >= 1200)
++   at compile time.
++   Clang with -fsanitize=undefined is a bit similar due to a bug:
++     http://llvm.org/bugs/show_bug.cgi?id=17381
++   but even without its sanitizer, it may be better to use the
++   double_zero version until IEEE 754 division by zero is properly
++   supported:
++     http://llvm.org/bugs/show_bug.cgi?id=17000
++*/
++#if (defined(_MSC_VER) && defined(_WIN32) && (_MSC_VER >= 1200)) || \
++    defined(__clang__)
+ static double double_zero = 0.0;
+ # define DBL_NAN (double_zero/double_zero)
+ # define DBL_POS_INF ((double) 1.0/double_zero)
+@@ -501,6 +509,8 @@
+    (with Xcode 2.4.1, i.e. the latest one). */
+ #define LVALUE(x) (&(x) == &(x) || &(x) != &(x))
+ #define DOUBLE_ISINF(x) (LVALUE(x) && ((x) > DBL_MAX || (x) < -DBL_MAX))
++/* The DOUBLE_ISNAN(x) macro is also valid on long double x
++   (assuming that the compiler isn't too broken). */
+ #ifdef MPFR_NANISNAN
+ /* Avoid MIPSpro / IRIX64 / gcc -ffast-math (incorrect) optimizations.
+    The + must not be replaced by a ||. With gcc -ffast-math, NaN is
+diff -Naurd mpfr-3.1.2-a/src/mpfr.h mpfr-3.1.2-b/src/mpfr.h
+--- mpfr-3.1.2-a/src/mpfr.h	2013-09-26 10:52:52.000000000 +0000
++++ mpfr-3.1.2-b/src/mpfr.h	2013-10-09 13:34:21.000000000 +0000
+@@ -27,7 +27,7 @@
+ #define MPFR_VERSION_MAJOR 3
+ #define MPFR_VERSION_MINOR 1
+ #define MPFR_VERSION_PATCHLEVEL 2
+-#define MPFR_VERSION_STRING "3.1.2-p2"
++#define MPFR_VERSION_STRING "3.1.2-p3"
+ 
+ /* Macros dealing with MPFR VERSION */
+ #define MPFR_VERSION_NUM(a,b,c) (((a) << 16L) | ((b) << 8) | (c))
+diff -Naurd mpfr-3.1.2-a/src/version.c mpfr-3.1.2-b/src/version.c
+--- mpfr-3.1.2-a/src/version.c	2013-09-26 10:52:52.000000000 +0000
++++ mpfr-3.1.2-b/src/version.c	2013-10-09 13:34:21.000000000 +0000
+@@ -25,5 +25,5 @@
+ const char *
+ mpfr_get_version (void)
+ {
+-  return "3.1.2-p2";
++  return "3.1.2-p3";
+ }
+diff -Naurd mpfr-3.1.2-a/tests/tget_flt.c mpfr-3.1.2-b/tests/tget_flt.c
+--- mpfr-3.1.2-a/tests/tget_flt.c	2013-03-13 15:37:44.000000000 +0000
++++ mpfr-3.1.2-b/tests/tget_flt.c	2013-10-09 13:34:21.000000000 +0000
+@@ -28,9 +28,17 @@
+ main (void)
+ {
+   mpfr_t x, y;
+-  float f, g, infp;
++  float f, g;
+   int i;
++#if !defined(MPFR_ERRDIVZERO)
++  float infp;
++#endif
++
++  tests_start_mpfr ();
+ 
++#if !defined(MPFR_ERRDIVZERO)
++  /* The definition of DBL_POS_INF involves a division by 0. This makes
++     "clang -O2 -fsanitize=undefined -fno-sanitize-recover" fail. */
+   infp = (float) DBL_POS_INF;
+   if (infp * 0.5 != infp)
+     {
+@@ -38,8 +46,7 @@
+       fprintf (stderr, "(this is probably a compiler bug, please report)\n");
+       exit (1);
+     }
+-
+-  tests_start_mpfr ();
++#endif
+ 
+   mpfr_init2 (x, 24);
+   mpfr_init2 (y, 24);
+@@ -353,6 +360,7 @@
+       printf ("expected %.8e, got %.8e\n", g, f);
+       exit (1);
+     }
++#if !defined(MPFR_ERRDIVZERO)
+   f = mpfr_get_flt (x, MPFR_RNDN); /* first round to 2^128 (even rule),
+                                       thus we should get +Inf */
+   g = infp;
+@@ -376,6 +384,7 @@
+       printf ("expected %.8e, got %.8e\n", g, f);
+       exit (1);
+     }
++#endif
+ 
+   mpfr_clear (x);
+   mpfr_clear (y);
+diff -Naurd mpfr-3.1.2-a/tests/tset_ld.c mpfr-3.1.2-b/tests/tset_ld.c
+--- mpfr-3.1.2-a/tests/tset_ld.c	2013-03-13 15:37:44.000000000 +0000
++++ mpfr-3.1.2-b/tests/tset_ld.c	2013-10-09 13:34:21.000000000 +0000
+@@ -47,8 +47,11 @@
+ static int
+ Isnan_ld (long double d)
+ {
+-  double e = (double) d;
+-  if (DOUBLE_ISNAN (e))
++  /* Do not convert d to double as this can give an overflow, which
++     may confuse compilers without IEEE 754 support (such as clang
++     -fsanitize=undefined), or trigger a trap if enabled.
++     The DOUBLE_ISNAN macro should work fine on long double. */
++  if (DOUBLE_ISNAN (d))
+     return 1;
+   LONGDOUBLE_NAN_ACTION (d, goto yes);
+   return 0;
+diff -Naurd mpfr-3.1.2-a/PATCHES mpfr-3.1.2-b/PATCHES
+--- mpfr-3.1.2-a/PATCHES	2013-11-15 00:51:49.211333830 +0000
++++ mpfr-3.1.2-b/PATCHES	2013-11-15 00:51:49.323334999 +0000
+@@ -0,0 +1 @@
++printf-alt0
+diff -Naurd mpfr-3.1.2-a/VERSION mpfr-3.1.2-b/VERSION
+--- mpfr-3.1.2-a/VERSION	2013-11-15 00:51:49.211333830 +0000
++++ mpfr-3.1.2-b/VERSION	2013-11-15 00:51:49.323334999 +0000
+@@ -1 +1 @@
+-3.1.2-p3
++3.1.2-p4
+diff -Naurd mpfr-3.1.2-a/src/mpfr.h mpfr-3.1.2-b/src/mpfr.h
+--- mpfr-3.1.2-a/src/mpfr.h	2013-11-15 00:51:49.211333830 +0000
++++ mpfr-3.1.2-b/src/mpfr.h	2013-11-15 00:51:49.323334999 +0000
+@@ -27,7 +27,7 @@
+ #define MPFR_VERSION_MAJOR 3
+ #define MPFR_VERSION_MINOR 1
+ #define MPFR_VERSION_PATCHLEVEL 2
+-#define MPFR_VERSION_STRING "3.1.2-p3"
++#define MPFR_VERSION_STRING "3.1.2-p4"
+ 
+ /* Macros dealing with MPFR VERSION */
+ #define MPFR_VERSION_NUM(a,b,c) (((a) << 16L) | ((b) << 8) | (c))
+diff -Naurd mpfr-3.1.2-a/src/vasprintf.c mpfr-3.1.2-b/src/vasprintf.c
+--- mpfr-3.1.2-a/src/vasprintf.c	2013-03-13 15:37:37.000000000 +0000
++++ mpfr-3.1.2-b/src/vasprintf.c	2013-11-15 00:51:49.267334408 +0000
+@@ -1040,7 +1040,7 @@
+ }
+ 
+ /* Determine the different parts of the string representation of the regular
+-   number P when SPEC.SPEC is 'e', 'E', 'g', or 'G'.
++   number P when spec.spec is 'e', 'E', 'g', or 'G'.
+    DEC_INFO contains the previously computed exponent and string or is NULL.
+ 
+    return -1 if some field > INT_MAX */
+@@ -1167,7 +1167,7 @@
+ }
+ 
+ /* Determine the different parts of the string representation of the regular
+-   number P when SPEC.SPEC is 'f', 'F', 'g', or 'G'.
++   number P when spec.spec is 'f', 'F', 'g', or 'G'.
+    DEC_INFO contains the previously computed exponent and string or is NULL.
+ 
+    return -1 if some field of number_parts is greater than INT_MAX */
+@@ -1559,7 +1559,7 @@
+             /* fractional part */
+             {
+               np->point = MPFR_DECIMAL_POINT;
+-              np->fp_trailing_zeros = (spec.spec == 'g' && spec.spec == 'G') ?
++              np->fp_trailing_zeros = (spec.spec == 'g' || spec.spec == 'G') ?
+                 spec.prec - 1 : spec.prec;
+             }
+           else if (spec.alt)
+diff -Naurd mpfr-3.1.2-a/src/version.c mpfr-3.1.2-b/src/version.c
+--- mpfr-3.1.2-a/src/version.c	2013-11-15 00:51:49.211333830 +0000
++++ mpfr-3.1.2-b/src/version.c	2013-11-15 00:51:49.323334999 +0000
+@@ -25,5 +25,5 @@
+ const char *
+ mpfr_get_version (void)
+ {
+-  return "3.1.2-p3";
++  return "3.1.2-p4";
+ }
+diff -Naurd mpfr-3.1.2-a/tests/tsprintf.c mpfr-3.1.2-b/tests/tsprintf.c
+--- mpfr-3.1.2-a/tests/tsprintf.c	2013-03-13 15:37:44.000000000 +0000
++++ mpfr-3.1.2-b/tests/tsprintf.c	2013-11-15 00:51:49.267334408 +0000
+@@ -456,10 +456,16 @@
+   check_sprintf ("1.999900  ", "%-#10.7RG", x);
+   check_sprintf ("1.9999    ", "%-10.7RG", x);
+   mpfr_set_ui (x, 1, MPFR_RNDN);
++  check_sprintf ("1.", "%#.1Rg", x);
++  check_sprintf ("1.   ", "%-#5.1Rg", x);
++  check_sprintf ("  1.0", "%#5.2Rg", x);
+   check_sprintf ("1.00000000000000000000000000000", "%#.30Rg", x);
+   check_sprintf ("1", "%.30Rg", x);
+   mpfr_set_ui (x, 0, MPFR_RNDN);
+-  check_sprintf ("0.000000000000000000000000000000", "%#.30Rg", x);
++  check_sprintf ("0.", "%#.1Rg", x);
++  check_sprintf ("0.   ", "%-#5.1Rg", x);
++  check_sprintf ("  0.0", "%#5.2Rg", x);
++  check_sprintf ("0.00000000000000000000000000000", "%#.30Rg", x);
+   check_sprintf ("0", "%.30Rg", x);
+ 
+   /* following tests with precision 53 bits */
+diff -Naurd mpfr-3.1.2-a/PATCHES mpfr-3.1.2-b/PATCHES
+--- mpfr-3.1.2-a/PATCHES	2013-12-01 11:07:49.575329762 +0000
++++ mpfr-3.1.2-b/PATCHES	2013-12-01 11:07:49.751331625 +0000
+@@ -0,0 +1 @@
++custom_init_set
+diff -Naurd mpfr-3.1.2-a/VERSION mpfr-3.1.2-b/VERSION
+--- mpfr-3.1.2-a/VERSION	2013-12-01 11:07:49.571329714 +0000
++++ mpfr-3.1.2-b/VERSION	2013-12-01 11:07:49.747331585 +0000
+@@ -1 +1 @@
+-3.1.2-p4
++3.1.2-p5
+diff -Naurd mpfr-3.1.2-a/src/mpfr.h mpfr-3.1.2-b/src/mpfr.h
+--- mpfr-3.1.2-a/src/mpfr.h	2013-12-01 11:07:49.571329714 +0000
++++ mpfr-3.1.2-b/src/mpfr.h	2013-12-01 11:07:49.747331585 +0000
+@@ -27,7 +27,7 @@
+ #define MPFR_VERSION_MAJOR 3
+ #define MPFR_VERSION_MINOR 1
+ #define MPFR_VERSION_PATCHLEVEL 2
+-#define MPFR_VERSION_STRING "3.1.2-p4"
++#define MPFR_VERSION_STRING "3.1.2-p5"
+ 
+ /* Macros dealing with MPFR VERSION */
+ #define MPFR_VERSION_NUM(a,b,c) (((a) << 16L) | ((b) << 8) | (c))
+@@ -861,7 +861,7 @@
+     _t = (mpfr_kind_t) _k;                                     \
+     _s = 1;                                                    \
+   } else {                                                     \
+-    _t = (mpfr_kind_t) -k;                                     \
++    _t = (mpfr_kind_t) - _k;                                   \
+     _s = -1;                                                   \
+   }                                                            \
+   _e = _t == MPFR_REGULAR_KIND ? (e) :                         \
+diff -Naurd mpfr-3.1.2-a/src/version.c mpfr-3.1.2-b/src/version.c
+--- mpfr-3.1.2-a/src/version.c	2013-12-01 11:07:49.575329762 +0000
++++ mpfr-3.1.2-b/src/version.c	2013-12-01 11:07:49.747331585 +0000
+@@ -25,5 +25,5 @@
+ const char *
+ mpfr_get_version (void)
+ {
+-  return "3.1.2-p4";
++  return "3.1.2-p5";
+ }
+diff -Naurd mpfr-3.1.2-a/PATCHES mpfr-3.1.2-b/PATCHES
+--- mpfr-3.1.2-a/PATCHES	2014-04-15 21:56:49.609057464 +0000
++++ mpfr-3.1.2-b/PATCHES	2014-04-15 21:56:49.697059857 +0000
+@@ -0,0 +1 @@
++li2-return
+diff -Naurd mpfr-3.1.2-a/VERSION mpfr-3.1.2-b/VERSION
+--- mpfr-3.1.2-a/VERSION	2014-04-15 21:56:49.609057464 +0000
++++ mpfr-3.1.2-b/VERSION	2014-04-15 21:56:49.697059857 +0000
+@@ -1 +1 @@
+-3.1.2-p5
++3.1.2-p6
+diff -Naurd mpfr-3.1.2-a/src/li2.c mpfr-3.1.2-b/src/li2.c
+--- mpfr-3.1.2-a/src/li2.c	2013-03-13 15:37:32.000000000 +0000
++++ mpfr-3.1.2-b/src/li2.c	2014-04-15 21:56:49.653058661 +0000
+@@ -630,5 +630,5 @@
+       return mpfr_check_range (y, inexact, rnd_mode);
+     }
+ 
+-  MPFR_ASSERTN (0);             /* should never reach this point */
++  MPFR_RET_NEVER_GO_HERE ();
+ }
+diff -Naurd mpfr-3.1.2-a/src/mpfr.h mpfr-3.1.2-b/src/mpfr.h
+--- mpfr-3.1.2-a/src/mpfr.h	2014-04-15 21:56:49.609057464 +0000
++++ mpfr-3.1.2-b/src/mpfr.h	2014-04-15 21:56:49.697059857 +0000
+@@ -27,7 +27,7 @@
+ #define MPFR_VERSION_MAJOR 3
+ #define MPFR_VERSION_MINOR 1
+ #define MPFR_VERSION_PATCHLEVEL 2
+-#define MPFR_VERSION_STRING "3.1.2-p5"
++#define MPFR_VERSION_STRING "3.1.2-p6"
+ 
+ /* Macros dealing with MPFR VERSION */
+ #define MPFR_VERSION_NUM(a,b,c) (((a) << 16L) | ((b) << 8) | (c))
+diff -Naurd mpfr-3.1.2-a/src/version.c mpfr-3.1.2-b/src/version.c
+--- mpfr-3.1.2-a/src/version.c	2014-04-15 21:56:49.609057464 +0000
++++ mpfr-3.1.2-b/src/version.c	2014-04-15 21:56:49.697059857 +0000
+@@ -25,5 +25,5 @@
+ const char *
+ mpfr_get_version (void)
+ {
+-  return "3.1.2-p5";
++  return "3.1.2-p6";
+ }
+diff -Naurd mpfr-3.1.2-a/PATCHES mpfr-3.1.2-b/PATCHES
+--- mpfr-3.1.2-a/PATCHES	2014-04-15 22:04:57.090286262 +0000
++++ mpfr-3.1.2-b/PATCHES	2014-04-15 22:04:57.162288198 +0000
+@@ -0,0 +1 @@
++exp3
+diff -Naurd mpfr-3.1.2-a/VERSION mpfr-3.1.2-b/VERSION
+--- mpfr-3.1.2-a/VERSION	2014-04-15 22:04:57.086286154 +0000
++++ mpfr-3.1.2-b/VERSION	2014-04-15 22:04:57.162288198 +0000
+@@ -1 +1 @@
+-3.1.2-p6
++3.1.2-p7
+diff -Naurd mpfr-3.1.2-a/src/exp3.c mpfr-3.1.2-b/src/exp3.c
+--- mpfr-3.1.2-a/src/exp3.c	2013-03-13 15:37:34.000000000 +0000
++++ mpfr-3.1.2-b/src/exp3.c	2014-04-15 22:04:57.126287230 +0000
+@@ -283,7 +283,7 @@
+             }
+         }
+ 
+-      if (mpfr_can_round (shift_x > 0 ? t : tmp, realprec, MPFR_RNDD, MPFR_RNDZ,
++      if (mpfr_can_round (shift_x > 0 ? t : tmp, realprec, MPFR_RNDN, MPFR_RNDZ,
+                           MPFR_PREC(y) + (rnd_mode == MPFR_RNDN)))
+         {
+           inexact = mpfr_set (y, shift_x > 0 ? t : tmp, rnd_mode);
+diff -Naurd mpfr-3.1.2-a/src/mpfr.h mpfr-3.1.2-b/src/mpfr.h
+--- mpfr-3.1.2-a/src/mpfr.h	2014-04-15 22:04:57.086286154 +0000
++++ mpfr-3.1.2-b/src/mpfr.h	2014-04-15 22:04:57.162288198 +0000
+@@ -27,7 +27,7 @@
+ #define MPFR_VERSION_MAJOR 3
+ #define MPFR_VERSION_MINOR 1
+ #define MPFR_VERSION_PATCHLEVEL 2
+-#define MPFR_VERSION_STRING "3.1.2-p6"
++#define MPFR_VERSION_STRING "3.1.2-p7"
+ 
+ /* Macros dealing with MPFR VERSION */
+ #define MPFR_VERSION_NUM(a,b,c) (((a) << 16L) | ((b) << 8) | (c))
+diff -Naurd mpfr-3.1.2-a/src/version.c mpfr-3.1.2-b/src/version.c
+--- mpfr-3.1.2-a/src/version.c	2014-04-15 22:04:57.090286262 +0000
++++ mpfr-3.1.2-b/src/version.c	2014-04-15 22:04:57.162288198 +0000
+@@ -25,5 +25,5 @@
+ const char *
+ mpfr_get_version (void)
+ {
+-  return "3.1.2-p6";
++  return "3.1.2-p7";
+ }
+diff -Naurd mpfr-3.1.2-a/tests/texp.c mpfr-3.1.2-b/tests/texp.c
+--- mpfr-3.1.2-a/tests/texp.c	2013-03-13 15:37:44.000000000 +0000
++++ mpfr-3.1.2-b/tests/texp.c	2014-04-15 22:04:57.126287230 +0000
+@@ -150,6 +150,22 @@
+       exit (1);
+     }
+ 
++  mpfr_set_prec (x, 118);
++  mpfr_set_str_binary (x, "0.1110010100011101010000111110011000000000000000000000000000000000000000000000000000000000000000000000000000000000000000E-86");
++  mpfr_set_prec (y, 118);
++  mpfr_exp_2 (y, x, MPFR_RNDU);
++  mpfr_exp_3 (x, x, MPFR_RNDU);
++  if (mpfr_cmp (x, y))
++    {
++      printf ("mpfr_exp_2 and mpfr_exp_3 differ for prec=118\n");
++      printf ("mpfr_exp_2 gives ");
++      mpfr_out_str (stdout, 2, 0, y, MPFR_RNDN);
++      printf ("\nmpfr_exp_3 gives ");
++      mpfr_out_str (stdout, 2, 0, x, MPFR_RNDN);
++      printf ("\n");
++      exit (1);
++    }
++
+   mpfr_clear (x);
+   mpfr_clear (y);
+   return 0;
+diff -Naurd mpfr-3.1.2-a/PATCHES mpfr-3.1.2-b/PATCHES
+--- mpfr-3.1.2-a/PATCHES	2014-04-15 22:20:32.243481506 +0000
++++ mpfr-3.1.2-b/PATCHES	2014-04-15 22:22:32.418722707 +0000
+@@ -0,0 +1 @@
++gmp6-compat
+diff -Naurd mpfr-3.1.2-a/VERSION mpfr-3.1.2-b/VERSION
+--- mpfr-3.1.2-a/VERSION	2014-04-15 22:20:20.755171478 +0000
++++ mpfr-3.1.2-b/VERSION	2014-04-15 22:21:45.225450147 +0000
+@@ -1 +1 @@
+-3.1.2-p7
++3.1.2-p8
+diff -Naurd mpfr-3.1.2-a/configure mpfr-3.1.2-b/configure
+--- mpfr-3.1.2-a/configure	2013-03-13 15:38:20.000000000 +0000
++++ mpfr-3.1.2-b/configure	2014-04-15 22:21:38.821277476 +0000
+@@ -14545,26 +14545,30 @@
+ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ fi
+ 
+-if test "$use_gmp_build" = yes ; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for valid GMP_NUMB_BITS" >&5
+-$as_echo_n "checking for valid GMP_NUMB_BITS... " >&6; }
+-  if test "$cross_compiling" = yes; then :
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for GMP_NUMB_BITS and sizeof(mp_limb_t) consistency" >&5
++$as_echo_n "checking for GMP_NUMB_BITS and sizeof(mp_limb_t) consistency... " >&6; }
++if test "$cross_compiling" = yes; then :
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: can't test" >&5
+ $as_echo "can't test" >&6; }
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdio.h>
+ #include <limits.h>
+ #include "gmp.h"
+-#include "gmp-impl.h"
+ 
+ int
+ main ()
+ {
+ 
+-  return GMP_NUMB_BITS == BYTES_PER_MP_LIMB * CHAR_BIT
+-         && sizeof(mp_limb_t) == BYTES_PER_MP_LIMB ? 0 : 1;
++  if (GMP_NUMB_BITS == sizeof(mp_limb_t) * CHAR_BIT)
++    return 0;
++  fprintf (stderr, "GMP_NUMB_BITS     = %ld\n", (long) GMP_NUMB_BITS);
++  fprintf (stderr, "sizeof(mp_limb_t) = %ld\n", (long) sizeof(mp_limb_t));
++  fprintf (stderr, "sizeof(mp_limb_t) * CHAR_BIT = %ld != GMP_NUMB_BITS\n",
++           (long) (sizeof(mp_limb_t) * CHAR_BIT));
++  return 1;
+ 
+   ;
+   return 0;
+@@ -14577,14 +14581,14 @@
+ 
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ $as_echo "no" >&6; }
+-       as_fn_error $? "GMP_NUMB_BITS is incorrect.
+-You probably need to change some of the GMP or MPFR compile options." "$LINENO" 5
++       as_fn_error $? "GMP_NUMB_BITS and sizeof(mp_limb_t) are not consistent.
++You probably need to change some of the GMP or MPFR compile options.
++See 'config.log' for details (search for GMP_NUMB_BITS)." "$LINENO" 5
+ fi
+ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+   conftest.$ac_objext conftest.beam conftest.$ac_ext
+ fi
+ 
+-fi
+ 
+ 
+ if test "$dont_link_with_gmp" = yes ; then
+diff -Naurd mpfr-3.1.2-a/configure.ac mpfr-3.1.2-b/configure.ac
+--- mpfr-3.1.2-a/configure.ac	2013-03-13 15:37:46.000000000 +0000
++++ mpfr-3.1.2-b/configure.ac	2013-03-13 15:37:46.000000000 +0000
+@@ -435,23 +435,29 @@
+    ])
+ fi
+ 
+-dnl Check for valid GMP_NUMB_BITS and BYTES_PER_MP_LIMB
++dnl Check for GMP_NUMB_BITS and sizeof(mp_limb_t) consistency.
++dnl Problems may occur if gmp.h was generated with some ABI
++dnl and is used with another ABI (or if nails are used).
+ dnl This test doesn't need to link with libgmp (at least it shouldn't).
+-if test "$use_gmp_build" = yes ; then
+-  AC_MSG_CHECKING(for valid GMP_NUMB_BITS)
+-  AC_RUN_IFELSE([AC_LANG_PROGRAM([[
++AC_MSG_CHECKING(for GMP_NUMB_BITS and sizeof(mp_limb_t) consistency)
++AC_RUN_IFELSE([AC_LANG_PROGRAM([[
++#include <stdio.h>
+ #include <limits.h>
+ #include "gmp.h"
+-#include "gmp-impl.h"
+ ]], [[
+-  return GMP_NUMB_BITS == BYTES_PER_MP_LIMB * CHAR_BIT
+-         && sizeof(mp_limb_t) == BYTES_PER_MP_LIMB ? 0 : 1;
++  if (GMP_NUMB_BITS == sizeof(mp_limb_t) * CHAR_BIT)
++    return 0;
++  fprintf (stderr, "GMP_NUMB_BITS     = %ld\n", (long) GMP_NUMB_BITS);
++  fprintf (stderr, "sizeof(mp_limb_t) = %ld\n", (long) sizeof(mp_limb_t));
++  fprintf (stderr, "sizeof(mp_limb_t) * CHAR_BIT = %ld != GMP_NUMB_BITS\n",
++           (long) (sizeof(mp_limb_t) * CHAR_BIT));
++  return 1;
+ ]])], [AC_MSG_RESULT(yes)], [
+        AC_MSG_RESULT(no)
+-       AC_MSG_ERROR([GMP_NUMB_BITS is incorrect.
+-You probably need to change some of the GMP or MPFR compile options.])],
++       AC_MSG_ERROR([GMP_NUMB_BITS and sizeof(mp_limb_t) are not consistent.
++You probably need to change some of the GMP or MPFR compile options.
++See 'config.log' for details (search for GMP_NUMB_BITS).])],
+        [AC_MSG_RESULT([can't test])])
+-fi
+ 
+ 
+ dnl We really need to link using libtool. But it is impossible with the current
+diff -Naurd mpfr-3.1.2-a/src/init2.c mpfr-3.1.2-b/src/init2.c
+--- mpfr-3.1.2-a/src/init2.c	2013-03-13 15:37:32.000000000 +0000
++++ mpfr-3.1.2-b/src/init2.c	2014-04-15 22:21:06.220398489 +0000
+@@ -30,11 +30,11 @@
+ 
+   /* Check if we can represent the number of limbs
+    * associated to the maximum of mpfr_prec_t*/
+-  MPFR_ASSERTN( MP_SIZE_T_MAX >= (MPFR_PREC_MAX/BYTES_PER_MP_LIMB) );
++  MPFR_ASSERTN( MP_SIZE_T_MAX >= (MPFR_PREC_MAX/MPFR_BYTES_PER_MP_LIMB) );
+ 
+-  /* Check for correct GMP_NUMB_BITS and BYTES_PER_MP_LIMB */
+-  MPFR_ASSERTN( GMP_NUMB_BITS == BYTES_PER_MP_LIMB * CHAR_BIT
+-                && sizeof(mp_limb_t) == BYTES_PER_MP_LIMB );
++  /* Check for correct GMP_NUMB_BITS and MPFR_BYTES_PER_MP_LIMB */
++  MPFR_ASSERTN( GMP_NUMB_BITS == MPFR_BYTES_PER_MP_LIMB * CHAR_BIT
++                && sizeof(mp_limb_t) == MPFR_BYTES_PER_MP_LIMB );
+ 
+   MPFR_ASSERTN (mp_bits_per_limb == GMP_NUMB_BITS);
+ 
+diff -Naurd mpfr-3.1.2-a/src/mpfr-gmp.h mpfr-3.1.2-b/src/mpfr-gmp.h
+--- mpfr-3.1.2-a/src/mpfr-gmp.h	2013-03-13 15:37:32.000000000 +0000
++++ mpfr-3.1.2-b/src/mpfr-gmp.h	2014-04-15 22:21:06.220398489 +0000
+@@ -72,7 +72,6 @@
+ #endif
+ 
+ /* Define some macros */
+-#define BYTES_PER_MP_LIMB (GMP_NUMB_BITS/CHAR_BIT)
+ 
+ #define MP_LIMB_T_MAX (~(mp_limb_t)0)
+ 
+@@ -96,19 +95,19 @@
+ #define SHRT_HIGHBIT       SHRT_MIN
+ 
+ /* MP_LIMB macros */
+-#define MPN_ZERO(dst, n) memset((dst), 0, (n)*BYTES_PER_MP_LIMB)
+-#define MPN_COPY_DECR(dst,src,n) memmove((dst),(src),(n)*BYTES_PER_MP_LIMB)
+-#define MPN_COPY_INCR(dst,src,n) memmove((dst),(src),(n)*BYTES_PER_MP_LIMB)
++#define MPN_ZERO(dst, n) memset((dst), 0, (n)*MPFR_BYTES_PER_MP_LIMB)
++#define MPN_COPY_DECR(dst,src,n) memmove((dst),(src),(n)*MPFR_BYTES_PER_MP_LIMB)
++#define MPN_COPY_INCR(dst,src,n) memmove((dst),(src),(n)*MPFR_BYTES_PER_MP_LIMB)
+ #define MPN_COPY(dst,src,n) \
+   do                                                                  \
+     {                                                                 \
+       if ((dst) != (src))                                             \
+         {                                                             \
+           MPFR_ASSERTD ((char *) (dst) >= (char *) (src) +            \
+-                                          (n) * BYTES_PER_MP_LIMB ||  \
++                                     (n) * MPFR_BYTES_PER_MP_LIMB ||  \
+                         (char *) (src) >= (char *) (dst) +            \
+-                                          (n) * BYTES_PER_MP_LIMB);   \
+-          memcpy ((dst), (src), (n) * BYTES_PER_MP_LIMB);             \
++                                     (n) * MPFR_BYTES_PER_MP_LIMB);   \
++          memcpy ((dst), (src), (n) * MPFR_BYTES_PER_MP_LIMB);        \
+         }                                                             \
+     }                                                                 \
+   while (0)
+diff -Naurd mpfr-3.1.2-a/src/mpfr-impl.h mpfr-3.1.2-b/src/mpfr-impl.h
+--- mpfr-3.1.2-a/src/mpfr-impl.h	2013-10-09 13:34:21.000000000 +0000
++++ mpfr-3.1.2-b/src/mpfr-impl.h	2014-04-15 22:21:06.220398489 +0000
+@@ -191,7 +191,7 @@
+ # endif
+ #endif
+ 
+-
++#define MPFR_BYTES_PER_MP_LIMB (GMP_NUMB_BITS/CHAR_BIT)
+ 
+ /******************************************************
+  ******************** Check GMP ***********************
+@@ -930,7 +930,7 @@
+ #define MPFR_SET_ALLOC_SIZE(x, n) \
+  ( ((mp_size_t*) MPFR_MANT(x))[-1] = n)
+ #define MPFR_MALLOC_SIZE(s) \
+-  ( sizeof(mpfr_size_limb_t) + BYTES_PER_MP_LIMB * ((size_t) s) )
++  ( sizeof(mpfr_size_limb_t) + MPFR_BYTES_PER_MP_LIMB * ((size_t) s) )
+ #define MPFR_SET_MANT_PTR(x,p) \
+    (MPFR_MANT(x) = (mp_limb_t*) ((mpfr_size_limb_t*) p + 1))
+ #define MPFR_GET_REAL_PTR(x) \
+@@ -964,7 +964,7 @@
+ #endif
+ 
+ #define MPFR_TMP_LIMBS_ALLOC(N) \
+-  ((mp_limb_t *) MPFR_TMP_ALLOC ((size_t) (N) * BYTES_PER_MP_LIMB))
++  ((mp_limb_t *) MPFR_TMP_ALLOC ((size_t) (N) * MPFR_BYTES_PER_MP_LIMB))
+ 
+ /* temporary allocate 1 limb at xp, and initialize mpfr variable x */
+ /* The temporary var doesn't have any size field, but it doesn't matter
+diff -Naurd mpfr-3.1.2-a/src/mpfr.h mpfr-3.1.2-b/src/mpfr.h
+--- mpfr-3.1.2-a/src/mpfr.h	2014-04-15 22:20:20.755171478 +0000
++++ mpfr-3.1.2-b/src/mpfr.h	2014-04-15 22:21:45.225450147 +0000
+@@ -27,7 +27,7 @@
+ #define MPFR_VERSION_MAJOR 3
+ #define MPFR_VERSION_MINOR 1
+ #define MPFR_VERSION_PATCHLEVEL 2
+-#define MPFR_VERSION_STRING "3.1.2-p7"
++#define MPFR_VERSION_STRING "3.1.2-p8"
+ 
+ /* Macros dealing with MPFR VERSION */
+ #define MPFR_VERSION_NUM(a,b,c) (((a) << 16L) | ((b) << 8) | (c))
+diff -Naurd mpfr-3.1.2-a/src/mul.c mpfr-3.1.2-b/src/mul.c
+--- mpfr-3.1.2-a/src/mul.c	2013-03-13 15:37:37.000000000 +0000
++++ mpfr-3.1.2-b/src/mul.c	2014-04-15 22:21:06.224398597 +0000
+@@ -106,7 +106,7 @@
+   MPFR_ASSERTD(tn <= k);
+ 
+   /* Check for no size_t overflow*/
+-  MPFR_ASSERTD((size_t) k <= ((size_t) -1) / BYTES_PER_MP_LIMB);
++  MPFR_ASSERTD((size_t) k <= ((size_t) -1) / MPFR_BYTES_PER_MP_LIMB);
+   MPFR_TMP_MARK(marker);
+   tmp = MPFR_TMP_LIMBS_ALLOC (k);
+ 
+@@ -301,7 +301,7 @@
+   MPFR_ASSERTD (tn <= k); /* tn <= k, thus no int overflow */
+ 
+   /* Check for no size_t overflow*/
+-  MPFR_ASSERTD ((size_t) k <= ((size_t) -1) / BYTES_PER_MP_LIMB);
++  MPFR_ASSERTD ((size_t) k <= ((size_t) -1) / MPFR_BYTES_PER_MP_LIMB);
+   MPFR_TMP_MARK (marker);
+   tmp = MPFR_TMP_LIMBS_ALLOC (k);
+ 
+diff -Naurd mpfr-3.1.2-a/src/stack_interface.c mpfr-3.1.2-b/src/stack_interface.c
+--- mpfr-3.1.2-a/src/stack_interface.c	2013-03-13 15:37:32.000000000 +0000
++++ mpfr-3.1.2-b/src/stack_interface.c	2014-04-15 22:21:06.220398489 +0000
+@@ -26,7 +26,7 @@
+ size_t
+ mpfr_custom_get_size (mpfr_prec_t prec)
+ {
+-  return MPFR_PREC2LIMBS (prec) * BYTES_PER_MP_LIMB;
++  return MPFR_PREC2LIMBS (prec) * MPFR_BYTES_PER_MP_LIMB;
+ }
+ 
+ #undef mpfr_custom_init
+diff -Naurd mpfr-3.1.2-a/src/version.c mpfr-3.1.2-b/src/version.c
+--- mpfr-3.1.2-a/src/version.c	2014-04-15 22:20:20.755171478 +0000
++++ mpfr-3.1.2-b/src/version.c	2014-04-15 22:21:45.225450147 +0000
+@@ -25,5 +25,5 @@
+ const char *
+ mpfr_get_version (void)
+ {
+-  return "3.1.2-p7";
++  return "3.1.2-p8";
+ }
+diff -Naurd mpfr-3.1.2-a/PATCHES mpfr-3.1.2-b/PATCHES
+--- mpfr-3.1.2-a/PATCHES	2014-06-30 15:15:25.533266905 +0000
++++ mpfr-3.1.2-b/PATCHES	2014-06-30 15:15:25.617269178 +0000
+@@ -0,0 +1 @@
++div-overflow
+diff -Naurd mpfr-3.1.2-a/VERSION mpfr-3.1.2-b/VERSION
+--- mpfr-3.1.2-a/VERSION	2014-06-30 15:15:25.529266797 +0000
++++ mpfr-3.1.2-b/VERSION	2014-06-30 15:15:25.617269178 +0000
+@@ -1 +1 @@
+-3.1.2-p8
++3.1.2-p9
+diff -Naurd mpfr-3.1.2-a/src/div.c mpfr-3.1.2-b/src/div.c
+--- mpfr-3.1.2-a/src/div.c	2013-03-13 15:37:33.000000000 +0000
++++ mpfr-3.1.2-b/src/div.c	2014-06-30 15:15:25.585268312 +0000
+@@ -750,7 +750,9 @@
+  truncate_check_qh:
+   if (qh)
+     {
+-      qexp ++;
++      if (MPFR_LIKELY (qexp < MPFR_EXP_MAX))
++        qexp ++;
++      /* else qexp is now incorrect, but one will still get an overflow */
+       q0p[q0size - 1] = MPFR_LIMB_HIGHBIT;
+     }
+   goto truncate;
+@@ -765,7 +767,9 @@
+   inex = 1; /* always here */
+   if (mpn_add_1 (q0p, q0p, q0size, MPFR_LIMB_ONE << sh))
+     {
+-      qexp ++;
++      if (MPFR_LIKELY (qexp < MPFR_EXP_MAX))
++        qexp ++;
++      /* else qexp is now incorrect, but one will still get an overflow */
+       q0p[q0size - 1] = MPFR_LIMB_HIGHBIT;
+     }
+ 
+diff -Naurd mpfr-3.1.2-a/src/mpfr.h mpfr-3.1.2-b/src/mpfr.h
+--- mpfr-3.1.2-a/src/mpfr.h	2014-06-30 15:15:25.533266905 +0000
++++ mpfr-3.1.2-b/src/mpfr.h	2014-06-30 15:15:25.613269070 +0000
+@@ -27,7 +27,7 @@
+ #define MPFR_VERSION_MAJOR 3
+ #define MPFR_VERSION_MINOR 1
+ #define MPFR_VERSION_PATCHLEVEL 2
+-#define MPFR_VERSION_STRING "3.1.2-p8"
++#define MPFR_VERSION_STRING "3.1.2-p9"
+ 
+ /* Macros dealing with MPFR VERSION */
+ #define MPFR_VERSION_NUM(a,b,c) (((a) << 16L) | ((b) << 8) | (c))
+diff -Naurd mpfr-3.1.2-a/src/version.c mpfr-3.1.2-b/src/version.c
+--- mpfr-3.1.2-a/src/version.c	2014-06-30 15:15:25.533266905 +0000
++++ mpfr-3.1.2-b/src/version.c	2014-06-30 15:15:25.613269070 +0000
+@@ -25,5 +25,5 @@
+ const char *
+ mpfr_get_version (void)
+ {
+-  return "3.1.2-p8";
++  return "3.1.2-p9";
+ }
+diff -Naurd mpfr-3.1.2-a/tests/tdiv.c mpfr-3.1.2-b/tests/tdiv.c
+--- mpfr-3.1.2-a/tests/tdiv.c	2013-03-13 15:37:44.000000000 +0000
++++ mpfr-3.1.2-b/tests/tdiv.c	2014-06-30 15:15:25.585268312 +0000
+@@ -1104,6 +1104,96 @@
+ #define RAND_FUNCTION(x) mpfr_random2(x, MPFR_LIMB_SIZE (x), randlimb () % 100, RANDS)
+ #include "tgeneric.c"
+ 
++static void
++test_extreme (void)
++{
++  mpfr_t x, y, z;
++  mpfr_exp_t emin, emax;
++  mpfr_prec_t p[4] = { 8, 32, 64, 256 };
++  int xi, yi, zi, j, r;
++  unsigned int flags, ex_flags;
++
++  emin = mpfr_get_emin ();
++  emax = mpfr_get_emax ();
++
++  mpfr_set_emin (MPFR_EMIN_MIN);
++  mpfr_set_emax (MPFR_EMAX_MAX);
++
++  for (xi = 0; xi < 4; xi++)
++    {
++      mpfr_init2 (x, p[xi]);
++      mpfr_setmax (x, MPFR_EMAX_MAX);
++      MPFR_ASSERTN (mpfr_check (x));
++      for (yi = 0; yi < 4; yi++)
++        {
++          mpfr_init2 (y, p[yi]);
++          mpfr_setmin (y, MPFR_EMIN_MIN);
++          for (j = 0; j < 2; j++)
++            {
++              MPFR_ASSERTN (mpfr_check (y));
++              for (zi = 0; zi < 4; zi++)
++                {
++                  mpfr_init2 (z, p[zi]);
++                  RND_LOOP (r)
++                    {
++                      mpfr_clear_flags ();
++                      mpfr_div (z, x, y, (mpfr_rnd_t) r);
++                      flags = __gmpfr_flags;
++                      MPFR_ASSERTN (mpfr_check (z));
++                      ex_flags = MPFR_FLAGS_OVERFLOW | MPFR_FLAGS_INEXACT;
++                      if (flags != ex_flags)
++                        {
++                          printf ("Bad flags in test_extreme on z = a/b"
++                                  " with %s and\n",
++                                  mpfr_print_rnd_mode ((mpfr_rnd_t) r));
++                          printf ("a = ");
++                          mpfr_dump (x);
++                          printf ("b = ");
++                          mpfr_dump (y);
++                          printf ("Expected flags:");
++                          flags_out (ex_flags);
++                          printf ("Got flags:     ");
++                          flags_out (flags);
++                          printf ("z = ");
++                          mpfr_dump (z);
++                          exit (1);
++                        }
++                      mpfr_clear_flags ();
++                      mpfr_div (z, y, x, (mpfr_rnd_t) r);
++                      flags = __gmpfr_flags;
++                      MPFR_ASSERTN (mpfr_check (z));
++                      ex_flags = MPFR_FLAGS_UNDERFLOW | MPFR_FLAGS_INEXACT;
++                      if (flags != ex_flags)
++                        {
++                          printf ("Bad flags in test_extreme on z = a/b"
++                                  " with %s and\n",
++                                  mpfr_print_rnd_mode ((mpfr_rnd_t) r));
++                          printf ("a = ");
++                          mpfr_dump (y);
++                          printf ("b = ");
++                          mpfr_dump (x);
++                          printf ("Expected flags:");
++                          flags_out (ex_flags);
++                          printf ("Got flags:     ");
++                          flags_out (flags);
++                          printf ("z = ");
++                          mpfr_dump (z);
++                          exit (1);
++                        }
++                    }
++                  mpfr_clear (z);
++                }  /* zi */
++              mpfr_nextabove (y);
++            }  /* j */
++          mpfr_clear (y);
++        }  /* yi */
++      mpfr_clear (x);
++    }  /* xi */
++
++  set_emin (emin);
++  set_emax (emax);
++}
++
+ int
+ main (int argc, char *argv[])
+ {
+@@ -1130,6 +1220,7 @@
+   test_20070603 ();
+   test_20070628 ();
+   test_generic (2, 800, 50);
++  test_extreme ();
+ 
+   tests_end_mpfr ();
+   return 0;
+diff -Naurd mpfr-3.1.2-a/PATCHES mpfr-3.1.2-b/PATCHES
+--- mpfr-3.1.2-a/PATCHES	2014-06-30 15:17:53.337268149 +0000
++++ mpfr-3.1.2-b/PATCHES	2014-06-30 15:17:53.417270314 +0000
+@@ -0,0 +1 @@
++vasprintf
+diff -Naurd mpfr-3.1.2-a/VERSION mpfr-3.1.2-b/VERSION
+--- mpfr-3.1.2-a/VERSION	2014-06-30 15:17:53.337268149 +0000
++++ mpfr-3.1.2-b/VERSION	2014-06-30 15:17:53.413270206 +0000
+@@ -1 +1 @@
+-3.1.2-p9
++3.1.2-p10
+diff -Naurd mpfr-3.1.2-a/src/mpfr.h mpfr-3.1.2-b/src/mpfr.h
+--- mpfr-3.1.2-a/src/mpfr.h	2014-06-30 15:17:53.337268149 +0000
++++ mpfr-3.1.2-b/src/mpfr.h	2014-06-30 15:17:53.413270206 +0000
+@@ -27,7 +27,7 @@
+ #define MPFR_VERSION_MAJOR 3
+ #define MPFR_VERSION_MINOR 1
+ #define MPFR_VERSION_PATCHLEVEL 2
+-#define MPFR_VERSION_STRING "3.1.2-p9"
++#define MPFR_VERSION_STRING "3.1.2-p10"
+ 
+ /* Macros dealing with MPFR VERSION */
+ #define MPFR_VERSION_NUM(a,b,c) (((a) << 16L) | ((b) << 8) | (c))
+diff -Naurd mpfr-3.1.2-a/src/vasprintf.c mpfr-3.1.2-b/src/vasprintf.c
+--- mpfr-3.1.2-a/src/vasprintf.c	2013-11-15 00:51:49.267334408 +0000
++++ mpfr-3.1.2-b/src/vasprintf.c	2014-06-30 15:17:53.377269231 +0000
+@@ -884,14 +884,18 @@
+            first digit, we want the exponent for radix two and the decimal
+            point AFTER the first digit. */
+         {
+-          MPFR_ASSERTN (exp > MPFR_EMIN_MIN /4); /* possible overflow */
++          /* An integer overflow is normally not possible since MPFR_EXP_MIN
++             is twice as large as MPFR_EMIN_MIN. */
++          MPFR_ASSERTN (exp > (MPFR_EXP_MIN + 3) / 4);
+           exp = (exp - 1) * 4;
+         }
+       else
+         /* EXP is the exponent for decimal point BEFORE the first digit, we
+            want the exponent for decimal point AFTER the first digit. */
+         {
+-          MPFR_ASSERTN (exp > MPFR_EMIN_MIN); /* possible overflow */
++          /* An integer overflow is normally not possible since MPFR_EXP_MIN
++             is twice as large as MPFR_EMIN_MIN. */
++          MPFR_ASSERTN (exp > MPFR_EXP_MIN);
+           --exp;
+         }
+     }
+diff -Naurd mpfr-3.1.2-a/src/version.c mpfr-3.1.2-b/src/version.c
+--- mpfr-3.1.2-a/src/version.c	2014-06-30 15:17:53.337268149 +0000
++++ mpfr-3.1.2-b/src/version.c	2014-06-30 15:17:53.413270206 +0000
+@@ -25,5 +25,5 @@
+ const char *
+ mpfr_get_version (void)
+ {
+-  return "3.1.2-p9";
++  return "3.1.2-p10";
+ }
+diff -Naurd mpfr-3.1.2-a/tests/tsprintf.c mpfr-3.1.2-b/tests/tsprintf.c
+--- mpfr-3.1.2-a/tests/tsprintf.c	2013-11-15 00:51:49.267334408 +0000
++++ mpfr-3.1.2-b/tests/tsprintf.c	2014-06-30 15:17:53.377269231 +0000
+@@ -1184,6 +1184,69 @@
+   check_emax_aux (MPFR_EMAX_MAX);
+ }
+ 
++static void
++check_emin_aux (mpfr_exp_t e)
++{
++  mpfr_t x;
++  char *s1, s2[256];
++  int i;
++  mpfr_exp_t emin;
++  mpz_t ee;
++
++  MPFR_ASSERTN (e >= LONG_MIN);
++  emin = mpfr_get_emin ();
++  set_emin (e);
++
++  mpfr_init2 (x, 16);
++  mpz_init (ee);
++
++  mpfr_setmin (x, e);
++  mpz_set_si (ee, e);
++  mpz_sub_ui (ee, ee, 1);
++
++  i = mpfr_asprintf (&s1, "%Ra", x);
++  MPFR_ASSERTN (i > 0);
++
++  gmp_snprintf (s2, 256, "0x1p%Zd", ee);
++
++  if (strcmp (s1, s2) != 0)
++    {
++      printf ("Error in check_emin_aux for emin = %ld\n", (long) e);
++      printf ("Expected %s\n", s2);
++      printf ("Got      %s\n", s1);
++      exit (1);
++    }
++
++  mpfr_free_str (s1);
++
++  i = mpfr_asprintf (&s1, "%Rb", x);
++  MPFR_ASSERTN (i > 0);
++
++  gmp_snprintf (s2, 256, "1p%Zd", ee);
++
++  if (strcmp (s1, s2) != 0)
++    {
++      printf ("Error in check_emin_aux for emin = %ld\n", (long) e);
++      printf ("Expected %s\n", s2);
++      printf ("Got      %s\n", s1);
++      exit (1);
++    }
++
++  mpfr_free_str (s1);
++
++  mpfr_clear (x);
++  mpz_clear (ee);
++  set_emin (emin);
++}
++
++static void
++check_emin (void)
++{
++  check_emin_aux (-15);
++  check_emin_aux (mpfr_get_emin ());
++  check_emin_aux (MPFR_EMIN_MIN);
++}
++
+ int
+ main (int argc, char **argv)
+ {
+@@ -1203,6 +1266,7 @@
+   decimal ();
+   mixed ();
+   check_emax ();
++  check_emin ();
+ 
+ #if defined(HAVE_LOCALE_H) && defined(HAVE_SETLOCALE)
+   locale_da_DK ();
+diff -Naurd mpfr-3.1.2-a/PATCHES mpfr-3.1.2-b/PATCHES
+--- mpfr-3.1.2-a/PATCHES	2014-12-04 01:41:57.131789485 +0000
++++ mpfr-3.1.2-b/PATCHES	2014-12-04 01:41:57.339791833 +0000
+@@ -0,0 +1 @@
++strtofr
+diff -Naurd mpfr-3.1.2-a/VERSION mpfr-3.1.2-b/VERSION
+--- mpfr-3.1.2-a/VERSION	2014-12-04 01:41:57.127789443 +0000
++++ mpfr-3.1.2-b/VERSION	2014-12-04 01:41:57.339791833 +0000
+@@ -1 +1 @@
+-3.1.2-p10
++3.1.2-p11
+diff -Naurd mpfr-3.1.2-a/src/mpfr.h mpfr-3.1.2-b/src/mpfr.h
+--- mpfr-3.1.2-a/src/mpfr.h	2014-12-04 01:41:57.127789443 +0000
++++ mpfr-3.1.2-b/src/mpfr.h	2014-12-04 01:41:57.335791790 +0000
+@@ -27,7 +27,7 @@
+ #define MPFR_VERSION_MAJOR 3
+ #define MPFR_VERSION_MINOR 1
+ #define MPFR_VERSION_PATCHLEVEL 2
+-#define MPFR_VERSION_STRING "3.1.2-p10"
++#define MPFR_VERSION_STRING "3.1.2-p11"
+ 
+ /* Macros dealing with MPFR VERSION */
+ #define MPFR_VERSION_NUM(a,b,c) (((a) << 16L) | ((b) << 8) | (c))
+diff -Naurd mpfr-3.1.2-a/src/strtofr.c mpfr-3.1.2-b/src/strtofr.c
+--- mpfr-3.1.2-a/src/strtofr.c	2013-03-13 15:37:32.000000000 +0000
++++ mpfr-3.1.2-b/src/strtofr.c	2014-12-04 01:41:57.287791246 +0000
+@@ -473,8 +473,10 @@
+       /* prec bits corresponds to ysize limbs */
+       ysize_bits = ysize * GMP_NUMB_BITS;
+       /* and to ysize_bits >= prec > MPFR_PREC (x) bits */
+-      y = MPFR_TMP_LIMBS_ALLOC (2 * ysize + 1);
+-      y += ysize; /* y has (ysize+1) allocated limbs */
++      /* we need to allocate one more limb to work around bug
++         https://gmplib.org/list-archives/gmp-bugs/2013-December/003267.html */
++      y = MPFR_TMP_LIMBS_ALLOC (2 * ysize + 2);
++      y += ysize; /* y has (ysize+2) allocated limbs */
+ 
+       /* pstr_size is the number of characters we read in pstr->mant
+          to have at least ysize full limbs.
+diff -Naurd mpfr-3.1.2-a/src/version.c mpfr-3.1.2-b/src/version.c
+--- mpfr-3.1.2-a/src/version.c	2014-12-04 01:41:57.131789485 +0000
++++ mpfr-3.1.2-b/src/version.c	2014-12-04 01:41:57.339791833 +0000
+@@ -25,5 +25,5 @@
+ const char *
+ mpfr_get_version (void)
+ {
+-  return "3.1.2-p10";
++  return "3.1.2-p11";
+ }

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.3.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'M4'
+version = '1.4.17'
+
+homepage = 'http://www.gnu.org/software/m4/m4.html'
+description = """GNU M4 is an implementation of the traditional Unix macro processor. It is mostly SVR4 compatible
+  although it has some extensions (for example, handling more than 9 positional parameters to macros).
+ GNU M4 also has built-in functions for including files, running shell commands, doing arithmetic, etc."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+# use same binutils version that was used when building GCC toolchain
+builddependencies = [('binutils', '2.25', '', True)]
+
+configopts = "--enable-cxx"
+
+sanity_check_paths = {
+    'files': ["bin/m4"],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.8-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.8-GCCcore-4.9.3.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = 'zlib'
+version = '1.2.8'
+
+homepage = 'http://www.zlib.net/'
+description = """zlib is designed to be a free, general-purpose, legally unencumbered -- that is,
+ not covered by any patents -- lossless data-compression library for use on virtually any
+ computer hardware and operating system."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [('http://sourceforge.net/projects/libpng/files/zlib/%(version)s', 'download')]
+
+# use same binutils version that was used when building GCC toolchain
+builddependencies = [('binutils', '2.25', '', True)]
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.so'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.8-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.8-GCCcore-4.9.3.eb
@@ -9,6 +9,7 @@ description = """zlib is designed to be a free, general-purpose, legally unencum
  computer hardware and operating system."""
 
 toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [('http://sourceforge.net/projects/libpng/files/zlib/%(version)s', 'download')]


### PR DESCRIPTION
requires ~~https://github.com/hpcugent/easybuild-framework/pull/1451~~ and https://github.com/hpcugent/easybuild-easyblocks/pull/773

This sort of replaces #2108, and deals with a coupe of problems there, in particular:

* avoids building GCC twice to construct the `foss` toolchain; the `GCC` is just a bundle of `GCCcore` and `binutils`
* drop `binutils` from versionsuffix of `GCCcore` (since it's only a build dep there)
* drop `-binutils-2.25` as versionsuffix for `binutils-2.25`; it looks stupid, and which binutils was used to build binutils with is most likely irrelevant

As opposed to #2108, these additional easyconfigs do not affect existing toolchain, in particular the `2015b` ones, which are close to 'end of life', and thus should not be fiddled with.

The intention is to use the `GCC/4.9.3-2.25` bundle as a base for the `2016a` toolchains (#2194 will be adjusted to use it, since `intel/2015.08` a likely candidate for `intel/2016a`).

There's a `GCC/4.9.3-binutils-2.25` too, which is an actual GCC build rather than a bundle. This may be confusing right now, but since there's no GCC 4.9 or binutils update, that's the way it is.

@ocaisa, @geimer, @wpoely86: thoughts?