### PR TITLE
add patch file to imkl 10.2.6.038 32-bit easyconfig to fix installer not being able to deal with -- in build path

### DIFF
--- a/easybuild/easyconfigs/i/imkl/imkl-10.2.6.038-32bit.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-10.2.6.038-32bit.eb
@@ -12,6 +12,8 @@ toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['l_mkl_p_%(version)s.tar.gz']
 
+patches = ['imkl-%(version)s_fix-install-double-dash.patch']
+
 dontcreateinstalldir = 'True'
 
 # deps for interface build

--- a/easybuild/easyconfigs/i/imkl/imkl-10.2.6.038_fix-install-double-dash.patch
+++ b/easybuild/easyconfigs/i/imkl/imkl-10.2.6.038_fix-install-double-dash.patch
@@ -1,0 +1,14 @@
+fix regex that doesn't handle directory names with a double dash (--) in them correctly
+this fix is specific to using '-32bit' as versionsuffix
+author: Kenneth Hoste (HPC-UGent)
+--- l_mkl_p_10.2.6.038/pset/install.sh.orig	2016-03-04 15:28:03.092055076 +0100
++++ l_mkl_p_10.2.6.038/pset/install.sh	2016-03-04 15:27:44.071603046 +0100
+@@ -1281,7 +1281,7 @@
+ 	
+ 	[ $err -eq ${ERR_OK} ] || return 1
+ 		
+-        RS=$(echo $CMD_STR | sed s/.*--$cmd[[:blank:]]*//g | sed 's/[[:blank:]]*--.*$//g')
++        RS=$(echo $CMD_STR | sed s/.*--$cmd[[:blank:]]*//g | sed 's/[[:blank:]]*--[^3].*$//g')
+         [[ -z "$RS" ]] && return 1
+         echo $RS
+ 	


### PR DESCRIPTION
issue introduced by renaming toolchain version to `''`, cfr. #2612)