### PR TITLE
Update files that have dummy as toolchain, are not a toolchain themse…

### DIFF
--- a/easybuild/easyconfigs/a/ABAQUS/ABAQUS-6.12.1-linux-x86_64.eb
+++ b/easybuild/easyconfigs/a/ABAQUS/ABAQUS-6.12.1-linux-x86_64.eb
@@ -5,7 +5,7 @@ versionsuffix = '-linux-x86_64'
 homepage = 'http://www.simulia.com/products/abaqus_fea.html'
 description = "Finite Element Analysis software for modeling, visualization and best-in-class implicit and explicit dynamics FEA."
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = [SOURCE_TGZ]
 

--- a/easybuild/easyconfigs/a/ABAQUS/ABAQUS-6.13.5-linux-x86_64.eb
+++ b/easybuild/easyconfigs/a/ABAQUS/ABAQUS-6.13.5-linux-x86_64.eb
@@ -5,7 +5,7 @@ versionsuffix = '-linux-x86_64'
 homepage = 'http://www.simulia.com/products/abaqus_fea.html'
 description = "Finite Element Analysis software for modeling, visualization and best-in-class implicit and explicit dynamics FEA."
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = [SOURCE_TGZ]
 

--- a/easybuild/easyconfigs/a/ABAQUS/ABAQUS-6.14.1-linux-x86_64.eb
+++ b/easybuild/easyconfigs/a/ABAQUS/ABAQUS-6.14.1-linux-x86_64.eb
@@ -5,7 +5,7 @@ versionsuffix = '-linux-x86_64'
 homepage = 'http://www.simulia.com/products/abaqus_fea.html'
 description = "Finite Element Analysis software for modeling, visualization and best-in-class implicit and explicit dynamics FEA."
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = [SOURCE_TGZ]
 

--- a/easybuild/easyconfigs/a/ADF/ADF-2009.01a.pc64_linux.intelmpi.eb
+++ b/easybuild/easyconfigs/a/ADF/ADF-2009.01a.pc64_linux.intelmpi.eb
@@ -6,7 +6,7 @@ version = '2009.01a.pc64_linux.intelmpi'
 homepage = 'http://www.scm.com/'
 description = "ADF is a premium-quality quantum chemistry software package based on Density Functional Theory (DFT)."
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['%(namelower)s%(version)s.bin.tgz']
 

--- a/easybuild/easyconfigs/b/Beast/Beast-2.1.3.eb
+++ b/easybuild/easyconfigs/b/Beast/Beast-2.1.3.eb
@@ -16,7 +16,7 @@ description = """ BEAST is a cross-platform program for Bayesian MCMC analysis o
  tree topology. BEAST uses MCMC to average over tree space, so that each tree is weighted 
  proportional to its posterior probability. """
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://github.com/CompEvol/beast2/releases/download/v%(version)s/']
 sources = ['BEAST.v%(version)s.tgz']

--- a/easybuild/easyconfigs/c/CMake/CMake-3.1.3.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.1.3.eb
@@ -7,7 +7,7 @@ homepage = 'http://www.cmake.org'
 description = """CMake, the cross-platform, open-source build system.
  CMake is a family of tools designed to build, test and package software."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/c/CMake/CMake-3.3.1.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.3.1.eb
@@ -7,7 +7,7 @@ homepage = 'http://www.cmake.org'
 description = """CMake, the cross-platform, open-source build system.
  CMake is a family of tools designed to build, test and package software."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/c/Chimera/Chimera-1.10-linux_x86_64.eb
+++ b/easybuild/easyconfigs/c/Chimera/Chimera-1.10-linux_x86_64.eb
@@ -12,7 +12,7 @@ description = """ UCSF Chimera is a highly extensible program for interactive vi
  and analysis of molecular structures and related data, including density maps, supramolecular 
  assemblies, sequence alignments, docking results, trajectories, and conformational ensembles. """
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 # no public download URL. Go to https://www.cgl.ucsf.edu/chimera/download.html
 sources = ['%(namelower)s-%(version)s%(versionsuffix)s.bin']

