### PR TITLE
Add ncdf4 for intel-2015a for a user.

### DIFF
--- a/easybuild/easyconfigs/n/ncdf4/ncdf4-1.15-intel-2015a-R-3.2.1.eb
+++ b/easybuild/easyconfigs/n/ncdf4/ncdf4-1.15-intel-2015a-R-3.2.1.eb
@@ -1,0 +1,31 @@
+easyblock = 'RPackage'
+
+name = 'ncdf4'
+version = '1.15'
+
+homepage = 'http://cran.r-project.org/web/packages/%(name)s'
+description = """ncdf4: Interface to Unidata netCDF (version 4 or earlier) format data files"""
+
+toolchain = {'name': 'intel', 'version': '2015a'}
+
+source_urls = [
+    'http://cran.r-project.org/src/contrib/',
+    'http://cran.r-project.org/src/contrib/Archive/$(name)s/',
+]
+sources = ['%(name)s_%(version)s.tar.gz']
+
+r = 'R'
+rver = '3.2.1'
+versionsuffix = '-%s-%s' % (r, rver)
+
+dependencies = [
+    (r, rver),
+    ('netCDF', '4.3.2'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['ncdf4'],
+}
+
+moduleclass = 'math'


### PR DESCRIPTION
I tried to also do it for intel-2015b w/ netCDF-4.3.3.1 but it has conflicting
dependencies that won't work with R-3.2.1-intel-2015b (cURL 7.43 vs 7.45).