### PR TITLE
Port Perl-5.20.3 to foss/2015b, for vcftools

### DIFF
--- a/easybuild/easyconfigs/p/Perl/Perl-5.20.3-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.20.3-foss-2015b.eb
@@ -1,0 +1,909 @@
+name = 'Perl'
+version = '5.20.3'
+
+homepage = 'http://www.perl.org/'
+description = """Larry Wall's Practical Extraction and Report Language"""
+
+toolchain = {'name': 'foss', 'version': '2015b'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = ['http://www.cpan.org/src/5.0']
+sources = [SOURCELOWER_TAR_GZ]
+
+exts_list = [
+    ('Config::General', '2.58', {
+        'source_tmpl': 'Config-General-2.58.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TL/TLINDEN'],
+    }),
+    ('File::Listing', '6.04', {
+        'source_tmpl': 'File-Listing-6.04.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('ExtUtils::InstallPaths', '0.011', {
+        'source_tmpl': 'ExtUtils-InstallPaths-0.011.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('ExtUtils::Helpers', '0.022', {
+        'source_tmpl': 'ExtUtils-Helpers-0.022.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('TAP::Harness::Env', '3.35', {
+        'source_tmpl': 'Test-Harness-3.35.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('ExtUtils::Config', '0.008', {
+        'source_tmpl': 'ExtUtils-Config-0.008.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('Module::Build::Tiny', '0.039', {
+        'source_tmpl': 'Module-Build-Tiny-0.039.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('aliased', '0.34', {
+        'source_tmpl': 'aliased-0.34.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Text::Glob', '0.09', {
+        'source_tmpl': 'Text-Glob-0.09.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RC/RCLAMP'],
+    }),
+    ('Regexp::Common', '2013031301', {
+        'source_tmpl': 'Regexp-Common-2013031301.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AB/ABIGAIL'],
+    }),
+    ('GO::Utils', '0.15', {
+        'source_tmpl': 'go-perl-0.15.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CM/CMUNGALL'],
+    }),
+    ('Module::Pluggable', '5.2', {
+        'source_tmpl': 'Module-Pluggable-5.2.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SI/SIMONW'],
+    }),
+    ('Test::Fatal', '0.014', {
+        'source_tmpl': 'Test-Fatal-0.014.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Test::Warnings', '0.021', {
+        'source_tmpl': 'Test-Warnings-0.021.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('DateTime::Locale', '0.46', {
+        'source_tmpl': 'DateTime-Locale-0.46.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('DateTime::TimeZone', '1.93', {
+        'source_tmpl': 'DateTime-TimeZone-1.93.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('Test::Requires', '0.10', {
+        'source_tmpl': 'Test-Requires-0.10.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TOKUHIROM'],
+    }),
+    ('Module::Implementation', '0.09', {
+        'source_tmpl': 'Module-Implementation-0.09.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('Module::Runtime', '0.014', {
+        'source_tmpl': 'Module-Runtime-0.014.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM'],
+    }),
+    ('Try::Tiny', '0.22', {
+        'source_tmpl': 'Try-Tiny-0.22.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY'],
+    }),
+    ('Params::Validate', '1.21', {
+        'source_tmpl': 'Params-Validate-1.21.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('List::MoreUtils', '0.413', {
+        'source_tmpl': 'List-MoreUtils-0.413.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+    }),
+    ('Exporter::Tiny', '0.042', {
+        'source_tmpl': 'Exporter-Tiny-0.042.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/T/TO/TOBYINK'],
+    }),
+    ('Class::Singleton', '1.5', {
+        'source_tmpl': 'Class-Singleton-1.5.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHAY'],
+    }),
+    ('DateTime', '1.20', {
+        'source_tmpl': 'DateTime-1.20.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('File::Find::Rule::Perl', '1.15', {
+        'source_tmpl': 'File-Find-Rule-Perl-1.15.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Module::Build', '0.4214', {
+        'source_tmpl': 'Module-Build-0.4214.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('Readonly', '2.00', {
+        'source_tmpl': 'Readonly-2.00.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/S/SA/SANKO'],
+    }),
+    ('Git', '0.41', {
+        'source_tmpl': 'Git-0.41.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MS/MSOUTH'],
+    }),
+    ('Tree::DAG_Node', '1.27', {
+        'source_tmpl': 'Tree-DAG_Node-1.27.tgz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+    }),
+    ('Template', '2.26', {
+        'source_tmpl': 'Template-Toolkit-2.26.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AB/ABW'],
+    }),
+    ('FreezeThaw', '0.5001', {
+        'source_tmpl': 'FreezeThaw-0.5001.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/I/IL/ILYAZ/modules'],
+    }),
+    ('DBI', '1.634', {
+        'source_tmpl': 'DBI-1.634.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TI/TIMB'],
+    }),
+    ('DBD::SQLite', '1.48', {
+        'source_tmpl': 'DBD-SQLite-1.48.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI'],
+    }),
+    ('Math::Bezier', '0.01', {
+        'source_tmpl': 'Math-Bezier-0.01.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AB/ABW'],
+    }),
+    ('Archive::Extract', '0.76', {
+        'source_tmpl': 'Archive-Extract-0.76.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('DBIx::Simple', '1.35', {
+        'source_tmpl': 'DBIx-Simple-1.35.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/J/JU/JUERD'],
+    }),
+    ('Shell', '0.72', {
+        'source_tmpl': 'Shell-0.72.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FE/FERREIRA'],
+    }),
+    ('File::Spec', '3.47', {
+        'source_tmpl': 'PathTools-3.47.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/S/SM/SMUELLER'],
+    }),
+    ('ExtUtils::MakeMaker', '7.10', {
+        'source_tmpl': 'ExtUtils-MakeMaker-7.10.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('Test::Simple', '1.001014', {
+        'source_tmpl': 'Test-Simple-1.001014.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('Set::Scalar', '1.29', {
+        'source_tmpl': 'Set-Scalar-1.29.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DA/DAVIDO'],
+    }),
+    ('IO::WrapTie', '2.111', {
+        'source_tmpl': 'IO-stringy-2.111.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DS/DSKOLL'],
+    }),
+    ('Encode::Locale', '1.05', {
+        'source_tmpl': 'Encode-Locale-1.05.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('XML::SAX::Base', '1.08', {
+        'source_tmpl': 'XML-SAX-Base-1.08.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GR/GRANTM'],
+    }),
+    ('XML::NamespaceSupport', '1.11', {
+        'source_tmpl': 'XML-NamespaceSupport-1.11.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PE/PERIGRIN'],
+    }),
+    ('XML::SAX', '0.99', {
+        'source_tmpl': 'XML-SAX-0.99.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GR/GRANTM'],
+    }),
+    ('Test::LeakTrace', '0.15', {
+        'source_tmpl': 'Test-LeakTrace-0.15.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GF/GFUJI'],
+    }),
+    ('Test::Exception', '0.40', {
+        'source_tmpl': 'Test-Exception-0.40.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('Text::Table', '1.130', {
+        'source_tmpl': 'Text-Table-1.130.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+    }),
+    ('MIME::Types', '2.11', {
+        'source_tmpl': 'MIME-Types-2.11.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MARKOV'],
+    }),
+    ('Module::Build::XSUtil', '0.16', {
+        'source_tmpl': 'Module-Build-XSUtil-0.16.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/H/HI/HIDEAKIO'],
+    }),
+    ('Tie::Function', '0.02', {
+        'source_tmpl': 'Tie-Function-0.02.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DA/DAVIDNICO/handy_tied_functions'],
+    }),
+    ('Template::Plugin::Number::Format', '1.06', {
+        'source_tmpl': 'Template-Plugin-Number-Format-1.06.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DARREN'],
+    }),
+    ('HTML::Parser', '3.71', {
+        'source_tmpl': 'HTML-Parser-3.71.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('Date::Handler', '1.2', {
+        'source_tmpl': 'Date-Handler-1.2.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BB/BBEAUSEJ'],
+    }),
+    ('Params::Util', '1.07', {
+        'source_tmpl': 'Params-Util-1.07.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+    }),
+    ('IO::HTML', '1.001', {
+        'source_tmpl': 'IO-HTML-1.001.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CJ/CJM'],
+    }),
+    ('Data::Grove', '0.08', {
+        'source_tmpl': 'libxml-perl-0.08.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/K/KM/KMACLEOD'],
+    }),
+    ('Class::ISA', '0.36', {
+        'source_tmpl': 'Class-ISA-0.36.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/S/SM/SMUELLER'],
+    }),
+    ('URI', '1.69', {
+        'source_tmpl': 'URI-1.69.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Ima::DBI', '0.35', {
+        'source_tmpl': 'Ima-DBI-0.35.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PE/PERRIN'],
+    }),
+    ('Tie::IxHash', '1.23', {
+        'source_tmpl': 'Tie-IxHash-1.23.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CH/CHORNY'],
+    }),
+    ('GO', '0.04', {
+        'source_tmpl': 'go-db-perl-0.04.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/S/SJ/SJCARBON'],
+    }),
+    ('Class::DBI::SQLite', '0.11', {
+        'source_tmpl': 'Class-DBI-SQLite-0.11.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA'],
+    }),
+    ('Pod::POM', '2.00', {
+        'source_tmpl': 'Pod-POM-2.00.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/N/NE/NEILB'],
+    }),
+    ('Math::Round', '0.07', {
+        'source_tmpl': 'Math-Round-0.07.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GR/GROMMEL'],
+    }),
+    ('Text::Diff', '1.43', {
+        'source_tmpl': 'Text-Diff-1.43.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/N/NE/NEILB'],
+    }),
+    ('Log::Message::Simple', '0.10', {
+        'source_tmpl': 'Log-Message-Simple-0.10.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('IO::Socket::SSL', '2.020', {
+        'source_tmpl': 'IO-Socket-SSL-2.020.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SU/SULLR'],
+    }),
+    ('Fennec::Lite', '0.004', {
+        'source_tmpl': 'Fennec-Lite-0.004.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('Sub::Uplevel', '0.25', {
+        'source_tmpl': 'Sub-Uplevel-0.25.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/'],
+    }),
+    ('Meta::Builder', '0.003', {
+        'source_tmpl': 'Meta-Builder-0.003.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('Exporter::Declare', '0.114', {
+        'source_tmpl': 'Exporter-Declare-0.114.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('IO::Stringy', '2.111', {
+        'source_tmpl': 'IO-stringy-2.111.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DS/DSKOLL'],
+    }),
+    ('Getopt::Long', '2.47', {
+        'source_tmpl': 'Getopt-Long-2.47.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JV/JV'],
+    }),
+    ('Log::Message', '0.08', {
+        'source_tmpl': 'Log-Message-0.08.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('Mouse', 'v2.4.5', {
+        'source_tmpl': 'Mouse-v2.4.5.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SY/SYOHEX'],
+    }),
+    ('Test::Version', '2.03', {
+        'source_tmpl': 'Test-Version-2.03.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PL/PLICEASE'],
+    }),
+    ('DBIx::Admin::TableInfo', '3.01', {
+        'source_tmpl': 'DBIx-Admin-TableInfo-3.01.tgz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+    }),
+    ('Net::HTTP', '6.09', {
+        'source_tmpl': 'Net-HTTP-6.09.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Test::Deep', '0.117', {
+        'source_tmpl': 'Test-Deep-0.117.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Test::Warn', '0.30', {
+        'source_tmpl': 'Test-Warn-0.30.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CH/CHORNY'],
+    }),
+    ('MRO::Compat', '0.12', {
+        'source_tmpl': 'MRO-Compat-0.12.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BO/BOBTFISH'],
+    }),
+    ('Moo', '2.000002', {
+        'source_tmpl': 'Moo-2.000002.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
+    }),
+    ('Hash::Merge', '0.200', {
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/R/RE/REHSACK/'],
+        'source_tmpl': 'Hash-Merge-0.200.tar.gz',
+    }),
+    ('SQL::Abstract', '1.81', {
+        'source_tmpl': 'SQL-Abstract-1.81.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RI/RIBASUSHI'],
+    }),
+    ('HTML::Form', '6.03', {
+        'source_tmpl': 'HTML-Form-6.03.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('File::Copy::Recursive', '0.38', {
+        'source_tmpl': 'File-Copy-Recursive-0.38.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DM/DMUEY'],
+    }),
+    ('Number::Compare', '0.03', {
+        'source_tmpl': 'Number-Compare-0.03.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RC/RCLAMP'],
+    }),
+    ('IPC::Run', '0.94', {
+        'source_tmpl': 'IPC-Run-0.94.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TODDR'],
+    }),
+    ('HTML::Entities::Interpolate', '1.05', {
+        'source_tmpl': 'HTML-Entities-Interpolate-1.05.tgz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+    }),
+    ('Test::ClassAPI', '1.06', {
+        'source_tmpl': 'Test-ClassAPI-1.06.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+    }),
+    ('Test::Most', '0.34', {
+        'source_tmpl': 'Test-Most-0.34.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/O/OV/OVID'],
+    }),
+    ('Class::Accessor', '0.34', {
+        'source_tmpl': 'Class-Accessor-0.34.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/K/KA/KASEI'],
+    }),
+    ('Test::Differences', '0.63', {
+        'source_tmpl': 'Test-Differences-0.63.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DC/DCANTRELL'],
+    }),
+    ('HTTP::Tiny', '0.056', {
+        'source_tmpl': 'HTTP-Tiny-0.056.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+    }),
+    ('Package::DeprecationManager', '0.14', {
+        'source_tmpl': 'Package-DeprecationManager-0.14.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('Digest::SHA1', '2.13', {
+        'source_tmpl': 'Digest-SHA1-2.13.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('Date::Language', '2.30', {
+        'source_tmpl': 'TimeDate-2.30.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GB/GBARR'],
+    }),
+    ('version', '0.9912', {
+        'source_tmpl': 'version-0.9912.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JP/JPEACOCK'],
+    }),
+    ('Sub::Uplevel', '0.25', {
+        'source_tmpl': 'Sub-Uplevel-0.25.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+    }),
+    # fails: uses 'gcc'
+    #('XML::Bare', '0.53', {
+    #    'source_tmpl': 'XML-Bare-0.53.tar.gz',
+    #    'source_urls': ['http://cpan.metacpan.org/authors/id/C/CO/CODECHILD'],
+    #}),
+    ('Dist::CheckConflicts', '0.11', {
+        'source_tmpl': 'Dist-CheckConflicts-0.11.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY'],
+    }),
+    ('Sub::Name', '0.14', {
+        'source_tmpl': 'Sub-Name-0.14.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Time::Piece', '1.30', {
+        'source_tmpl': 'Time-Piece-1.30.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Digest::HMAC', '1.03', {
+        'source_tmpl': 'Digest-HMAC-1.03.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('HTTP::Negotiate', '6.01', {
+        'source_tmpl': 'HTTP-Negotiate-6.01.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('MIME::Lite', '3.030', {
+        'source_tmpl': 'MIME-Lite-3.030.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Crypt::Rijndael', '1.13', {
+        'source_tmpl': 'Crypt-Rijndael-1.13.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('B::Lint', '1.20', {
+        'source_tmpl': 'B-Lint-1.20.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Canary::Stability', '2006', {
+        'source_tmpl': 'Canary-Stability-2006.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/ML/MLEHMANN'],
+    }),
+    ('AnyEvent', '7.11', {
+        'source_tmpl': 'AnyEvent-7.11.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/ML/MLEHMANN'],
+    }),
+    ('Object::Accessor', '0.48', {
+        'source_tmpl': 'Object-Accessor-0.48.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('Data::UUID', '1.221', {
+        'source_tmpl': 'Data-UUID-1.221.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Test::Pod', '1.51', {
+        'source_tmpl': 'Test-Pod-1.51.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('AppConfig', '1.71', {
+        'source_tmpl': 'AppConfig-1.71.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/N/NE/NEILB'],
+    }),
+    ('Net::SMTP::SSL', '1.03', {
+        'source_tmpl': 'Net-SMTP-SSL-1.03.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('XML::Tiny', '2.06', {
+        'source_tmpl': 'XML-Tiny-2.06.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DC/DCANTRELL'],
+    }),
+    ('HTML::Tagset', '3.20', {
+        'source_tmpl': 'HTML-Tagset-3.20.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/P/PE/PETDANCE'],
+    }),
+    ('HTML::Tree', '5.03', {
+        'source_tmpl': 'HTML-Tree-5.03.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CJ/CJM'],
+    }),
+    ('Devel::GlobalDestruction', '0.13', {
+        'source_tmpl': 'Devel-GlobalDestruction-0.13.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/H/HA/HAARG'],
+    }),
+    ('WWW::RobotRules', '6.02', {
+        'source_tmpl': 'WWW-RobotRules-6.02.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('Expect', '1.32', {
+        'source_tmpl': 'Expect-1.32.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SZ/SZABGAB'],
+    }),
+    ('Term::UI', '0.46', {
+        'source_tmpl': 'Term-UI-0.46.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('Net::SNMP', 'v6.0.1', {
+        'source_tmpl': 'Net-SNMP-v6.0.1.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DT/DTOWN'],
+    }),
+    ('XML::SAX::Writer', '0.56', {
+        'source_tmpl': 'XML-SAX-Writer-0.56.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PERIGRIN'],
+    }),
+    ('Statistics::Descriptive', '3.0609', {
+        'source_tmpl': 'Statistics-Descriptive-3.0609.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+    }),
+    ('Class::Load', '0.23', {
+        'source_tmpl': 'Class-Load-0.23.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('LWP::Simple', '6.13', {
+        'source_tmpl': 'libwww-perl-6.13.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Time::Piece::MySQL', '0.06', {
+        'source_tmpl': 'Time-Piece-MySQL-0.06.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/K/KA/KASEI'],
+    }),
+    ('Package::Stash::XS', '0.28', {
+        'source_tmpl': 'Package-Stash-XS-0.28.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY'],
+    }),
+    ('GD::Graph', '1.49', {
+        'source_tmpl': 'GDGraph-1.49.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RU/RUZ'],
+    }),
+    ('Set::Array', '0.30', {
+        'source_tmpl': 'Set-Array-0.30.tgz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RS/RSAVAGE'],
+    }),
+    ('boolean', '0.45', {
+        'source_tmpl': 'boolean-0.45.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/I/IN/INGY'],
+    }),
+    ('Number::Format', '1.75', {
+        'source_tmpl': 'Number-Format-1.75.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/W/WR/WRW'],
+    }),
+    ('Data::Stag', '0.14', {
+        'source_tmpl': 'Data-Stag-0.14.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CM/CMUNGALL'],
+    }),
+    ('Test::Tester', '1.001014', {
+        'source_tmpl': 'Test-Simple-1.001014.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('Test::NoWarnings', '1.04', {
+        'source_tmpl': 'Test-NoWarnings-1.04.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+    }),
+    ('Crypt::DES', '2.07', {
+        'source_tmpl': 'Crypt-DES-2.07.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DP/DPARIS'],
+    }),
+    ('Exporter', '5.72', {
+        'source_tmpl': 'Exporter-5.72.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TODDR'],
+    }),
+    ('Class::Inspector', '1.28', {
+        'source_tmpl': 'Class-Inspector-1.28.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+    }),
+    ('Parse::RecDescent', '1.967012', {
+        'source_tmpl': 'Parse-RecDescent-1.967012.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JT/JTBRAUN'],
+    }),
+    ('Carp', '1.36', {
+        'source_tmpl': 'Carp-1.36.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('XML::XPath', '1.13', {
+        'source_tmpl': 'XML-XPath-1.13.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/M/MS/MSERGEANT'],
+    }),
+    ('Capture::Tiny', '0.30', {
+        'source_tmpl': 'Capture-Tiny-0.30.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+    }),
+    ('JSON', '2.90', {
+        'source_tmpl': 'JSON-2.90.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MAKAMAKA'],
+    }),
+    ('Sub::Exporter', '0.987', {
+        'source_tmpl': 'Sub-Exporter-0.987.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Class::Load::XS', '0.09', {
+        'source_tmpl': 'Class-Load-XS-0.09.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Set::IntSpan::Fast', '1.15', {
+        'source_tmpl': 'Set-IntSpan-Fast-1.15.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AN/ANDYA'],
+    }),
+    ('Sub::Exporter::Progressive', '0.001011', {
+        'source_tmpl': 'Sub-Exporter-Progressive-0.001011.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FR/FREW'],
+    }),
+    ('LWP', '6.13', {
+        'source_tmpl': 'libwww-perl-6.13.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Data::Dumper::Concise', '2.022', {
+        'source_tmpl': 'Data-Dumper-Concise-2.022.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/F/FR/FREW'],
+    }),
+    ('File::Slurp::Tiny', '0.004', {
+        'source_tmpl': 'File-Slurp-Tiny-0.004.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('Algorithm::Diff', '1.1903', {
+        'source_tmpl': 'Algorithm-Diff-1.1903.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TY/TYEMQ'],
+    }),
+    ('AnyData', '0.12', {
+        'source_tmpl': 'AnyData-0.12.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+    }),
+    ('Text::Iconv', '1.7', {
+        'source_tmpl': 'Text-Iconv-1.7.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/M/MP/MPIOTR'],
+    }),
+    ('Class::Data::Inheritable', '0.08', {
+        'source_tmpl': 'Class-Data-Inheritable-0.08.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TM/TMTM'],
+    }),
+    ('Text::Balanced', '2.03', {
+        'source_tmpl': 'Text-Balanced-2.03.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHAY'],
+    }),
+    ('strictures', '2.000001', {
+        'source_tmpl': 'strictures-2.000001.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
+    }),
+    ('Switch', '2.17', {
+        'source_tmpl': 'Switch-2.17.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CH/CHORNY'],
+    }),
+    ('File::Which', '1.19', {
+        'source_tmpl': 'File-Which-1.19.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PL/PLICEASE'],
+    }),
+    ('Email::Date::Format', '1.005', {
+        'source_tmpl': 'Email-Date-Format-1.005.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Error', '0.17024', {
+        'source_tmpl': 'Error-0.17024.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+    }),
+    ('Mock::Quick', '1.110', {
+        'source_tmpl': 'Mock-Quick-1.110.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('Text::CSV', '1.33', {
+        'source_tmpl': 'Text-CSV-1.33.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MAKAMAKA'],
+    }),
+    ('Test::Output', '1.03', {
+        'source_tmpl': 'Test-Output-1.03.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BD/BDFOY'],
+    }),
+    ('Class::DBI', 'v3.0.17', {
+        'source_tmpl': 'Class-DBI-v3.0.17.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TM/TMTM'],
+    }),
+    ('List::AllUtils', '0.09', {
+        'source_tmpl': 'List-AllUtils-0.09.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('UNIVERSAL::moniker', '0.08', {
+        'source_tmpl': 'UNIVERSAL-moniker-0.08.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/K/KA/KASEI'],
+    }),
+    ('Exception::Class', '1.39', {
+        'source_tmpl': 'Exception-Class-1.39.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('File::CheckTree', '4.42', {
+        'source_tmpl': 'File-CheckTree-4.42.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Math::VecStat', '0.08', {
+        'source_tmpl': 'Math-VecStat-0.08.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AS/ASPINELLI'],
+    }),
+    ('Pod::LaTeX', '0.61', {
+        'source_tmpl': 'Pod-LaTeX-0.61.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TJ/TJENNESS'],
+    }),
+    ('Eval::Closure', '0.13', {
+        'source_tmpl': 'Eval-Closure-0.13.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DO/DOY'],
+    }),
+    ('HTTP::Request', '6.11', {
+        'source_tmpl': 'HTTP-Message-6.11.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('XML::Twig', '3.49', {
+        'source_tmpl': 'XML-Twig-3.49.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MI/MIROD'],
+    }),
+    ('IO::String', '1.08', {
+        'source_tmpl': 'IO-String-1.08.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('XML::Simple', '2.20', {
+        'source_tmpl': 'XML-Simple-2.20.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GR/GRANTM'],
+    }),
+    ('Sub::Install', '0.928', {
+        'source_tmpl': 'Sub-Install-0.928.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('HTTP::Cookies', '6.01', {
+        'source_tmpl': 'HTTP-Cookies-6.01.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('Pod::Plainer', '1.04', {
+        'source_tmpl': 'Pod-Plainer-1.04.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RM/RMBARKER'],
+    }),
+    ('Test::Exception::LessClever', '0.006', {
+        'source_tmpl': 'Test-Exception-LessClever-0.006.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/E/EX/EXODIST'],
+    }),
+    ('LWP::MediaTypes', '6.02', {
+        'source_tmpl': 'LWP-MediaTypes-6.02.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('Scalar::Util', '1.42', {
+        'source_tmpl': 'Scalar-List-Utils-1.42.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PE/PEVANS'],
+    }),
+    ('Data::Section::Simple', '0.07', {
+        'source_tmpl': 'Data-Section-Simple-0.07.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA'],
+    }),
+    ('IO::Scalar', '2.111', {
+        'source_tmpl': 'IO-stringy-2.111.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DS/DSKOLL'],
+    }),
+    ('Class::Trigger', '0.14', {
+        'source_tmpl': 'Class-Trigger-0.14.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA'],
+    }),
+    ('HTTP::Daemon', '6.01', {
+        'source_tmpl': 'HTTP-Daemon-6.01.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('File::HomeDir', '1.00', {
+        'source_tmpl': 'File-HomeDir-1.00.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+    }),
+    ('HTTP::Date', '6.02', {
+        'source_tmpl': 'HTTP-Date-6.02.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('Authen::SASL', '2.16', {
+        'source_tmpl': 'Authen-SASL-2.16.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GB/GBARR'],
+    }),
+    ('Clone', '0.38', {
+        'source_tmpl': 'Clone-0.38.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/G/GA/GARU'],
+    }),
+    ('Data::Types', '0.09', {
+        'source_tmpl': 'Data-Types-0.09.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DW/DWHEELER'],
+    }),
+    ('Import::Into', '1.002005', {
+        'source_tmpl': 'Import-Into-1.002005.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/H/HA/HAARG'],
+    }),
+    ('DateTime::Tiny', '1.04', {
+        'source_tmpl': 'DateTime-Tiny-1.04.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+    }),
+    ('DBD::AnyData', '0.110', {
+        'source_tmpl': 'DBD-AnyData-0.110.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+    }),
+    ('Text::Format', '0.59', {
+        'source_tmpl': 'Text-Format-0.59.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/S/SH/SHLOMIF'],
+    }),
+    ('Devel::CheckCompiler', '0.06', {
+        'source_tmpl': 'Devel-CheckCompiler-0.06.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SY/SYOHEX'],
+    }),
+    ('Log::Handler', '0.87', {
+        'source_tmpl': 'Log-Handler-0.87.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BL/BLOONIX'],
+    }),
+    ('DBIx::ContextualFetch', '1.03', {
+        'source_tmpl': 'DBIx-ContextualFetch-1.03.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/T/TM/TMTM'],
+    }),
+    ('HTML::Entities', '3.71', {
+        'source_tmpl': 'HTML-Parser-3.71.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/G/GA/GAAS'],
+    }),
+    ('Devel::StackTrace', '2.00', {
+        'source_tmpl': 'Devel-StackTrace-2.00.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DR/DROLSKY'],
+    }),
+    ('Term::ReadKey', '2.33', {
+        'source_tmpl': 'TermReadKey-2.33.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/J/JS/JSTOWE'],
+    }),
+    ('Set::IntSpan', '1.19', {
+        'source_tmpl': 'Set-IntSpan-1.19.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/S/SW/SWMCD'],
+    }),
+    ('Moose', '2.1603', {
+        'source_tmpl': 'Moose-2.1603.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/E/ET/ETHER'],
+    }),
+    ('Algorithm::Dependency', '1.110', {
+        'source_tmpl': 'Algorithm-Dependency-1.110.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/A/AD/ADAMK'],
+    }),
+    ('Font::TTF', '1.05', {
+        'source_tmpl': 'Font-TTF-1.05.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MH/MHOSKEN'],
+    }),
+    ('IPC::Run3', '0.048', {
+        'source_tmpl': 'IPC-Run3-0.048.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('File::Find::Rule', '0.33', {
+        'source_tmpl': 'File-Find-Rule-0.33.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RC/RCLAMP'],
+    }),
+    ('SQL::Statement', '1.407', {
+        'source_tmpl': 'SQL-Statement-1.407.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RE/REHSACK'],
+    }),
+    ('File::Slurp', '9999.19', {
+        'source_tmpl': 'File-Slurp-9999.19.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/U/UR/URI'],
+    }),
+    ('Package::Stash', '0.37', {
+        'source_tmpl': 'Package-Stash-0.37.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY'],
+    }),
+    ('Data::OptList', '0.109', {
+        'source_tmpl': 'Data-OptList-0.109.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('CPANPLUS', '0.9154', {
+        'source_tmpl': 'CPANPLUS-0.9154.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/B/BI/BINGOS'],
+    }),
+    ('Test::Harness', '3.35', {
+        'source_tmpl': 'Test-Harness-3.35.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/L/LE/LEONT'],
+    }),
+    ('IO::Tty', '1.12', {
+        'source_tmpl': 'IO-Tty-1.12.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/T/TO/TODDR'],
+    }),
+    ('Text::Soundex', '3.04', {
+        'source_tmpl': 'Text-Soundex-3.04.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/R/RJ/RJBS'],
+    }),
+    ('Lingua::EN::PluralToSingular', '0.14', {
+        'source_tmpl': 'Lingua-EN-PluralToSingular-0.14.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/B/BK/BKB'],
+    }),
+    ('Want', '0.26', {
+        'source_tmpl': 'Want-0.26.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/R/RO/ROBIN'],
+    }),
+    ('Cwd::Guard', '0.04', {
+        'source_tmpl': 'Cwd-Guard-0.04.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/K/KA/KAZEBURO'],
+    }),
+    ('Bundle::BioPerl', '2.1.9', {
+        'source_tmpl': 'Bundle-BioPerl-2.1.9.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS'],
+    }),
+    ('Mail::Util', '2.14', {
+        'source_tmpl': 'MailTools-2.14.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/M/MA/MARKOV'],
+    }),
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
Full version of Perl, as needed by vcftools-0.1.14