--- a/easybuild/easyconfigs/c/cramtools/cramtools-2.0-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/c/cramtools/cramtools-2.0-Java-1.7.0_80.eb
@@ -9,7 +9,7 @@ read data. Although this is intended as a stable version the code is released as
 early access. Parts of the CRAMTools are experimental and may not be supported
 in the future."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/enasequence/%(name)s/archive/']

--- a/easybuild/easyconfigs/f/FDS/FDS-6.0.1-no-OFED.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-6.0.1-no-OFED.eb
@@ -9,7 +9,7 @@ description = """
  Fire Dynamics Simulator (FDS) is a large-eddy simulation (LES) code for low-speed flows, with an emphasis on smoke and
  heat transport from fires.
 """
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 # download .sh from https://bintray.com/nist-fire-research/releases/FDS-SMV/6.0.1/view/files to create tarball
 sources = ['FDS_6.0.1-SMV_6.1.5_linux64.tar.gz']

--- a/easybuild/easyconfigs/f/fastqc/fastqc-0.11.2.eb
+++ b/easybuild/easyconfigs/f/fastqc/fastqc-0.11.2.eb
@@ -6,7 +6,7 @@ version = '0.11.2'
 homepage = 'http://www.bioinformatics.babraham.ac.uk/projects/fastqc/'
 description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://www.bioinformatics.babraham.ac.uk/projects/fastqc/']
 sources = ['%(name)s_v%(version)s.zip']

--- a/easybuild/easyconfigs/f/fastqc/fastqc-0.11.3.eb
+++ b/easybuild/easyconfigs/f/fastqc/fastqc-0.11.3.eb
@@ -6,7 +6,7 @@ version = '0.11.3'
 homepage = 'http://www.bioinformatics.babraham.ac.uk/projects/fastqc/'
 description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://www.bioinformatics.babraham.ac.uk/projects/fastqc/']
 sources = ['%(name)s_v%(version)s.zip']

--- a/easybuild/easyconfigs/f/fastqc/fastqc-0.11.4.eb
+++ b/easybuild/easyconfigs/f/fastqc/fastqc-0.11.4.eb
@@ -6,7 +6,7 @@ version = '0.11.4'
 homepage = 'http://www.bioinformatics.babraham.ac.uk/projects/fastqc/'
 description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://www.bioinformatics.babraham.ac.uk/projects/fastqc/']
 sources = ['%(name)s_v%(version)s.zip']

--- a/easybuild/easyconfigs/g/GATK/GATK-1.0.5083.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-1.0.5083.eb
@@ -9,7 +9,7 @@ description = """The GATK is a structured software library that makes writing ef
  medical resequencing projects such as 1000 Genomes and The Cancer Genome Atlas. These tools include things
  like a depth of coverage analyzers, a quality score recalibrator, a SNP/indel caller and a local realigner."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 # download manually from http://www.broadinstitute.org/gatk/download
 sources = ['GenomeAnalysisTK-%(version)s.tar.bz2']

--- a/easybuild/easyconfigs/g/GATK/GATK-2.5-2-Java-1.7.0_10.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-2.5-2-Java-1.7.0_10.eb
@@ -22,7 +22,7 @@ description = """The Genome Analysis Toolkit or GATK is a software package devel
  data quality assurance. Its robust architecture, powerful processing engine and 
  high-performance computing features make it capable of taking on projects of any size."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 # download manually from http://www.broadinstitute.org/gatk/download
 sources = ['GenomeAnalysisTK-%(version)s.tar.bz2']

