### PR TITLE
Add checksum and remove option with default value in some MVAPICH2 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3-hwloc-chkpt.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3-hwloc-chkpt.eb
@@ -16,7 +16,7 @@ source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2']
 configopts = '--with-mpe '
 
 # enable hwloc support
-configopts += '--with-hwloc '
+withhwloc = True
 dependencies = [('hwloc', '1.5.1')]
 
 # enable checkpointing support

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3-hwloc-chkpt.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3-hwloc-chkpt.eb
@@ -12,8 +12,6 @@ sources = [SOURCELOWER_TGZ]
 # note: this URL will only work for the most recent version (previous versions no longer available?)
 source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2']
 
-rdma_type = "gen2"  # 'gen2' or 'udapl'
-
 # enable building of MPE routines
 configopts = '--with-mpe '
 

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3-hwloc-chkpt.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3-hwloc-chkpt.eb
@@ -18,7 +18,7 @@ rdma_type = "gen2"  # 'gen2' or 'udapl'
 configopts = '--with-mpe '
 
 # enable hwloc support
-withhwloc = True
+configopts += '--with-hwloc '
 dependencies = [('hwloc', '1.5.1')]
 
 # enable checkpointing support

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3-hwloc-chkpt.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3-hwloc-chkpt.eb
@@ -15,7 +15,7 @@ source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2']
 rdma_type = "gen2"  # 'gen2' or 'udapl'
 
 # enable building of MPE routines
-withmpe = True
+configopts = '--with-mpe '
 
 # enable hwloc support
 withhwloc = True

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3-hwloc-chkpt.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3-hwloc-chkpt.eb
@@ -13,7 +13,7 @@ sources = [SOURCELOWER_TGZ]
 source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2']
 
 # enable building of MPE routines
-configopts = '--with-mpe '
+withmpe = True
 
 # enable hwloc support
 withhwloc = True

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3.eb
@@ -14,7 +14,7 @@ source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2']
 builddependencies = [('Bison', '2.5')]
 
 # enable building of MPE routines
-configopts = '--with-mpe '
+withmpe = True
 
 # parallel build tends to fail
 parallel = 1

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3.eb
@@ -16,7 +16,7 @@ builddependencies = [('Bison', '2.5')]
 rdma_type = "gen2"  # 'gen2' or 'udapl'
 
 # enable building of MPE routines
-withmpe = True
+configopts = '--with-mpe '
 
 # parallel build tends to fail
 parallel = 1

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.7-GCC-4.6.3.eb
@@ -13,8 +13,6 @@ source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2']
 
 builddependencies = [('Bison', '2.5')]
 
-rdma_type = "gen2"  # 'gen2' or 'udapl'
-
 # enable building of MPE routines
 configopts = '--with-mpe '
 

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.8.1-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.8.1-GCC-4.7.2.eb
@@ -9,6 +9,9 @@ toolchain = {'name': 'GCC', 'version': '4.7.2'}
 source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2/']
 sources = [SOURCELOWER_TGZ]
 
+# Let's store the checksum in order to be sure it doesn't suddenly change
+checksums = ['ef4ae05e3b5ad485326505db7381246c']
+
 builddependencies = [('Bison', '2.7')]
 
 # parallel build doesn't work

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9-ClangGCC-1.1.3.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9-ClangGCC-1.1.3.eb
@@ -9,6 +9,9 @@ toolchain = {'name': 'ClangGCC', 'version': '1.1.3'}
 source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2/']
 sources = [SOURCELOWER_TGZ]
 
+# Let's store the checksum in order to be sure it doesn't suddenly change
+checksums = ['5dc58ed08fd3142c260b70fe297e127c']
+
 dependencies = [('Bison', '2.7')]
 
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9-ClangGCC-1.2.3.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9-ClangGCC-1.2.3.eb
@@ -9,6 +9,9 @@ toolchain = {'name': 'ClangGCC', 'version': '1.2.3'}
 source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2/']
 sources = [SOURCELOWER_TGZ]
 
+# Let's store the checksum in order to be sure it doesn't suddenly change
+checksums = ['5dc58ed08fd3142c260b70fe297e127c']
+
 dependencies = [('Bison', '2.7')]
 
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9-GCC-4.7.3.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9-GCC-4.7.3.eb
@@ -9,6 +9,9 @@ toolchain = {'name': 'GCC', 'version': '4.7.3'}
 source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2/']
 sources = [SOURCELOWER_TGZ]
 
+# Let's store the checksum in order to be sure it doesn't suddenly change
+checksums = ['5dc58ed08fd3142c260b70fe297e127c']
+
 builddependencies = [('Bison', '2.7')]
 
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9-iccifort-2011.13.367.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9-iccifort-2011.13.367.eb
@@ -10,6 +10,9 @@ toolchainopts = {'optarch': True, 'pic': True}
 source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich2/']
 sources = [SOURCELOWER_TGZ]
 
+# Let's store the checksum in order to be sure it doesn't suddenly change
+checksums = ['5dc58ed08fd3142c260b70fe297e127c']
+
 builddependencies = [('Bison', '2.7')]
 
 # the hydra launcher start's before LD_LIBRARY_PATH is forwarded, so we provide this hint on where to find some libs


### PR DESCRIPTION
MVAPICH2 easyblock uses some deprecated configure options:
- `--enable-mpe` disappeared starting version >= 1.9
- `--enable-hwloc` disappeared starting version >= 2.0

PR https://github.com/hpcugent/easybuild-easyblocks/pull/853 removes these deprecated options from the easyblock. 
This current PR set these options directly in the easyconfig files when there are used.

This PR have to be merged first before PR https://github.com/hpcugent/easybuild-easyblocks/pull/853.