### PR TITLE
Added missing libxml2 dependency

### DIFF
--- a/easybuild/easyconfigs/g/GLib/GLib-2.40.0-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.40.0-goolf-1.7.20.eb
@@ -15,6 +15,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.1'),
     ('gettext', '0.19.2'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.41.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.41.2-intel-2015a.eb
@@ -14,6 +14,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.1'),
     ('gettext', '0.19.2'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.8')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.41.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.41.2-intel-2015b.eb
@@ -14,6 +14,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.1'),
     ('gettext', '0.19.2'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.10')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.0-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.0-GCC-4.9.2.eb
@@ -15,6 +15,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.4'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.9', '-bare')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.0-foss-2015a.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.0-foss-2015a.eb
@@ -15,6 +15,7 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.4'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.0-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.0-intel-2015a.eb
@@ -15,6 +15,7 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.4'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.1-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.1-goolf-1.7.20.eb
@@ -15,6 +15,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.1'),
     ('gettext', '0.19.2'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.1-intel-2015a-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.1-intel-2015a-Python-2.7.10.eb
@@ -15,6 +15,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.1'),
     ('gettext', '0.19.2'),
+    ('libxml2', '2.9.2'),
 ]
 python = 'Python'
 pyver = '2.7.10'

--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.1-intel-2015a.eb
@@ -15,6 +15,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.1'),
     ('gettext', '0.19.2'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.46.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.46.0-intel-2015b.eb
@@ -15,6 +15,7 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.6'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.10')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.47.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.47.1-intel-2015b.eb
@@ -15,6 +15,7 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.6'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.10')]
 


### PR DESCRIPTION
This is in relation to fixing #2636.

Not sure which version to use, especially for the older ones, but stuck with `2.9.2` for simplicity.