--- a/easybuild/easyconfigs/g/GATK/GATK-2.6-5-Java-1.7.0_10.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-2.6-5-Java-1.7.0_10.eb
@@ -22,7 +22,7 @@ description = """The Genome Analysis Toolkit or GATK is a software package devel
  data quality assurance. Its robust architecture, powerful processing engine and 
  high-performance computing features make it capable of taking on projects of any size."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 # download manually from http://www.broadinstitute.org/gatk/download
 sources = ['GenomeAnalysisTK-%(version)s.tar.bz2']

--- a/easybuild/easyconfigs/g/GATK/GATK-2.7-4-Java-1.7.0_10.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-2.7-4-Java-1.7.0_10.eb
@@ -22,7 +22,7 @@ description = """The Genome Analysis Toolkit or GATK is a software package devel
  data quality assurance. Its robust architecture, powerful processing engine and 
  high-performance computing features make it capable of taking on projects of any size."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 # download manually from http://www.broadinstitute.org/gatk/download
 sources = ['GenomeAnalysisTK-%(version)s.tar.bz2']

--- a/easybuild/easyconfigs/g/GATK/GATK-2.7-4.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-2.7-4.eb
@@ -9,7 +9,7 @@ description = """The GATK is a structured software library that makes writing ef
  medical resequencing projects such as 1000 Genomes and The Cancer Genome Atlas. These tools include things
  like a depth of coverage analyzers, a quality score recalibrator, a SNP/indel caller and a local realigner."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 # download manually from http://www.broadinstitute.org/gatk/download
 sources = ['GenomeAnalysisTK-%(version)s.tar.bz2']

--- a/easybuild/easyconfigs/g/GATK/GATK-2.8-1-Java-1.7.0_10.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-2.8-1-Java-1.7.0_10.eb
@@ -22,7 +22,7 @@ description = """The Genome Analysis Toolkit or GATK is a software package devel
  data quality assurance. Its robust architecture, powerful processing engine and 
  high-performance computing features make it capable of taking on projects of any size."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 # download manually from http://www.broadinstitute.org/gatk/download
 sources = ['GenomeAnalysisTK-%(version)s.tar.bz2']

--- a/easybuild/easyconfigs/g/GATK/GATK-3.0-0-Java-1.7.0_10.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-3.0-0-Java-1.7.0_10.eb
@@ -22,7 +22,7 @@ description = """The Genome Analysis Toolkit or GATK is a software package devel
  data quality assurance. Its robust architecture, powerful processing engine and 
  high-performance computing features make it capable of taking on projects of any size."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 # download manually from http://www.broadinstitute.org/gatk/download
 sources = ['%s-%s.tar.bz2' % ("GenomeAnalysisTK", version)]

--- a/easybuild/easyconfigs/g/GATK/GATK-3.3-0-Java-1.7.0_21.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-3.3-0-Java-1.7.0_21.eb
@@ -22,7 +22,7 @@ description = """The Genome Analysis Toolkit or GATK is a software package devel
  data quality assurance. Its robust architecture, powerful processing engine and 
  high-performance computing features make it capable of taking on projects of any size."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 # download manually from http://www.broadinstitute.org/gatk/download
 sources = ['GenomeAnalysisTK-%(version)s.tar.bz2']

--- a/easybuild/easyconfigs/g/GATK/GATK-3.3-0-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-3.3-0-Java-1.7.0_80.eb
@@ -22,7 +22,7 @@ description = """The Genome Analysis Toolkit or GATK is a software package devel
  data quality assurance. Its robust architecture, powerful processing engine and 
  high-performance computing features make it capable of taking on projects of any size."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 # download manually from http://www.broadinstitute.org/gatk/download
 sources = ['GenomeAnalysisTK-%(version)s.tar.bz2']

--- a/easybuild/easyconfigs/g/GATK/GATK-3.3-0-Java-1.8.0_66.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-3.3-0-Java-1.8.0_66.eb
@@ -22,7 +22,7 @@ description = """The Genome Analysis Toolkit or GATK is a software package devel
  data quality assurance. Its robust architecture, powerful processing engine and 
  high-performance computing features make it capable of taking on projects of any size."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 # download manually from http://www.broadinstitute.org/gatk/download
 sources = ['GenomeAnalysisTK-%(version)s.tar.bz2']

