### PR TITLE
{lib} [goolf-1.7.20]  libxml2-2.9.3 (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.3-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.3-goolf-1.7.20.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'libxml2'
+version = '2.9.3'
+
+homepage = 'http://xmlsoft.org/'
+description = """Libxml2 is the XML C parser and 
+toolchain developed for the Gnome project
+ (but usable outside of the Gnome platform)."""
+
+toolchain = {'name': 'goolf', 'version': '1.7.20'}
+toolchainopts = {'pic': True}
+
+source_urls = [
+    'http://xmlsoft.org/sources/',
+    'http://xmlsoft.org/sources/old/'
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = 'CC="$CC" CXX="$CXX" --with-pic --without-python --with-zlib=$EBROOTZLIB'
+
+dependencies = [('zlib', '1.2.8')]
+
+sanity_check_paths = {
+    'files': [('lib/libxml2.a', 'lib64/libxml2.a'), ('lib/libxml2.%s' % SHLIB_EXT, 'lib64/libxml2.%s' % SHLIB_EXT)],
+    'dirs': ['bin', 'include/libxml2/libxml'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
I had to modify the default libxml2 easyconfig to include this in the configopts

```
--with-zlib=$EBROOTZLIB
```

before adding ``` --with-zlib=$EBROOTZLIB``` the libxml2 build procedure was using the system zlib (I have zlib-devel rpm installed) and then I was getting weird errors like this one compiling another application which uses libxml2 module. I loaded libxml2 module which loads zlib-1.2.8 as dependency but libxml2.so looks for system zlib

```
/scicore/soft/apps/libxml2/2.9.3-goolf-1.7.20/lib/libxml2.so: undefined reference to `gzopen64@ZLIB_1.2.3.3'
```

I think this fix should be added in every libxml2 easyconfig to avoid issues in systems where zlib-devel is installed
