### PR TITLE
fix sanity check for xtrans

### DIFF
--- a/easybuild/easyconfigs/x/xtrans/xtrans-1.2.6-foss-2014b.eb
+++ b/easybuild/easyconfigs/x/xtrans/xtrans-1.2.6-foss-2014b.eb
@@ -15,9 +15,8 @@ sources = [SOURCE_TAR_GZ]
 source_urls = [XORG_LIB_SOURCE]
 
 sanity_check_paths = {
-    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtransdnet.c', 'Xtrans.h',
-                                                    'Xtransint.h', 'Xtranslcl.c', 'Xtransos2.c', 'Xtranssock.c',
-                                                    'Xtranstli.c', 'Xtransutil.c']],
+    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtrans.h', 'Xtransint.h',
+                                                    'Xtranslcl.c', 'Xtranssock.c', 'Xtranstli.c', 'Xtransutil.c']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/x/xtrans/xtrans-1.3.4-intel-2014b.eb
+++ b/easybuild/easyconfigs/x/xtrans/xtrans-1.3.4-intel-2014b.eb
@@ -15,9 +15,8 @@ sources = [SOURCE_TAR_GZ]
 source_urls = [XORG_LIB_SOURCE]
 
 sanity_check_paths = {
-    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtransdnet.c', 'Xtrans.h',
-                                                    'Xtransint.h', 'Xtranslcl.c', 'Xtransos2.c', 'Xtranssock.c',
-                                                    'Xtranstli.c', 'Xtransutil.c']],
+    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtrans.h', 'Xtransint.h',
+                                                    'Xtranslcl.c', 'Xtranssock.c', 'Xtransutil.c']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/x/xtrans/xtrans-1.3.4-intel-2015a.eb
+++ b/easybuild/easyconfigs/x/xtrans/xtrans-1.3.4-intel-2015a.eb
@@ -15,9 +15,8 @@ sources = [SOURCE_TAR_GZ]
 source_urls = [XORG_LIB_SOURCE]
 
 sanity_check_paths = {
-    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtransdnet.c', 'Xtrans.h',
-                                                    'Xtransint.h', 'Xtranslcl.c', 'Xtransos2.c', 'Xtranssock.c',
-                                                    'Xtranstli.c', 'Xtransutil.c']],
+    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtrans.h', 'Xtransint.h',
+                                                    'Xtranslcl.c', 'Xtranssock.c', 'Xtransutil.c']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/x/xtrans/xtrans-1.3.5-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/x/xtrans/xtrans-1.3.5-goolf-1.5.14.eb
@@ -15,8 +15,6 @@ sources = [SOURCE_TAR_GZ]
 source_urls = [XORG_LIB_SOURCE]
 
 sanity_check_paths = {
-    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtrans.h', 'Xtransint.h', 'Xtranslcl.c',
-                                                    'Xtranssock.c', 'Xtransutil.c']],
     'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtrans.h', 'Xtransint.h',
                                                     'Xtranslcl.c', 'Xtranssock.c', 'Xtransutil.c']],
     'dirs': [],

--- a/easybuild/easyconfigs/x/xtrans/xtrans-1.3.5-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/x/xtrans/xtrans-1.3.5-goolf-1.5.14.eb
@@ -15,9 +15,10 @@ sources = [SOURCE_TAR_GZ]
 source_urls = [XORG_LIB_SOURCE]
 
 sanity_check_paths = {
-    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtransdnet.c', 'Xtrans.h',
-                                                    'Xtransint.h', 'Xtranslcl.c', 'Xtransos2.c', 'Xtranssock.c',
-                                                    'Xtranstli.c', 'Xtransutil.c']],
+    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtrans.h', 'Xtransint.h', 'Xtranslcl.c',
+                                                    'Xtranssock.c', 'Xtransutil.c']],
+    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtrans.h', 'Xtransint.h',
+                                                    'Xtranslcl.c', 'Xtranssock.c', 'Xtransutil.c']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/x/xtrans/xtrans-1.3.5-intel-2015a.eb
+++ b/easybuild/easyconfigs/x/xtrans/xtrans-1.3.5-intel-2015a.eb
@@ -15,9 +15,8 @@ sources = [SOURCE_TAR_GZ]
 source_urls = [XORG_LIB_SOURCE]
 
 sanity_check_paths = {
-    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtransdnet.c', 'Xtrans.h',
-                                                    'Xtransint.h', 'Xtranslcl.c', 'Xtransos2.c', 'Xtranssock.c',
-                                                    'Xtranstli.c', 'Xtransutil.c']],
+    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtrans.h', 'Xtransint.h',
+                                                    'Xtranslcl.c', 'Xtranssock.c', 'Xtransutil.c']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/x/xtrans/xtrans-1.3.5-intel-2015b.eb
+++ b/easybuild/easyconfigs/x/xtrans/xtrans-1.3.5-intel-2015b.eb
@@ -15,9 +15,8 @@ sources = [SOURCE_TAR_GZ]
 source_urls = [XORG_LIB_SOURCE]
 
 sanity_check_paths = {
-    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtransdnet.c', 'Xtrans.h',
-                                                    'Xtransint.h', 'Xtranslcl.c', 'Xtransos2.c', 'Xtranssock.c',
-                                                    'Xtranstli.c', 'Xtransutil.c']],
+    'files': ['include/X11/Xtrans/%s' % x for x in ['transport.c', 'Xtrans.c', 'Xtrans.h', 'Xtransint.h',
+                                                    'Xtranslcl.c', 'Xtranssock.c', 'Xtransutil.c']],
     'dirs': [],
 }
 


### PR DESCRIPTION
list of files in `sanity_check_paths` was incorrectly expanded in #2504 

reported by @hajgato