### PR TITLE
LLVM llvm-config needs ncurses

### DIFF
--- a/easybuild/easyconfigs/l/LLVM/LLVM-3.6.2-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-3.6.2-intel-2015a-Python-2.7.9.eb
@@ -26,6 +26,10 @@ builddependencies = [
     (python, pyver),
 ]
 
+dependencies = [
+    ('ncurses', '5.9'),
+]
+
 configopts = '-DBUILD_SHARED_LIBS=ON '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LLVM/LLVM-3.6.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-3.6.2-intel-2015a.eb
@@ -23,6 +23,10 @@ builddependencies = [
     ('Python', '2.7.10'),
 ]
 
+dependencies = [
+    ('ncurses', '5.9'),
+]
+
 configopts = '-DBUILD_SHARED_LIBS=ON '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LLVM/LLVM-3.6.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-3.6.2-intel-2015b.eb
@@ -23,6 +23,10 @@ builddependencies = [
     ('Python', '2.7.11'),
 ]
 
+dependencies = [
+    ('ncurses', '5.9'),
+]
+
 configopts = '-DBUILD_SHARED_LIBS=ON '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LLVM/LLVM-3.7.0-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-3.7.0-intel-2015a.eb
@@ -23,6 +23,10 @@ builddependencies = [
     ('Python', '2.7.10'),
 ]
 
+dependencies = [
+    ('ncurses', '5.9'),
+]
+
 configopts = '-DBUILD_SHARED_LIBS=ON '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LLVM/LLVM-3.7.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-3.7.0-intel-2015b.eb
@@ -23,6 +23,10 @@ builddependencies = [
     ('Python', '2.7.10'),
 ]
 
+dependencies = [
+    ('ncurses', '5.9'),
+]
+
 configopts = '-DBUILD_SHARED_LIBS=ON -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS -shared-intel" '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LLVM/LLVM-3.7.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-3.7.1-foss-2016a.eb
@@ -23,7 +23,7 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('ncurses', '5.9'),
+    ('ncurses', '6.0'),
 ]
 
 configopts = '-DBUILD_SHARED_LIBS=ON'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-3.7.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-3.7.1-foss-2016a.eb
@@ -22,6 +22,10 @@ builddependencies = [
     ('Python', '2.7.11'),
 ]
 
+dependencies = [
+    ('ncurses', '5.9'),
+]
+
 configopts = '-DBUILD_SHARED_LIBS=ON'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LLVM/LLVM-3.7.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-3.7.1-intel-2015b.eb
@@ -23,6 +23,10 @@ builddependencies = [
     ('Python', '2.7.11'),
 ]
 
+dependencies = [
+    ('ncurses', '5.9'),
+]
+
 configopts = '-DBUILD_SHARED_LIBS=ON -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS -shared-intel" '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/LLVM/LLVM-3.7.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-3.7.1-intel-2016a.eb
@@ -23,6 +23,10 @@ builddependencies = [
     ('Python', '2.7.11'),
 ]
 
+dependencies = [
+    ('ncurses', '6.0'),
+]
+
 configopts = '-DBUILD_SHARED_LIBS=ON -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS -shared-intel" '
 
 sanity_check_paths = {


### PR DESCRIPTION
llvm has `Python` builddependency, `ncurses` was used from there. Since `Python` was only a builddependency, `ncurses` needed as dependency.
