### PR TITLE
{chem} CP2K 3.0 CrayGNU-2015.11-XC 

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-3.0-CrayGNU-2015.11-XC-cuda-7.0.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-3.0-CrayGNU-2015.11-XC-cuda-7.0.eb
@@ -1,0 +1,48 @@
+# contributed by Luca Marsella (CSCS)
+name = 'CP2K'
+version = "3.0"
+cudaversion = '7.0'
+versionsuffix = '-cuda-%s' % cudaversion
+
+homepage = 'http://www.cp2k.org/'
+description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
+ simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
+ methods such as e.g. density functional theory (DFT) using a mixed Gaussian and plane waves approach (GPW), and
+ classical pair and many-body potentials. """
+
+toolchain = {'name': 'CrayGNU', 'version': '2015.11-XC'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = [SOURCEFORGE_SOURCE]
+
+patches = [
+    'CP2K-2.6.0-ifort-compiler-bug-fix.patch',
+    'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+
+dependencies = [
+    ('Libint', '1.1.4'),
+    ('libxc', '2.2.2'),
+]
+
+builddependencies = [
+    ('cudatoolkit/7.0.28-1.0502.10742.5.1', EXTERNAL_MODULE),
+    ('fftw/3.3.4.3', EXTERNAL_MODULE),
+    ('flex', '2.5.39'),
+    ('Bison', '3.0.2'),
+]
+
+# don't use parallel make, results in compilation failure
+# because Fortran module files aren't created before they are needed
+parallel = 1
+
+# regression test
+runtest = False
+# regression test reports failures
+#ignore_regtest_fails = True
+
+# build type
+type = 'psmp'
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/c/CP2K/CP2K-3.0-CrayGNU-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-3.0-CrayGNU-2015.11-XC.eb
@@ -2,8 +2,6 @@
 name = 'CP2K'
 version = "3.0"
 
-easyblock = 'cp2kcray'
-
 homepage = 'http://www.cp2k.org/'
 description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
  simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different

--- a/easybuild/easyconfigs/c/CP2K/CP2K-3.0-CrayGNU-2015.11-XC.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-3.0-CrayGNU-2015.11-XC.eb
@@ -1,0 +1,47 @@
+# contributed by Luca Marsella (CSCS)
+name = 'CP2K'
+version = "3.0"
+
+easyblock = 'cp2kcray'
+
+homepage = 'http://www.cp2k.org/'
+description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
+ simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
+ methods such as e.g. density functional theory (DFT) using a mixed Gaussian and plane waves approach (GPW), and
+ classical pair and many-body potentials. """
+
+toolchain = {'name': 'CrayGNU', 'version': '2015.11-XC'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = [SOURCEFORGE_SOURCE]
+
+patches = [
+    'CP2K-2.6.0-ifort-compiler-bug-fix.patch',
+    'CP2K-2.4.0-fix_compile_date_lastsvn.patch',
+]
+
+dependencies = [
+    ('Libint', '1.1.4'),
+    ('libxc', '2.2.2'),
+]
+
+builddependencies = [
+    ('fftw/3.3.4.3', EXTERNAL_MODULE),
+    ('flex', '2.5.39'),
+    ('Bison', '3.0.2'),
+]
+
+# don't use parallel make, results in compilation failure
+# because Fortran module files aren't created before they are needed
+parallel = 1
+
+# regression test
+runtest = False
+# regression test reports failures
+#ignore_regtest_fails = True
+
+# build type
+type = 'psmp'
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.2-CrayGNU-2015.11-XC.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.2-CrayGNU-2015.11-XC.eb
@@ -1,0 +1,33 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libxc'
+version = '2.2.2'
+
+homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
+ The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2015.11-XC'}
+toolchainopts = {'opt': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+
+configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared'
+
+# From the libxc mailing list
+# To summarize: expect less tests to fail in libxc 2.0.2, but don't expect
+# a fully working testsuite soon (unless someone wants to volunteer to do
+# it, of course  ) In the meantime, unless the majority of the tests
+# fail, your build should be fine.
+#runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['lib/libxc.a', 'lib/libxc.so'],
+    'dirs': ['include'],
+}
+
+parallel = 1
+
+moduleclass = 'chem'


### PR DESCRIPTION
- CUDA enabled CP2K requires easyblock https://github.com/hpcugent/easybuild-easyblocks/pull/850
- The CPU version should work with stock cp2k.py

by @lucamar