### PR TITLE
removed fftw from the new Cray* XC toolchains

### DIFF
--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.06-XC.eb
@@ -14,7 +14,6 @@ dependencies = [
     ('craype/2.4.0', EXTERNAL_MODULE),
     ('cray-libsci/13.0.4', EXTERNAL_MODULE),
     ('cray-mpich/7.2.2', EXTERNAL_MODULE),
-    ('fftw/3.3.4.3', EXTERNAL_MODULE),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.11-XC.eb
@@ -14,7 +14,6 @@ dependencies = [
     ('craype/2.4.2', EXTERNAL_MODULE),
     ('cray-libsci/13.2.0', EXTERNAL_MODULE),
     ('cray-mpich/7.2.6', EXTERNAL_MODULE),
-    ('fftw/3.3.4.5', EXTERNAL_MODULE),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.06-XC.eb
@@ -14,7 +14,6 @@ dependencies = [
     ('craype/2.4.0', EXTERNAL_MODULE),
     ('cray-libsci/13.0.4', EXTERNAL_MODULE),
     ('cray-mpich/7.2.2', EXTERNAL_MODULE),
-    ('fftw/3.3.4.3', EXTERNAL_MODULE),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.11-XC.eb
@@ -14,7 +14,6 @@ dependencies = [
     ('craype/2.4.2', EXTERNAL_MODULE),
     ('cray-libsci/13.2.0', EXTERNAL_MODULE),
     ('cray-mpich/7.2.6', EXTERNAL_MODULE),
-    ('fftw/3.3.4.5', EXTERNAL_MODULE),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.06-XC.eb
@@ -14,7 +14,6 @@ dependencies = [
     ('craype/2.4.0', EXTERNAL_MODULE),
     ('cray-libsci/13.0.4', EXTERNAL_MODULE),
     ('cray-mpich/7.2.2', EXTERNAL_MODULE),
-    ('fftw/3.3.4.3', EXTERNAL_MODULE),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.11-XC.eb
@@ -14,7 +14,6 @@ dependencies = [
     ('craype/2.4.2', EXTERNAL_MODULE),
     ('cray-libsci/13.2.0', EXTERNAL_MODULE),
     ('cray-mpich/7.2.6', EXTERNAL_MODULE),
-    ('fftw/3.3.4.5', EXTERNAL_MODULE),
 ]
 
 moduleclass = 'toolchain'


### PR DESCRIPTION
To be in sync with https://github.com/hpcugent/easybuild-framework/pull/1585

(now we need to rebuild all apps using XC  to test where we need fftw...)