### PR TITLE
Harden dummy:dummy binutils

### DIFF
--- a/easybuild/easyconfigs/b/binutils/binutils-2.25.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25.eb
@@ -19,8 +19,10 @@ builddependencies = [
 ]
 
 # statically link with zlib, to avoid runtime dependency on zlib
-preconfigopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
-prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+# further, add the system library path in the rpath: this should 'harden' the
+# resulting binutils to bootstrap GCC (no trouble when other libstdc++ is build etc)
+preconfigopts = 'LIBS="$EBROOTZLIB/lib/libz.a -Wl,-rpath=/lib64 -Wl,-rpath=/usr/lib64 -Wl,-rpath=/lib -Wl,-rpath=/usr/lib"'
+prebuildopts = preconfigopts
 
 # make sure that system libraries are also considered by ld and ld.gold is also built
 # --enable-plugins should be used whenever --enable-gold is used, see http://llvm.org/docs/GoldPlugin.html


### PR DESCRIPTION
By adding the system library path using the `rpath` option, the
resulting binaries should be 'harden' to work in an environment with a
other libstdc++ etc. The rpath will make sure it always finds the
correct library.

Fix for #2188