### PR TITLE
Update OpenSSL to 1.0.1r

### DIFF
--- a/easybuild/easyconfigs/o/OpenSSL/OpenSSL-1.0.1r-foss-2015b.eb
+++ b/easybuild/easyconfigs/o/OpenSSL/OpenSSL-1.0.1r-foss-2015b.eb
@@ -1,0 +1,19 @@
+name = 'OpenSSL'
+version = '1.0.1r'
+
+homepage = 'http://www.openssl.org/'
+description = """The OpenSSL Project is a collaborative effort to develop a robust, commercial-grade, full-featured,
+ and Open Source toolchain implementing the Secure Sockets Layer (SSL v2/v3) and Transport Layer Security (TLS v1) 
+ protocols as well as a full-strength general purpose cryptography library. """
+
+toolchain = {'name': 'foss', 'version': '2015b'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.openssl.org/source/']
+
+dependencies = [('zlib', '1.2.8')]
+
+runtest = 'test'
+
+moduleclass = 'system'


### PR DESCRIPTION
Required by a new EB I'm working on.

I needed to increase the download timeout when testing locally, possibly because I have IPv6 and that download was particularly slow.