--- a/easybuild/easyconfigs/g/GATK/GATK-3.5-Java-1.8.0_66.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-3.5-Java-1.8.0_66.eb
@@ -22,7 +22,7 @@ description = """The Genome Analysis Toolkit or GATK is a software package devel
  data quality assurance. Its robust architecture, powerful processing engine and 
  high-performance computing features make it capable of taking on projects of any size."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 # download manually from http://www.broadinstitute.org/gatk/download
 sources = ['GenomeAnalysisTK-%(version)s.tar.bz2']

--- a/easybuild/easyconfigs/g/GenotypeHarmonizer/GenotypeHarmonizer-1.4.14-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/g/GenotypeHarmonizer/GenotypeHarmonizer-1.4.14-Java-1.7.0_80.eb
@@ -7,7 +7,7 @@ homepage = 'https://github.com/molgenis/systemsgenetics/wiki/Genotype-Harmonizer
 description = """The Genotype Harmonizer is an easy to use command-line tool that allows harmonization of genotype data
  stored using different file formats with different and potentially unknown strands."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 java = 'Java'
 javaver = '1.7.0_80'

--- a/easybuild/easyconfigs/i/icc/icc-2013.5.192-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2013.5.192-GCC-4.8.3.eb
@@ -4,7 +4,7 @@ version = '2013.5.192'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2015.0.090-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2015.0.090-GCC-4.9.2.eb
@@ -4,7 +4,7 @@ version = '2015.0.090'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2015.1.133-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2015.1.133-GCC-4.9.2.eb
@@ -4,7 +4,7 @@ version = '2015.1.133'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2015.2.164-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2015.2.164-GCC-4.9.2.eb
@@ -4,7 +4,7 @@ version = '2015.2.164'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2015.3.187-GNU-4.9.3-2.25.eb
@@ -4,7 +4,7 @@ version = '2015.3.187'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2015.5.223-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2015.5.223-GCC-4.9.3-2.25.eb
@@ -4,7 +4,7 @@ version = '2015.5.223'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_ccompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.0.109-GCC-4.9.3-2.25.eb
@@ -6,7 +6,7 @@ version = '2016.0.109'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp.tgz']
 

