### PR TITLE
add CMake as runtime dep for Instant, define $CC and $CXX in Instant module file

### DIFF
--- a/easybuild/easyconfigs/i/Instant/Instant-1.6.0-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/Instant/Instant-1.6.0-intel-2015b-Python-2.7.11.eb
@@ -18,7 +18,7 @@ versionsuffix = '-Python-%s' % pyver
 dependencies = [
     ('Python', pyver),
     ('SWIG', '3.0.8', versionsuffix),
-    ('CMake', '3.1.4'),  # runtime dep!
+    ('CMake', '3.4.1'),  # runtime dep!
 ]
 
 # compiler-related variables *must* be set, since Instant does runtime compilation and remembers $CFLAGS/$CXXFLAGS

--- a/easybuild/easyconfigs/i/Instant/Instant-1.6.0-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/Instant/Instant-1.6.0-intel-2015b-Python-2.7.11.eb
@@ -18,7 +18,14 @@ versionsuffix = '-Python-%s' % pyver
 dependencies = [
     ('Python', pyver),
     ('SWIG', '3.0.8', versionsuffix),
+    ('CMake', '3.1.4'),  # runtime dep!
 ]
+
+# compiler-related variables *must* be set, since Instant does runtime compilation and remembers $CFLAGS/$CXXFLAGS
+modextravars = {
+    'CC': 'icc',
+    'CXX': 'icpc',
+}
 
 pyshortver = '.'.join(pyver.split('.')[:2])
 sanity_check_paths = {


### PR DESCRIPTION
These enhancements are required for runtime use of Instant(/DOLFIN)