### PR TITLE
use available flex easyblock

### DIFF
--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.2-binutils-2.25.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.2-binutils-2.25.eb
@@ -1,5 +1,3 @@
-easyblock = 'ConfigureMake'
-
 name = 'flex'
 version = '2.5.39'
 

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.2.eb
@@ -1,5 +1,3 @@
-easyblock = 'ConfigureMake'
-
 name = 'flex'
 version = '2.5.39'
 

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.3-binutils-2.25.eb
@@ -1,5 +1,3 @@
-easyblock = 'ConfigureMake'
-
 name = 'flex'
 version = '2.5.39'
 

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.3.eb
@@ -1,5 +1,3 @@
-easyblock = 'ConfigureMake'
-
 name = 'flex'
 version = '2.5.39'
 

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-5.1.0-binutils-2.25.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-5.1.0-binutils-2.25.eb
@@ -1,5 +1,3 @@
-easyblock = 'ConfigureMake'
-
 name = 'flex'
 version = '2.5.39'
 

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCCcore-4.9.3.eb
@@ -1,5 +1,3 @@
-easyblock = 'ConfigureMake'
-
 name = 'flex'
 version = '2.5.39'
 

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GNU-4.9.3-2.25.eb
@@ -1,5 +1,3 @@
-easyblock = 'ConfigureMake'
-
 name = 'flex'
 version = '2.5.39'
 


### PR DESCRIPTION
There's an easyblock available for flex, so we should use it (in *all* flex easyconfigs).