--- a/easybuild/easyconfigs/i/icc/icc-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.1.150-GCC-4.9.3-2.25.eb
@@ -6,7 +6,7 @@ version = '2016.1.150'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update%(version_minor)s.tgz']
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2013.5.192-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2013.5.192-GCC-4.8.3.eb
@@ -4,7 +4,7 @@ version = '2013.5.192'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "Fortran compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_fcompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2015.0.090-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2015.0.090-GCC-4.9.2.eb
@@ -4,7 +4,7 @@ version = '2015.0.090'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "Fortran compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_fcompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2015.1.133-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2015.1.133-GCC-4.9.2.eb
@@ -4,7 +4,7 @@ version = '2015.1.133'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "Fortran compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_fcompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2015.2.164-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2015.2.164-GCC-4.9.2.eb
@@ -4,7 +4,7 @@ version = '2015.2.164'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "Fortran compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_fcompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2015.3.187-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2015.3.187-GNU-4.9.3-2.25.eb
@@ -4,7 +4,7 @@ version = '2015.3.187'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "Fortran compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_fcompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2015.5.223-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2015.5.223-GCC-4.9.3-2.25.eb
@@ -4,7 +4,7 @@ version = '2015.5.223'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "Fortran compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_fcompxe_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3-2.25.eb
@@ -6,7 +6,7 @@ version = '2016.0.109'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran.tgz']
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -6,7 +6,7 @@ version = '2016.1.150'
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran_update%(version_minor)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-10.2.6.038-32bit.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-10.2.6.038-32bit.eb
@@ -8,7 +8,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_p_%(version)s.tar.gz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-10.2.6.038.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-10.2.6.038.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_p_%(version)s.tar.gz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-10.3.10.319.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-10.3.10.319.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s_intel64.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-10.3.12.361-MVAPICH2-1.9.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-10.3.12.361-MVAPICH2-1.9.eb
@@ -6,7 +6,7 @@ description = """Intel Math Kernel Library is a library of highly optimized, ext
 for science, engineering, and financial applications that require maximum performance. Core math functions include
 BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-10.3.12.361-OpenMPI-1.6.3.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-10.3.12.361-OpenMPI-1.6.3.eb
@@ -6,7 +6,7 @@ description = """Intel Math Kernel Library is a library of highly optimized, ext
 for science, engineering, and financial applications that require maximum performance. Core math functions include
 BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-10.3.12.361.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-10.3.12.361.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-10.3.6.233.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-10.3.6.233.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s_intel64.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-11.0.1.117.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.0.1.117.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-11.0.2.146.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.0.2.146.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-11.0.3.163.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.0.3.163.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-11.0.4.183.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.0.4.183.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-11.0.5.192.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.0.5.192.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-11.1.0.080.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.1.0.080.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-11.1.1.106.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.1.1.106.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-11.1.2.144-2013.5.192-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.1.2.144-2013.5.192-GCC-4.8.3.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-11.1.2.144-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.1.2.144-GCC-4.8.3.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-11.1.2.144-OpenMPI-1.6.5.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.1.2.144-OpenMPI-1.6.5.eb
@@ -6,7 +6,7 @@ description = """Intel Math Kernel Library is a library of highly optimized, ext
 for science, engineering, and financial applications that require maximum performance. Core math functions include
 BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-11.1.2.144.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.1.2.144.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/imkl/imkl-11.1.3.174.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.1.3.174.eb
@@ -7,7 +7,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/m/MATLAB/MATLAB-2012b.eb
+++ b/easybuild/easyconfigs/m/MATLAB/MATLAB-2012b.eb
@@ -6,7 +6,7 @@ description = """MATLAB is a high-level language and interactive environment
  that enables you to perform computationally intensive tasks faster than with
  traditional programming languages such as C, C++, and Fortran."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = [SOURCELOWER_TAR_GZ]
 

--- a/easybuild/easyconfigs/m/MATLAB/MATLAB-2015a.eb
+++ b/easybuild/easyconfigs/m/MATLAB/MATLAB-2015a.eb
@@ -6,7 +6,7 @@ description = """MATLAB is a high-level language and interactive environment
  that enables you to perform computationally intensive tasks faster than with
  traditional programming languages such as C, C++, and Fortran."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = [SOURCELOWER_TAR_GZ]
 

--- a/easybuild/easyconfigs/m/MCR/MCR-R2014a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2014a.eb
@@ -6,7 +6,7 @@ description = """The MATLAB Runtime is a standalone set of shared libraries
  that enables the execution of compiled MATLAB applications
  or components on computers that do not have MATLAB installed."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = [
     'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',

--- a/easybuild/easyconfigs/m/MCR/MCR-R2015a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2015a.eb
@@ -6,7 +6,7 @@ description = """The MATLAB Runtime is a standalone set of shared libraries
  that enables the execution of compiled MATLAB applications
  or components on computers that do not have MATLAB installed."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = [
     'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',

--- a/easybuild/easyconfigs/o/ORCA/ORCA-2_9_1-linux_x86-64.eb
+++ b/easybuild/easyconfigs/o/ORCA/ORCA-2_9_1-linux_x86-64.eb
@@ -10,7 +10,7 @@ description = """ORCA is a flexible, efficient and easy-to-use general purpose t
  and multireference correlated ab initio methods. 
  It can also treat environmental and relativistic effects."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['%%(namelower)s_%s_%s.tbz' % (version.split('-')[0], '-'.join(version.split('-')[1:]))]
 

