### PR TITLE
Update BFAST to use goolf-1.7.20

### DIFF
--- a/easybuild/easyconfigs/b/BFAST/BFAST-0.7.0a-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/b/BFAST/BFAST-0.7.0a-goolf-1.7.20.eb
@@ -1,0 +1,40 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-94.html
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'BFAST'
+version = '0.7.0a'
+
+homepage = 'http://bfast.sourceforge.net/'
+description = """BFAST facilitates the fast and accurate mapping of short reads to reference sequences.
+ Some advantages of BFAST include:
+ 1) Speed: enables billions of short reads to be mapped quickly. 
+ 2) Accuracy: A priori probabilities for mapping reads with defined set of variants. 
+ 3) An easy way to measurably tune accuracy at the expense of speed."""
+
+toolchain = {'name': 'goolf', 'version': '1.7.20'}
+
+import string
+swdir = version.rstrip(string.lowercase + string.uppercase)
+# eg. http://sourceforge.net/projects/bfast/files/bfast/0.7.0/bfast-0.7.0a.tar.gz/download
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://sourceforge.net/projects/bfast/files/bfast/%s/' % swdir, 'download']
+
+dependencies = [('bzip2', '1.0.6')]
+
+sanity_check_paths = {
+    'files': ["bin/bfast"],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
This updates to using a newer GCC 4.8.4 via goolf-1.7.20 in order to avoid a build
failure for GCC 4.7.2 in goolf-1.4.10.  The build failes  due to a texinfo parsing
bug in GCC documentation files.

This problem appears on systems like CentOS 7 due to stricter parsing in newer
versions of texinfo (5+) supplied by the system environment.

See the bug report for GCC 4.7.2 and patch description

  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52903

Address issue #2507 