### PR TITLE
argparse is part of the Python standard library as of 3.2

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-goalf-1.1.0-no-OFED.eb
@@ -48,9 +48,6 @@ exts_list = [
     ('mpi4py', '1.3', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
-    ('argparse', '1.2.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],
-    }),
     ('Cython', '0.19.1', {
         'source_urls': ['http://www.cython.org/release/'],
     }),

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-goolf-1.4.10.eb
@@ -48,9 +48,6 @@ exts_list = [
     ('mpi4py', '1.3', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
-    ('argparse', '1.2.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],
-    }),
     ('Cython', '0.19.1', {
         'source_urls': ['http://www.cython.org/release/'],
     }),

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-4.0.6.eb
@@ -50,9 +50,6 @@ exts_list = [
     ('mpi4py', '1.3', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
-    ('argparse', '1.2.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],
-    }),
     ('Cython', '0.19.1', {
         'source_urls': ['http://www.cython.org/release/'],
     }),

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-5.3.0.eb
@@ -48,9 +48,6 @@ exts_list = [
     ('mpi4py', '1.3', {
         'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
     }),
-    ('argparse', '1.2.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],
-    }),
     ('Cython', '0.19.1', {
         'source_urls': ['http://www.cython.org/release/'],
     }),

--- a/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
@@ -60,9 +60,6 @@ exts_list = [
             'paycheck-1.0.2_setup-open-README-utf8.patch',
         ],
     }),
-    ('argparse', '1.2.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],
-    }),
     ('lockfile', '0.9.1', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
         # tarball has changed upstream, so make sure we get the right version by verifying the checksum

--- a/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2015a.eb
@@ -60,9 +60,6 @@ exts_list = [
             'paycheck-1.0.2_setup-open-README-utf8.patch',
         ],
     }),
-    ('argparse', '1.2.1', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],
-    }),
     ('lockfile', '0.9.1', {
         'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
         # tarball has changed upstream, so make sure we get the right version by verifying the checksum

--- a/easybuild/easyconfigs/p/Python/Python-3.4.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.3-intel-2015a.eb
@@ -58,9 +58,6 @@ exts_list = [
             'paycheck-1.0.2_setup-open-README-utf8.patch',
         ],
     }),
-    ('argparse', '1.3.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],
-    }),
     ('pbr', '0.11.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
     }),

--- a/easybuild/easyconfigs/p/Python/Python-3.5.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.0-intel-2015b.eb
@@ -58,9 +58,6 @@ exts_list = [
             'paycheck-1.0.2_setup-open-README-utf8.patch',
         ],
     }),
-    ('argparse', '1.4.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],
-    }),
     ('pbr', '1.8.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
     }),


### PR DESCRIPTION
cfr. https://docs.python.org/3/library/argparse.html