### PR TITLE
add Python as dependency for InterProScan

### DIFF
--- a/easybuild/easyconfigs/i/InterProScan/InterProScan-5.16-55.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/i/InterProScan/InterProScan-5.16-55.0-intel-2015b.eb
@@ -16,6 +16,7 @@ dependencies = [
     ('Java', '1.7.0_80', '', True),
     ('Perl', '5.20.3'),
     ('libgd', '2.1.1'),
+    ('Python', '2.7.10'),
 ]
 
 sanity_check_paths = {


### PR DESCRIPTION
InterProScan 5.16 needs Python 2.7

purposely not adjusting versionsuffix, since it needs both Perl and Python and it would become too messy in this case...