### PR TITLE
Ignore log files created by easybuild via gc3pie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 *egg-info/
 *.swp
 *.ropeproject/
+eb-*.log


### PR DESCRIPTION
Installing software using gc3pie generated `eb-*.log` files; let git ignore these files.