### PR TITLE
{bio} [foss-2015b] TopHat2-2.1.1

### DIFF
--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.1.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.1.1-foss-2015b.eb
@@ -1,0 +1,41 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics
+# Biozentrum - University of Basel
+# Modified by: Adam Huffman
+# The Francis Crick Institute
+
+easyblock = 'ConfigureMake'
+
+name = 'TopHat'
+version = '2.1.1'
+
+homepage = 'http://ccb.jhu.edu/software/tophat/'
+description = """TopHat is a fast splice junction mapper for RNA-Seq reads."""
+
+toolchain = {'name': 'foss', 'version': '2015b'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://ccb.jhu.edu/software/tophat/downloads/']
+
+patches = [
+    'tophat_ictce.patch',
+    'tophat-2.0.13-zlib.patch',
+]
+
+dependencies = [
+    ('Boost', '1.60.0'),
+    ('zlib', '1.2.8'),
+]
+
+configopts = '--with-boost=$EBROOTBOOST'
+
+parallel = 1
+
+sanity_check_paths = {
+    'files': ['bin/tophat'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.1.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.1.1-foss-2015b.eb
@@ -20,7 +20,6 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://ccb.jhu.edu/software/tophat/downloads/']
 
 patches = [
-    #'tophat_ictce.patch',
     'tophat-2.0.13-zlib.patch',
 ]
 

--- a/easybuild/easyconfigs/t/TopHat/TopHat-2.1.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/t/TopHat/TopHat-2.1.1-foss-2015b.eb
@@ -20,7 +20,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://ccb.jhu.edu/software/tophat/downloads/']
 
 patches = [
-    'tophat_ictce.patch',
+    #'tophat_ictce.patch',
     'tophat-2.0.13-zlib.patch',
 ]
 


### PR DESCRIPTION
Update to latest maintenance release.

Disable obsolete patch for older versions of SeqAn. That should probably be removed for the Intel toolchain too, but I don't have that compiler installed anywhere to test.

