### PR TITLE
fix comment in HOD easyconfigs

### DIFF
--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-2.2.1-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-2.2.1-intel-2015a-Python-2.7.9.eb
@@ -19,7 +19,7 @@ pythonver = '2.7.9'
 pythonshortver = '.'.join(pythonver.split('.')[:2])
 versionsuffix = '-%s-%s' % (python, pythonver)
 
-# a Python version with mpi4py and pbs_python (vsc.fancylogger) is required at runtime
+# a Python version with mpi4py and pbs_python (vsc.utils.fancylogger) is required at runtime
 dependencies = [
     (python, pythonver),
     ('pbs_python', '4.6.0', versionsuffix),

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-2.2.2-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-2.2.2-intel-2015a-Python-2.7.9.eb
@@ -19,7 +19,7 @@ pythonver = '2.7.9'
 pythonshortver = '.'.join(pythonver.split('.')[:2])
 versionsuffix = '-%s-%s' % (python, pythonver)
 
-# a Python version with mpi4py and pbs_python (vsc.fancylogger) is required at runtime
+# a Python version with mpi4py and pbs_python (vsc.utils.fancylogger) is required at runtime
 dependencies = [
     (python, pythonver),
     ('pbs_python', '4.6.0', versionsuffix),

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-2.2.3-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-2.2.3-intel-2015a-Python-2.7.9.eb
@@ -19,7 +19,7 @@ pythonver = '2.7.9'
 pythonshortver = '.'.join(pythonver.split('.')[:2])
 versionsuffix = '-%s-%s' % (python, pythonver)
 
-# a Python version with mpi4py and pbs_python (vsc.fancylogger) is required at runtime
+# a Python version with mpi4py and pbs_python (vsc.utils.fancylogger) is required at runtime
 dependencies = [
     (python, pythonver),
     ('pbs_python', '4.6.0', versionsuffix),

--- a/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-2.2.4-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/h/hanythingondemand/hanythingondemand-2.2.4-intel-2015a-Python-2.7.9.eb
@@ -19,7 +19,7 @@ pythonver = '2.7.9'
 pythonshortver = '.'.join(pythonver.split('.')[:2])
 versionsuffix = '-%s-%s' % (python, pythonver)
 
-# a Python version with mpi4py and pbs_python (vsc.fancylogger) is required at runtime
+# a Python version with mpi4py and pbs_python (vsc.utils.fancylogger) is required at runtime
 dependencies = [
     (python, pythonver),
     ('pbs_python', '4.6.0', versionsuffix),


### PR DESCRIPTION
`vsc.fancylogger` is deprecated (and will soon cease to exist), so only mention `vsc.utils.fancylogger`