### PR TITLE
Add easyconfig for PGI 15.10 using GCCcore 4.9.3.

### DIFF
--- a/easybuild/easyconfigs/p/PGI/PGI-15.10-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-15.10-GCC-4.9.3-2.25.eb
@@ -1,0 +1,25 @@
+name = 'PGI'
+version = '15.10'
+
+homepage = 'http://www.pgroup.com/'
+description = "C, C++ and Fortran compilers from The Portland Group - PGI"
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86_64.tar.gz']
+checksums = ['cae307f7ad467a1811a5d5da758048ab']
+
+gccver = '4.9.3'
+binutilsver = '2.25'
+versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+
+dependencies = [
+    ('GCCcore', gccver),
+    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+]
+
+# license file
+import os
+license_file = os.path.join(os.getenv('HOME'), "licenses", "pgi", "license.dat")
+
+moduleclass = 'compiler'


### PR DESCRIPTION
Note: this depends on framework PR1342
https://github.com/hpcugent/easybuild-framework/pull/1342
which has not been merged yet.
