### PR TITLE
added new Cray* toolchain versions with dependency pinning

### DIFF
--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.06-XC.eb
@@ -1,0 +1,20 @@
+easyblock = 'CrayToolchain'
+
+name = 'CrayCCE'
+version = '2015.06-XC'
+
+homepage = 'http://docs.cray.com/books/S-9407-1511'
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module (PE release: November 2015).\n"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+dependencies = [
+    ('PrgEnv-cray/5.2.40', EXTERNAL_MODULE),
+    ('cce/8.3.12', EXTERNAL_MODULE),
+    ('craype/2.4.0', EXTERNAL_MODULE),
+    ('cray-libsci/13.0.4', EXTERNAL_MODULE),
+    ('cray-mpich/7.2.2', EXTERNAL_MODULE),
+    ('fftw/3.3.4.3', EXTERNAL_MODULE),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.11-XC.eb
@@ -1,0 +1,20 @@
+easyblock = 'CrayToolchain'
+
+name = 'CrayCCE'
+version = '2015.11-XC'
+
+homepage = 'http://docs.cray.com/books/S-9407-1511'
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module (PE release: November 2015).\n"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+dependencies = [
+    ('PrgEnv-cray/5.2.82', EXTERNAL_MODULE),
+    ('cce/8.4.1', EXTERNAL_MODULE),
+    ('craype/2.4.2', EXTERNAL_MODULE),
+    ('cray-libsci/13.2.0', EXTERNAL_MODULE),
+    ('cray-mpich/7.2.6', EXTERNAL_MODULE),
+    ('fftw/3.3.4.5', EXTERNAL_MODULE),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.06-XC.eb
@@ -1,0 +1,20 @@
+easyblock = 'CrayToolchain'
+
+name = 'CrayGNU'
+version = '2015.06-XC'
+
+homepage = 'http://docs.cray.com/books/S-9407-1506'
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module (PE release: June 2015).\n"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+dependencies = [
+    ('PrgEnv-gnu/5.2.40', EXTERNAL_MODULE),
+    ('gcc/4.8.2', EXTERNAL_MODULE),
+    ('craype/2.4.0', EXTERNAL_MODULE),
+    ('cray-libsci/13.0.4', EXTERNAL_MODULE),
+    ('cray-mpich/7.2.2', EXTERNAL_MODULE),
+    ('fftw/3.3.4.3', EXTERNAL_MODULE),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.11-XC.eb
@@ -1,0 +1,20 @@
+easyblock = 'CrayToolchain'
+
+name = 'CrayGNU'
+version = '2015.11-XC'
+
+homepage = 'http://docs.cray.com/books/S-9407-1511'
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module (PE release: November 2015).\n"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+dependencies = [
+    ('PrgEnv-gnu/5.2.82', EXTERNAL_MODULE),
+    ('gcc/4.9.3', EXTERNAL_MODULE),
+    ('craype/2.4.2', EXTERNAL_MODULE),
+    ('cray-libsci/13.2.0', EXTERNAL_MODULE),
+    ('cray-mpich/7.2.6', EXTERNAL_MODULE),
+    ('fftw/3.3.4.5', EXTERNAL_MODULE),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.06-XC.eb
@@ -10,6 +10,7 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 dependencies = [
     ('PrgEnv-intel/5.2.82', EXTERNAL_MODULE),
+    ('intel/15.0.1.133', EXTERNAL_MODULE),
     ('craype/2.4.0', EXTERNAL_MODULE),
     ('cray-libsci/13.0.4', EXTERNAL_MODULE),
     ('cray-mpich/7.2.2', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.06-XC.eb
@@ -1,0 +1,19 @@
+easyblock = 'CrayToolchain'
+
+name = 'CrayIntel'
+version = '2015.06-XC'
+
+homepage = 'http://docs.cray.com/books/S-9407-1511'
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module (PE release: November 2015).\n"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+dependencies = [
+    ('PrgEnv-intel/5.2.82', EXTERNAL_MODULE),
+    ('craype/2.4.0', EXTERNAL_MODULE),
+    ('cray-libsci/13.0.4', EXTERNAL_MODULE),
+    ('cray-mpich/7.2.2', EXTERNAL_MODULE),
+    ('fftw/3.3.4.3', EXTERNAL_MODULE),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.11-XC.eb
@@ -1,0 +1,19 @@
+easyblock = 'CrayToolchain'
+
+name = 'CrayIntel'
+version = '2015.11-XC'
+
+homepage = 'http://docs.cray.com/books/S-9407-1511'
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module (PE release: November 2015).\n"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+dependencies = [
+    ('PrgEnv-intel/5.2.82', EXTERNAL_MODULE),
+    ('craype/2.4.2', EXTERNAL_MODULE),
+    ('cray-libsci/13.2.0', EXTERNAL_MODULE),
+    ('cray-mpich/7.2.6', EXTERNAL_MODULE),
+    ('fftw/3.3.4.5', EXTERNAL_MODULE),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.11-XC.eb
@@ -10,6 +10,7 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 dependencies = [
     ('PrgEnv-intel/5.2.82', EXTERNAL_MODULE),
+    ('intel/15.0.1.133', EXTERNAL_MODULE),
     ('craype/2.4.2', EXTERNAL_MODULE),
     ('cray-libsci/13.2.0', EXTERNAL_MODULE),
     ('cray-mpich/7.2.6', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/h/HPL/HPL-2.1-CrayCCE-2015.06-XC.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.1-CrayCCE-2015.06-XC.eb
@@ -1,0 +1,22 @@
+name = 'HPL'
+version = '2.1'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'CrayCCE', 'version': '2015.06-XC'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+patches = [
+    # fix Make dependencies, so parallel build also works
+    'HPL_parallel-make.patch',
+    'HPL-2.1_LINKER-ld.patch',
+]
+
+parallel = 1
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/HPL/HPL-2.1-CrayCCE-2015.11-XC.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.1-CrayCCE-2015.11-XC.eb
@@ -1,0 +1,22 @@
+name = 'HPL'
+version = '2.1'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'CrayCCE', 'version': '2015.11-XC'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+patches = [
+    # fix Make dependencies, so parallel build also works
+    'HPL_parallel-make.patch',
+    'HPL-2.1_LINKER-ld.patch',
+]
+
+parallel = 1
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/HPL/HPL-2.1-CrayGNU-2015.06-XC.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.1-CrayGNU-2015.06-XC.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.1'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2015.06-XC'}
+toolchainopts = {'optarch': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/HPL/HPL-2.1-CrayGNU-2015.11-XC.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.1-CrayGNU-2015.11-XC.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.1'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2015.11-XC'}
+toolchainopts = {'optarch': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/HPL/HPL-2.1-CrayIntel-2015.06-XC.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.1-CrayIntel-2015.06-XC.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.1'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'CrayIntel', 'version': '2015.06-XC'}
+toolchainopts = {'optarch': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/HPL/HPL-2.1-CrayIntel-2015.11-XC.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.1-CrayIntel-2015.11-XC.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.1'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'CrayIntel', 'version': '2015.11-XC'}
+toolchainopts = {'optarch': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'


### PR DESCRIPTION
This PR adds eb files for the new CrayGNU, CrayIntel and CrayCCE toolchains (with dep. pinning). For validation, it adds also easyconfig files for HPL.

Requires: EB 2.5.0 and [hpcugent/easybuild-easyblocks/pull/766](https://github.com/hpcugent/easybuild-easyblocks/pull/766)