### PR TITLE
Create texinfo 4.13a easyconfig

### DIFF
--- a/easybuild/easyconfigs/t/texinfo/texinfo-4.13a-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/t/texinfo/texinfo-4.13a-GCC-4.8.4.eb
@@ -1,0 +1,31 @@
+easyblock = 'ConfigureMake'
+
+name = 'texinfo'
+version = '4.13a'
+
+homepage = 'https://www.gnu.org/software/texinfo/'
+description = """Texinfo is the official documentation format of the GNU project."""
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+toolchain = {'name': 'GCC', 'version': '4.8.4'}
+
+osdependencies = ['texlive']
+
+preinstallopts = "make TEXMF=%(installdir)s/texmf install-tex && "
+
+# This will overwrite a users $TEXMFHOME so this module is best used as a build dependency
+modextravars = {'TEXMFHOME': '%(installdir)s/texmf'}
+modloadmsg = "\n\nWARNING: This texinfo module has (re)defined the value for the environment variable \\$TEXMFHOME.\n"
+modloadmsg += "If you use a custom texmf directory (such as ~/texmf) you should copy files found in the\n"
+modloadmsg += "new \\$TEXMFHOME to your custom directory and reset the value of \\$TEXMFHOME to point to that space:\n"
+modloadmsg += "\tcp -r $TEXMFHOME/* /path/to/your/texmf\n"
+modloadmsg += "\texport TEXMFHOME=/path/to/your/texmf\n\n"
+
+sanity_check_paths = {
+    'files': ['bin/info', 'bin/makeinfo', 'bin/texi2pdf', 'texmf/tex/texinfo/texinfo.tex'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/texinfo/texinfo-4.13a.eb
+++ b/easybuild/easyconfigs/t/texinfo/texinfo-4.13a.eb
@@ -9,7 +9,7 @@ description = """Texinfo is the official documentation format of the GNU project
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 
-toolchain = {'name': 'GCC', 'version': '4.8.4'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 osdependencies = ['texlive']
 


### PR DESCRIPTION
Create a texinfo 4.13 easyconfig based on the newer 5.2 easyconfig
to support builing older GCC (<=4.7.2) on newer systems. The 4.x releases
of texinfo tolerated a document parsing error in earlier versions of GCC.

In particular, loading the resulting module allows building GCC 4.7.2
on CentOS7.  This GCC is the foundation of the goolf-1.4.10 toolchain
used by many bioinformatics packages in the current EasyBuild (2.6).

The easyconfig's GCC requirement was set to 4.8.4 as a convinience to match
the version of GCC likely already built by the goolf-1.7.20 toolchain.