### PR TITLE
{compiler}[GCC-4.9.3-2.25] fix: added M4 as builddependency

### DIFF
--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCCcore-4.9.3.eb
@@ -12,6 +12,7 @@ sources = [SOURCE_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 builddependencies = [
+    ('M4', '1.4.17'),
     ('flex', '2.5.39'),
     ('Bison', '3.0.4'),
     # zlib required, but being linked instatically, so not a runtime dep

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25.eb
@@ -12,6 +12,7 @@ sources = [SOURCE_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 builddependencies = [
+	('M4', '1.4.17'),
     ('flex', '2.5.39'),
     ('Bison', '3.0.4'),
     # zlib required, but being linked instatically, so not a runtime dep

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCCcore-4.9.3.eb
@@ -11,6 +11,9 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
 # use same binutils version that was used when building GCCcore toolchain
-builddependencies = [('binutils', '2.25', '', True)]
+builddependencies = [
+	('M4', '1.4.17'),
+	('binutils', '2.25', '', True)
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39.eb
@@ -5,10 +5,12 @@ homepage = 'http://flex.sourceforge.net/'
 description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners. A scanner,
  sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
+
+builddependencies = [('M4', '1.4.17')]
 
 moduleclass = 'lang'


### PR DESCRIPTION
Related to the issue [#2384](https://github.com/hpcugent/easybuild-easyconfigs/issues/2384)
On a clean system trying to install GCC-4.9.3-2.25.eb drives to an error due to missing M4 on the machine. This has been solved adding M4 as builddependency in some of the easyconfigs related to the GCC-4.9.3-2.25 installation and we were thus able to successfully install such toolchain.