### PR TITLE
Update impi-5.1.2.150-iccifort-2016.1.150-GCC-4.9.3-2.25.eb

### DIFF
--- a/easybuild/easyconfigs/i/impi/impi-5.1.2.150-iccifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/impi/impi-5.1.2.150-iccifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -19,6 +19,9 @@ dontcreateinstalldir = 'True'
 import os
 license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
 
+# set up all the mpi commands to default to intel compilers
+# set_mpi_wrappers_all = 'True'
+
 moduleclass = 'mpi'
 
 postinstallcmds = [


### PR DESCRIPTION
Provide hint on how to set defaults for `impi` to use intel compilers