### PR TITLE
Update naming of GTK+, PyCairo and Gdk-Pixbuf

### DIFF
--- a/easybuild/easyconfigs/g/GTK+/GTK+-2.24.28-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/GTK+/GTK+-2.24.28-intel-2015a.eb
@@ -1,6 +1,6 @@
 easyblock = 'ConfigureMake'
 
-name = 'gtk+'
+name = 'GTK+'
 version = '2.24.28'
 
 homepage = 'https://developer.gnome.org/gtk+/stable/'
@@ -15,7 +15,7 @@ sources = [SOURCELOWER_TAR_XZ]
 
 dependencies = [
     ('ATK', '2.16.0'),
-    ('gdk-pixbuf', '2.31.4'),
+    ('Gdk-Pixbuf', '2.31.4'),
     ('Pango', '1.37.1'),
 ]
 

--- a/easybuild/easyconfigs/g/GTK+/GTK+-2.24.28-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/GTK+/GTK+-2.24.28-intel-2015b.eb
@@ -1,6 +1,6 @@
 easyblock = 'ConfigureMake'
 
-name = 'gtk+'
+name = 'GTK+'
 version = '2.24.28'
 
 homepage = 'https://developer.gnome.org/gtk+/stable/'
@@ -15,7 +15,7 @@ sources = [SOURCELOWER_TAR_XZ]
 
 dependencies = [
     ('ATK', '2.16.0'),
-    ('gdk-pixbuf', '2.31.4'),
+    ('Gdk-Pixbuf', '2.31.4'),
     ('Pango', '1.37.1'),
 ]
 

--- a/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.31.4-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.31.4-intel-2015a.eb
@@ -1,6 +1,6 @@
 easyblock = 'ConfigureMake'
 
-name = 'gdk-pixbuf'
+name = 'Gdk-Pixbuf'
 version = '2.31.4'
 
 homepage = 'https://developer.gnome.org/gdk-pixbuf/stable/'
@@ -11,7 +11,7 @@ description = """
  in preparation for the change to GTK+ 3. 
 """
 
-toolchain = {'name': 'intel', 'version': '2015b'}
+toolchain = {'name': 'intel', 'version': '2015a'}
 
 source_urls = ['http://ftp.gnome.org/pub/GNOME/sources/%(namelower)s/%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_XZ]
@@ -19,7 +19,7 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('GLib', '2.41.2'),
     ('libjpeg-turbo', '1.4.0'),
-    ('libpng', '1.6.18'),
+    ('libpng', '1.6.17'),
     ('LibTIFF', '4.0.3'),
 
 ]

--- a/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.31.4-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.31.4-intel-2015b.eb
@@ -1,6 +1,6 @@
 easyblock = 'ConfigureMake'
 
-name = 'gdk-pixbuf'
+name = 'Gdk-Pixbuf'
 version = '2.31.4'
 
 homepage = 'https://developer.gnome.org/gdk-pixbuf/stable/'
@@ -11,7 +11,7 @@ description = """
  in preparation for the change to GTK+ 3. 
 """
 
-toolchain = {'name': 'intel', 'version': '2015a'}
+toolchain = {'name': 'intel', 'version': '2015b'}
 
 source_urls = ['http://ftp.gnome.org/pub/GNOME/sources/%(namelower)s/%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_XZ]
@@ -19,7 +19,7 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('GLib', '2.41.2'),
     ('libjpeg-turbo', '1.4.0'),
-    ('libpng', '1.6.17'),
+    ('libpng', '1.6.18'),
     ('LibTIFF', '4.0.3'),
 
 ]

--- a/easybuild/easyconfigs/g/Gtkmm/Gtkmm-2.24.4-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/Gtkmm/Gtkmm-2.24.4-intel-2015a.eb
@@ -15,7 +15,7 @@ sources = [SOURCELOWER_TAR_XZ]
 
 dependencies = [
     ('Atkmm', '2.22.7'),
-    ('gtk+', '2.24.28'),
+    ('GTK+', '2.24.28'),
     ('Pangomm', '2.36.0'),
 ]
 

--- a/easybuild/easyconfigs/g/Gtkmm/Gtkmm-2.24.4-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/Gtkmm/Gtkmm-2.24.4-intel-2015b.eb
@@ -15,7 +15,7 @@ sources = [SOURCELOWER_TAR_XZ]
 
 dependencies = [
     ('Atkmm', '2.22.7'),
-    ('gtk+', '2.24.28'),
+    ('GTK+', '2.24.28'),
     ('Pangomm', '2.36.0'),
 ]
 

--- a/easybuild/easyconfigs/g/gtkglext/gtkglext-1.2.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/gtkglext/gtkglext-1.2.0-intel-2015b.eb
@@ -15,7 +15,7 @@ patches = ['gtkglext-%(version)s_fix-gtk-compat.patch']
 
 pangover = '1.37.1'
 dependencies = [
-    ('gtk+', '2.24.28'),
+    ('GTK+', '2.24.28'),
     ('Pango', pangover),
     ('pangox-compat', '0.0.2', '-Pango-%s' % pangover),
 ]

--- a/easybuild/easyconfigs/p/PyCairo/PyCairo-1.10.0-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/p/PyCairo/PyCairo-1.10.0-intel-2015b-Python-2.7.10.eb
@@ -1,6 +1,6 @@
 easyblock = 'Waf'
 
-name = 'pycairo'
+name = 'PyCairo'
 version = '1.10.0'
 
 homepage = 'http://cairographics.org/pycairo/'


### PR DESCRIPTION
fleshed out from #2443

@ocaisa: I prefer making changes like this in a separate PR (it makes #2443 needlessly complicated, and deserves it's own entry in the release notes)