### PR TITLE
{devel}[intel-2016a] Xorg-headers 20160225 (WIP)

### DIFF
--- a/easybuild/easyconfigs/x/Xorg-headers/Xorg-headers-20160225-intel-2016a.eb
+++ b/easybuild/easyconfigs/x/Xorg-headers/Xorg-headers-20160225-intel-2016a.eb
@@ -1,6 +1,6 @@
 easyblock = 'EB_Xorg'
 
-name = 'Xorg-headres'
+name = 'Xorg-headers'
 version = '20160225'
 
 homepage = "http://www.freedesktop.org/wiki/Software/xlibs"

--- a/easybuild/easyconfigs/x/Xorg-headers/Xorg-headers-20160225-intel-2016a.eb
+++ b/easybuild/easyconfigs/x/Xorg-headers/Xorg-headers-20160225-intel-2016a.eb
@@ -1,0 +1,95 @@
+easyblock = 'EB_Xorg'
+
+name = 'Xorg-headres'
+version = '20160225'
+
+homepage = "http://www.freedesktop.org/wiki/Software/xlibs"
+description = "X protocol and ancillary headers"
+
+toolchain = {'name': 'intel', 'version': '2016a'}
+toolchainopts = {'optarch': True}
+
+sources = []
+source_urls = ['http://xorg.freedesktop.org/archive/individual/proto/']
+
+#Xorg_installs[(name, version, configuredir(def:name-version), extension(def:.tar.bz2),
+#               extra_source_urls(def:do not add),...]
+Xorg_installs = [
+    ('bigreqsproto', '1.1.2'),
+    ('compositeproto', '0.4.2'),
+    ('damageproto', '1.2.1'),
+    ('dmxproto', '2.3.1'),
+    ('dri2proto', '2.8'),
+    ('dri3proto', '1.0'),
+    ('fixesproto', '5.0'),
+    ('fontsproto', '2.1.3'),
+    ('glproto', '1.4.17'),
+    ('inputproto', '2.3.1'),
+    ('kbproto', '1.0.7'),
+    ('presentproto', '1.0'),
+    ('randrproto', '1.5.0'),
+    ('recordproto', '1.14.2'),
+    ('renderproto', '0.11.1'),
+    ('resourceproto', '1.2.0'),
+    ('scrnsaverproto', '1.2.2'),
+    ('videoproto', '2.3.2'),
+    ('xcmiscproto', '1.2.2'),
+    ('xextproto', '7.3.0'),
+    ('xf86bigfontproto', '1.2.0'),
+    ('xf86dgaproto', '2.1'),
+    ('xf86driproto', '2.1.1'),
+    ('xf86vidmodeproto', '2.3.1'),
+    ('xineramaproto', '1.2.1'),
+    ('xproto', '7.0.28'),
+]
+
+dependencies = [
+    ('xorg-macros', '1.19.0'),
+]
+
+sanity_check_paths = {
+    'files': ['include/X11/%s' % x for x in ['Xwindows.h', 'Xmd.h', 'XWDFile.h', 'Xos_r.h', 'ap_keysym.h',
+                                             'Sunkeysym.h', 'Xfuncproto.h', 'Xos.h', 'Xwinsock.h', 'XF86keysym.h',
+                                             'Xprotostr.h', 'Xfuncs.h', 'Xw32defs.h', 'Xproto.h', 'Xpoll.h',
+                                             'keysym.h', 'Xarch.h', 'Xatom.h', 'HPkeysym.h', 'Xalloca.h', 'Xosdefs.h',
+                                             'X.h', 'DECkeysym.h', 'keysymdef.h', 'Xdefs.h', 'Xthreads.h']] +
+             ['lib/pkgconfig/%s' % x for x in ['xcmiscproto.pc', 'dri2proto.pc', 'dmxproto.pc', 'inputproto.pc',
+                                               'scrnsaverproto.pc', 'randrproto.pc', 'xf86bigfontproto.pc',
+                                               'resourceproto.pc', 'xproto.pc', 'glproto.pc', 'xf86vidmodeproto.pc',
+                                               'dri3proto.pc', 'kbproto.pc', 'xf86dgaproto.pc', 'xextproto.pc',
+                                               'bigreqsproto.pc', 'renderproto.pc', 'xineramaproto.pc',
+                                               'fixesproto.pc', 'recordproto.pc', 'damageproto.pc', 'xf86driproto.pc',
+                                               'videoproto.pc', 'compositeproto.pc', 'presentproto.pc',
+                                               'fontsproto.pc']] +
+             ['include/GL/%s' % x for x in ['glxproto.h', 'glxint.h', 'glxmd.h', 'glxtokens.h',]] +
+             ['include/GL/internal/glcore.h'] +
+             ['include/X11/extensions/%s' % x for x in ['dri2proto.h', 'presentproto.h', 'xfixesproto.h',
+                                                        'xf86vmstr.h', 'xtestconst.h', 'render.h', 'cupproto.h',
+                                                        'xtestproto.h', 'damageproto.h', 'lbx.h', 'bigreqsproto.h',
+                                                        'xf86dgastr.h', 'vldXvMC.h', 'XvMC.h', 'XKBstr.h', 'shm.h',
+                                                        'randr.h', 'lbxproto.h', 'EVIproto.h', 'xf86bigfstr.h',
+                                                        'xf86bigfont.h', 'cup.h', 'xtestext1proto.h', 'XIproto.h',
+                                                        'xtestext1const.h', 'xf86vmproto.h', 'xcmiscproto.h', 'dbe.h',
+                                                        'geproto.h', 'xf86dga1str.h', 'randrproto.h', 'securproto.h',
+                                                        'bigreqstr.h', 'xf86dgaproto.h', 'xf86dgaconst.h',
+                                                        'renderproto.h', 'syncproto.h', 'syncconst.h',
+                                                        'mitmiscconst.h', 'mitmiscproto.h', 'XKB.h', 'XI2proto.h',
+                                                        'xf86vm.h', 'shmproto.h', 'dri2tokens.h', 'damagewire.h',
+                                                        'XKBsrv.h', 'XvMCproto.h', 'ag.h', 'dbeproto.h',
+                                                        'xfixeswire.h', 'secur.h', 'agproto.h', 'ge.h', 'dmxproto.h',
+                                                        'xf86dga.h', 'saverproto.h', 'syncstr.h', 'Xvproto.h',
+                                                        'dpmsconst.h', 'recordproto.h', 'recordconst.h',
+                                                        'dpmsproto.h', 'xf86bigfproto.h', 'shmstr.h', 'xcmiscstr.h',
+                                                        'XI.h', 'Xv.h', 'XI2.h', 'xf86dga1const.h', 'EVI.h',
+                                                        'xf86dga1proto.h', 'multibufproto.h', 'multibufconst.h',
+                                                        'XKBproto.h', 'panoramiXproto.h', 'shapestr.h', 'dri3proto.h',
+                                                        'recordstr.h', 'XResproto.h', 'saver.h', 'presenttokens.h',
+                                                        'composite.h', 'shapeproto.h', 'compositeproto.h',
+                                                        'shapeconst.h', 'XKBgeom.h', 'dmx.h']] +
+             ['include/X11/dri/%s' % x for x in ['xf86dri.h', 'xf86driproto.h', 'xf86dristr.h']] +
+             ['include/X11/fonts/%s' % x for x in ['fontproto.h', 'fontstruct.h', 'FS.h', 'fsmasks.h', 'font.h',
+                                                   'FSproto.h']],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/x/Xorg-headers/Xorg-headers-20160225-intel-2016a.eb
+++ b/easybuild/easyconfigs/x/Xorg-headers/Xorg-headers-20160225-intel-2016a.eb
@@ -12,8 +12,7 @@ toolchainopts = {'optarch': True}
 sources = []
 source_urls = ['http://xorg.freedesktop.org/archive/individual/proto/']
 
-#Xorg_installs[(name, version, configuredir(def:name-version), extension(def:.tar.bz2),
-#               extra_source_urls(def:do not add),...]
+#Xorg_installs[(name, version, {'parameter1': "parameter1", ...}), ...]
 Xorg_installs = [
     ('bigreqsproto', '1.1.2'),
     ('compositeproto', '0.4.2'),


### PR DESCRIPTION
Depends on https://github.com/hpcugent/easybuild-easyblocks/pull/843
Its is not ready, it finishes with an error (do not able to figure out the reason)
```
== packaging...
== FAILED: Installation ended unsuccessfully (build directory: /tmp/hajgato/build/Xorgheadres/20160225/intel-2016a): (no error)
== Results of the build can be found in the log file /tmp/hajgato/eb-gaE9VH/easybuild-Xorg-headres-20160225-20160226.232539.rCjMe.log
```
