### PR TITLE
{bio}[dummy-dummy] VarScan 2.4.1

### DIFF
--- a/easybuild/easyconfigs/v/VarScan/VarScan-2.4.1-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/v/VarScan/VarScan-2.4.1-Java-1.7.0_80.eb
@@ -12,7 +12,7 @@ description = """Variant calling and somatic mutation/CNV detection for next-gen
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-sources = ['%s.v%s.jar' % (name, version)]
+sources = ['%(name)s.v%(version)s.jar']
 source_urls = ['https://github.com/dkoboldt/varscan/releases/download/v%(version)s']
 
 java = 'Java'

--- a/easybuild/easyconfigs/v/VarScan/VarScan-2.4.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/v/VarScan/VarScan-2.4.1-foss-2015b.eb
@@ -1,0 +1,29 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Adam Huffman, based on initial work by Jordi Blasco
+# The Francis Crick Institute
+
+easyblock = 'JAR'
+
+name = 'VarScan'
+version = '2.4.1'
+
+homepage = 'https://github.com/dkoboldt/varscan'
+description = """Variant calling and somatic mutation/CNV detection for next-generation sequencing data"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = ['%s.v%s.jar' % (name, version)]
+source_urls = ['https://github.com/dkoboldt/varscan/releases/download/v%(version)s']
+
+java = 'Java'
+javaver = '1.7.0_80'
+versionsuffix = '-%s-%s' % (java, javaver)
+
+dependencies = [(java, javaver)]
+
+sanity_check_paths = {
+    'files': sources,
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
I'm submitting this separately because the upstream location has changed and I think there was some boilerplate text in the 2.3.9 version (e.g.references to junit and homepage), cfr. #1808