--- a/easybuild/easyconfigs/o/ORCA/ORCA-3_0_0-linux_x86-64_openmpi_165.eb
+++ b/easybuild/easyconfigs/o/ORCA/ORCA-3_0_0-linux_x86-64_openmpi_165.eb
@@ -11,7 +11,7 @@ description = """ORCA is a flexible, efficient and easy-to-use general purpose t
  and multireference correlated ab initio methods.
  It can also treat environmental and relativistic effects."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['%%(namelower)s_%s_%s.tbz' % (version.split('-')[0], '-'.join(version.split('-')[1:]))]
 

--- a/easybuild/easyconfigs/o/ORCA/ORCA-3_0_2-linux_x86-64-OpenMPI-1.6.5.eb
+++ b/easybuild/easyconfigs/o/ORCA/ORCA-3_0_2-linux_x86-64-OpenMPI-1.6.5.eb
@@ -13,7 +13,7 @@ description = """ORCA is a flexible, efficient and easy-to-use general purpose t
  and multireference correlated ab initio methods.
  It can also treat environmental and relativistic effects."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['%%(namelower)s_%s_%s.tbz' % (version.split('-')[0], '-'.join(version.split('-')[1:]))]
 

--- a/easybuild/easyconfigs/o/ORCA/ORCA-3_0_2-linux_x86-64-OpenMPI-1.8.1.eb
+++ b/easybuild/easyconfigs/o/ORCA/ORCA-3_0_2-linux_x86-64-OpenMPI-1.8.1.eb
@@ -13,7 +13,7 @@ description = """ORCA is a flexible, efficient and easy-to-use general purpose t
  and multireference correlated ab initio methods.
  It can also treat environmental and relativistic effects."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['%%(namelower)s_%s_%s.tbz' % (version.split('-')[0], '-'.join(version.split('-')[1:]))]
 

--- a/easybuild/easyconfigs/o/ORCA/ORCA-3_0_3-linux_x86-64-OpenMPI-1.6.5.eb
+++ b/easybuild/easyconfigs/o/ORCA/ORCA-3_0_3-linux_x86-64-OpenMPI-1.6.5.eb
@@ -13,7 +13,7 @@ description = """ORCA is a flexible, efficient and easy-to-use general purpose t
  and multireference correlated ab initio methods.
  It can also treat environmental and relativistic effects."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['%%(namelower)s_%s_%s.tbz' % (version.split('-')[0], '-'.join(version.split('-')[1:]))]
 

--- a/easybuild/easyconfigs/p/PGI/PGI-15.10-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-15.10-GCC-4.9.3-2.25.eb
@@ -4,7 +4,7 @@ version = '15.10'
 homepage = 'http://www.pgroup.com/'
 description = "C, C++ and Fortran compilers from The Portland Group - PGI"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-x86_64.tar.gz']
 checksums = ['cae307f7ad467a1811a5d5da758048ab']

