### PR TITLE
{bio}[foss-2015b] BamUtil-1.0.13

### DIFF
--- a/easybuild/easyconfigs/b/BamUtil/BamUtil-1.0.13-foss-2015b.eb
+++ b/easybuild/easyconfigs/b/BamUtil/BamUtil-1.0.13-foss-2015b.eb
@@ -4,11 +4,10 @@
 # adam.huffman@crick.ac.uk
 # The Francis Crick Institute
 #
-# This is the version bundled with the libStatGen library
+# This is the version with the bundled libStatGen library
 
 name = 'BamUtil'
 version = '1.0.13'
-versionsuffix = 'libStatGen'
 
 easyblock = 'MakeCp'
 

--- a/easybuild/easyconfigs/b/BamUtil/BamUtil-libStatGen-1.0.13-foss-2015b.eb
+++ b/easybuild/easyconfigs/b/BamUtil/BamUtil-libStatGen-1.0.13-foss-2015b.eb
@@ -1,0 +1,32 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Author: Adam Huffman
+# adam.huffman@crick.ac.uk
+# The Francis Crick Institute
+#
+# This is the version bundled with the libStatGen library
+
+name = 'BamUtil'
+version = '1.0.13'
+versionsuffix = 'libStatGen'
+
+easyblock = 'MakeCp'
+
+homepage = 'http://genome.sph.umich.edu/wiki/BamUtil'
+description = """BamUtil is a repository that contains several programs
+  that perform operations on SAM/BAM files. All of these programs
+  are built into a single executable, bam."""
+
+toolchain = {'name': 'foss', 'version': '2015b'}
+
+sources = ['%(name)sLibStatGen.%(version)s.tgz']
+source_urls = ['http://genome.sph.umich.edu/w/images/7/70/']
+
+files_to_copy = ["bamUtil/bin", "libStatGen"]
+
+sanity_check_paths = {
+    'files': ["bin/bam"],
+    'dirs': ["libStatGen"],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
I've added the versionsuffix because this build uses the bundled libStatGen library, rather than supplying that from a separate EB.