### PR TITLE
removed PrgEnv version, craype and fftw from the new Cray* XC toolchain (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.06-XC.eb
@@ -11,10 +11,8 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 dependencies = [
     ('PrgEnv-cray/5.2.40', EXTERNAL_MODULE),
     ('cce/8.3.12', EXTERNAL_MODULE),
-    ('craype/2.4.0', EXTERNAL_MODULE),
     ('cray-libsci/13.0.4', EXTERNAL_MODULE),
     ('cray-mpich/7.2.2', EXTERNAL_MODULE),
-    ('fftw/3.3.4.3', EXTERNAL_MODULE),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.06-XC.eb
@@ -9,7 +9,8 @@ description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 dependencies = [
-    ('PrgEnv-cray/5.2.40', EXTERNAL_MODULE),
+    # PrgEnv version is not pinned, as Cray recommends to use the latest (default) version
+    ('PrgEnv-cray', EXTERNAL_MODULE),
     ('cce/8.3.12', EXTERNAL_MODULE),
     ('cray-libsci/13.0.4', EXTERNAL_MODULE),
     ('cray-mpich/7.2.2', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.06-XC.eb
@@ -4,7 +4,7 @@ name = 'CrayCCE'
 version = '2015.06-XC'
 
 homepage = 'http://docs.cray.com/books/S-9407-1511'
-description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module (PE release: November 2015).\n"""
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-cray module (PE release: November 2015).\n"""
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 

--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.11-XC.eb
@@ -4,7 +4,7 @@ name = 'CrayCCE'
 version = '2015.11-XC'
 
 homepage = 'http://docs.cray.com/books/S-9407-1511'
-description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module (PE release: November 2015).\n"""
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-cray module (PE release: November 2015).\n"""
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 

--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.11-XC.eb
@@ -11,10 +11,8 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 dependencies = [
     ('PrgEnv-cray/5.2.82', EXTERNAL_MODULE),
     ('cce/8.4.1', EXTERNAL_MODULE),
-    ('craype/2.4.2', EXTERNAL_MODULE),
     ('cray-libsci/13.2.0', EXTERNAL_MODULE),
     ('cray-mpich/7.2.6', EXTERNAL_MODULE),
-    ('fftw/3.3.4.5', EXTERNAL_MODULE),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-2015.11-XC.eb
@@ -9,7 +9,8 @@ description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 dependencies = [
-    ('PrgEnv-cray/5.2.82', EXTERNAL_MODULE),
+    # PrgEnv version is not pinned, as Cray recommends to use the latest (default) version
+    ('PrgEnv-cray', EXTERNAL_MODULE),
     ('cce/8.4.1', EXTERNAL_MODULE),
     ('cray-libsci/13.2.0', EXTERNAL_MODULE),
     ('cray-mpich/7.2.6', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.06-XC.eb
@@ -11,10 +11,8 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 dependencies = [
     ('PrgEnv-gnu/5.2.40', EXTERNAL_MODULE),
     ('gcc/4.8.2', EXTERNAL_MODULE),
-    ('craype/2.4.0', EXTERNAL_MODULE),
     ('cray-libsci/13.0.4', EXTERNAL_MODULE),
     ('cray-mpich/7.2.2', EXTERNAL_MODULE),
-    ('fftw/3.3.4.3', EXTERNAL_MODULE),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.06-XC.eb
@@ -9,7 +9,8 @@ description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 dependencies = [
-    ('PrgEnv-gnu/5.2.40', EXTERNAL_MODULE),
+    # PrgEnv version is not pinned, as Cray recommends to use the latest (default) version
+    ('PrgEnv-gnu', EXTERNAL_MODULE),
     ('gcc/4.8.2', EXTERNAL_MODULE),
     ('cray-libsci/13.0.4', EXTERNAL_MODULE),
     ('cray-mpich/7.2.2', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.11-XC.eb
@@ -11,10 +11,8 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 dependencies = [
     ('PrgEnv-gnu/5.2.82', EXTERNAL_MODULE),
     ('gcc/4.9.3', EXTERNAL_MODULE),
-    ('craype/2.4.2', EXTERNAL_MODULE),
     ('cray-libsci/13.2.0', EXTERNAL_MODULE),
     ('cray-mpich/7.2.6', EXTERNAL_MODULE),
-    ('fftw/3.3.4.5', EXTERNAL_MODULE),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-2015.11-XC.eb
@@ -9,7 +9,8 @@ description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 dependencies = [
-    ('PrgEnv-gnu/5.2.82', EXTERNAL_MODULE),
+    # PrgEnv version is not pinned, as Cray recommends to use the latest (default) version
+    ('PrgEnv-gnu', EXTERNAL_MODULE),
     ('gcc/4.9.3', EXTERNAL_MODULE),
     ('cray-libsci/13.2.0', EXTERNAL_MODULE),
     ('cray-mpich/7.2.6', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.06-XC.eb
@@ -11,10 +11,8 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 dependencies = [
     ('PrgEnv-intel/5.2.82', EXTERNAL_MODULE),
     ('intel/15.0.1.133', EXTERNAL_MODULE),
-    ('craype/2.4.0', EXTERNAL_MODULE),
     ('cray-libsci/13.0.4', EXTERNAL_MODULE),
     ('cray-mpich/7.2.2', EXTERNAL_MODULE),
-    ('fftw/3.3.4.3', EXTERNAL_MODULE),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.06-XC.eb
@@ -4,7 +4,7 @@ name = 'CrayIntel'
 version = '2015.06-XC'
 
 homepage = 'http://docs.cray.com/books/S-9407-1511'
-description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module (PE release: November 2015).\n"""
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-intel module (PE release: November 2015).\n"""
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.06-XC.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.06-XC.eb
@@ -9,7 +9,8 @@ description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 dependencies = [
-    ('PrgEnv-intel/5.2.82', EXTERNAL_MODULE),
+    # PrgEnv version is not pinned, as Cray recommends to use the latest (default) version
+    ('PrgEnv-intel', EXTERNAL_MODULE),
     ('intel/15.0.1.133', EXTERNAL_MODULE),
     ('cray-libsci/13.0.4', EXTERNAL_MODULE),
     ('cray-mpich/7.2.2', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.11-XC.eb
@@ -4,7 +4,7 @@ name = 'CrayIntel'
 version = '2015.11-XC'
 
 homepage = 'http://docs.cray.com/books/S-9407-1511'
-description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module (PE release: November 2015).\n"""
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-intel module (PE release: November 2015).\n"""
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.11-XC.eb
@@ -11,10 +11,8 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 dependencies = [
     ('PrgEnv-intel/5.2.82', EXTERNAL_MODULE),
     ('intel/15.0.1.133', EXTERNAL_MODULE),
-    ('craype/2.4.2', EXTERNAL_MODULE),
     ('cray-libsci/13.2.0', EXTERNAL_MODULE),
     ('cray-mpich/7.2.6', EXTERNAL_MODULE),
-    ('fftw/3.3.4.5', EXTERNAL_MODULE),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-2015.11-XC.eb
@@ -9,7 +9,8 @@ description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 dependencies = [
-    ('PrgEnv-intel/5.2.82', EXTERNAL_MODULE),
+    # PrgEnv version is not pinned, as Cray recommends to use the latest (default) version
+    ('PrgEnv-intel', EXTERNAL_MODULE),
     ('intel/15.0.1.133', EXTERNAL_MODULE),
     ('cray-libsci/13.2.0', EXTERNAL_MODULE),
     ('cray-mpich/7.2.6', EXTERNAL_MODULE),


### PR DESCRIPTION
This removes fftw (as discussed before) and also craype from the toolchain. I'm creating this PR to update with the latest results and to keep track of the discussion.

The craype removal was advised by Cray (they claim that craype is backwards compatible) as a fix for the bugs we were having when swapping (non-default) PrgEnv dependencies. 

Ideally we want to pin versions for all the dependencies, but first I'd like to have a working TC and hopefully this version will work on more systems. For the moment this version works on Daint, Dora, Santis and Brisi (we still need to test on Swan and Sisu). 

Here I've also removed the version from the PrgEnv and the other change required is to unload + load the PrgEnv instead of swapping. PR#?? 

This replaces https://github.com/hpcugent/easybuild-easyconfigs/pull/2442