### PR TITLE
GLib doesn't require libxml2 with Python bindings

### DIFF
--- a/easybuild/easyconfigs/g/GLib/GLib-2.47.5-intel-2016a.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.47.5-intel-2016a.eb
@@ -12,18 +12,14 @@ toolchainopts = {'optarch': True, 'pic': True}
 source_urls = [FTPGNOME_SOURCE]
 sources = [SOURCELOWER_TAR_XZ]
 
-pyver = '2.7.11'
-pyshortver = '.'.join(pyver.split('.')[:2])
-pysuffix = '-Python-%s' % pyver
-
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.6'),
-    ('libxml2', '2.9.3', pysuffix),
+    ('libxml2', '2.9.3'),
     ('PCRE', '8.38'),
 ]
 
-builddependencies = [('Python', pyver)]
+builddependencies = [('Python', '2.7.11')]
 
 configopts = "--disable-maintainer-mode --disable-silent-rules --disable-libelf --enable-static --enable-shared"
 


### PR DESCRIPTION
as far as I can tell, GLib doesn't require the Python bindings to libxml2

it does require `xmllint` provided by `libxml2` however, both at build time (e.g. for testing), and at runtime (cfr. https://developer.gnome.org/gio/stable/glib-compile-resources.html)

cc @hajgato, @ocaisa