--- a/easybuild/easyconfigs/p/pbs_python/pbs_python-4.6.0.eb
+++ b/easybuild/easyconfigs/p/pbs_python/pbs_python-4.6.0.eb
@@ -9,7 +9,7 @@ description = """The pbs_python package is a wrapper class for the Torque C libr
  an ascii version named pbsmon. PBSQuery is also included in this package. This is a python module build on top of
  the pbs python module to simplify querying the batch server, eg: how many jobs, how many nodes, ..."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://ftp.sara.nl/pub/outgoing/']
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/p/picard/picard-1.100.eb
+++ b/easybuild/easyconfigs/p/picard/picard-1.100.eb
@@ -4,7 +4,7 @@ version = '1.100'
 homepage = 'http://sourceforge.net/projects/picard'
 description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(name)s-tools-%(version)s.zip']

--- a/easybuild/easyconfigs/p/picard/picard-1.109.eb
+++ b/easybuild/easyconfigs/p/picard/picard-1.109.eb
@@ -4,7 +4,7 @@ version = '1.109'
 homepage = 'http://sourceforge.net/projects/picard'
 description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(name)s-tools-%(version)s.zip']

--- a/easybuild/easyconfigs/p/picard/picard-1.119-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/p/picard/picard-1.119-Java-1.7.0_80.eb
@@ -4,7 +4,7 @@ version = '1.119'
 homepage = 'http://sourceforge.net/projects/picard'
 description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(name)s-tools-%(version)s.zip']

--- a/easybuild/easyconfigs/p/picard/picard-1.119.eb
+++ b/easybuild/easyconfigs/p/picard/picard-1.119.eb
@@ -4,7 +4,7 @@ version = '1.119'
 homepage = 'http://sourceforge.net/projects/picard'
 description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(name)s-tools-%(version)s.zip']

--- a/easybuild/easyconfigs/p/picard/picard-1.39.eb
+++ b/easybuild/easyconfigs/p/picard/picard-1.39.eb
@@ -4,7 +4,7 @@ version = '1.39'
 homepage = 'http://sourceforge.net/projects/picard'
 description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%(name)s-tools-%(version)s.zip']

--- a/easybuild/easyconfigs/p/picard/picard-2.1.0.eb
+++ b/easybuild/easyconfigs/p/picard/picard-2.1.0.eb
@@ -10,7 +10,7 @@ description = """ A set of command line tools (in Java) for manipulating
  high-throughput sequencing (HTS) data and formats such as SAM/BAM/CRAM 
  and VCF."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['https://github.com/broadinstitute/%(name)s/releases/download/%(version)s']
 sources = ['%(name)s-tools-%(version)s.zip']

--- a/easybuild/easyconfigs/s/snpEff/snpEff-3.6-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/s/snpEff/snpEff-3.6-Java-1.7.0_80.eb
@@ -7,7 +7,7 @@ homepage = 'http://sourceforge.net/projects/snpeff/'
 description = """SnpEff is a variant annotation and effect prediction tool. 
  It annotates and predicts the effects of genetic variants (such as amino acid changes)."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 java = 'Java'
 javaver = '1.7.0_80'

--- a/easybuild/easyconfigs/s/snpEff/snpEff-4.1d-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/s/snpEff/snpEff-4.1d-Java-1.7.0_80.eb
@@ -7,7 +7,7 @@ homepage = 'http://sourceforge.net/projects/snpeff/'
 description = """SnpEff is a variant annotation and effect prediction tool. 
  It annotates and predicts the effects of genetic variants (such as amino acid changes)."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 java = 'Java'
 javaver = '1.7.0_80'

--- a/easybuild/easyconfigs/v/VarScan/VarScan-2.4.1-Java-1.7.0_80.eb
+++ b/easybuild/easyconfigs/v/VarScan/VarScan-2.4.1-Java-1.7.0_80.eb
@@ -10,7 +10,7 @@ version = '2.4.1'
 homepage = 'https://github.com/dkoboldt/varscan'
 description = """Variant calling and somatic mutation/CNV detection for next-generation sequencing data"""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['%(name)s.v%(version)s.jar']
 source_urls = ['https://github.com/dkoboldt/varscan/releases/download/v%(version)s']


### PR DESCRIPTION
…lves and have dependencies. Without an empty version the dependencies do not get loaded at build time.

To get the list of files:
```
for f in `grep -r "^toolchain.*version.*dummy" easybuild | cut -f1 -d:`; do grep "dependencies[ ]*=" $f > /dev/null; if [ $? -eq 0 ]; then echo $f; fi; done
```
The result can be cleaned of toolchains. To make the changes:
```
cat cleaned_list |xargs -i sed -i 's/'\''dummy'\''}/'\'''\''}/' {}
```