### PR TITLE
add missing libxml2 dependencies in GLib easyconfigs

### DIFF
--- a/easybuild/easyconfigs/g/GLib/GLib-2.40.0-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.40.0-goolf-1.7.20.eb
@@ -15,6 +15,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.1'),
     ('gettext', '0.19.2'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.41.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.41.2-intel-2015a.eb
@@ -14,6 +14,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.1'),
     ('gettext', '0.19.2'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.8')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.41.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.41.2-intel-2015b.eb
@@ -14,6 +14,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.1'),
     ('gettext', '0.19.2'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.10')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.0-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.0-GCC-4.9.2.eb
@@ -15,6 +15,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.4'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.9', '-bare')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.0-foss-2015a.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.0-foss-2015a.eb
@@ -15,6 +15,7 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.4'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.0-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.0-intel-2015a.eb
@@ -15,6 +15,7 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.4'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.1-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.1-goolf-1.7.20.eb
@@ -15,6 +15,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.1'),
     ('gettext', '0.19.2'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.1-intel-2015a-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.1-intel-2015a-Python-2.7.10.eb
@@ -15,6 +15,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.1'),
     ('gettext', '0.19.2'),
+    ('libxml2', '2.9.2'),
 ]
 python = 'Python'
 pyver = '2.7.10'

--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.1-intel-2015a.eb
@@ -15,6 +15,7 @@ sources = ['glib-%(version)s.tar.xz']
 dependencies = [
     ('libffi', '3.1'),
     ('gettext', '0.19.2'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.9')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.46.0-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.46.0-intel-2015b-Python-2.7.11.eb
@@ -2,6 +2,8 @@ easyblock = 'ConfigureMake'
 
 name = 'GLib'
 version = '2.46.0'
+pyver = '2.7.11'
+versionsuffix = '-Python-%s' % pyver
 
 homepage = 'http://www.gtk.org/'
 description = """GLib is one of the base libraries of the GTK+ project"""
@@ -15,8 +17,8 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.6'),
-    ('libxml2', '2.9.3', '-Python-2.7.10'),
+    ('libxml2', '2.9.3', versionsuffix),
 ]
-builddependencies = [('Python', '2.7.10')]
+builddependencies = [('Python', pyver)]
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GLib/GLib-2.46.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.46.0-intel-2015b.eb
@@ -15,6 +15,7 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.6'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.10')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.46.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.46.0-intel-2015b.eb
@@ -15,8 +15,8 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.6'),
-    ('libxml2', '2.9.2'),
+    ('libxml2', '2.9.3', '-Python-2.7.11'),
 ]
-builddependencies = [('Python', '2.7.10')]
+builddependencies = [('Python', '2.7.11')]
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/GLib/GLib-2.46.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.46.0-intel-2015b.eb
@@ -15,7 +15,7 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.6'),
-    ('libxml2', '2.9.3', '-Python-2.7.10'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.10')]
 

--- a/easybuild/easyconfigs/g/GLib/GLib-2.47.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.47.1-intel-2015b.eb
@@ -15,6 +15,7 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('libffi', '3.2.1'),
     ('gettext', '0.19.6'),
+    ('libxml2', '2.9.2'),
 ]
 builddependencies = [('Python', '2.7.10')]
 

--- a/easybuild/easyconfigs/q/Qt/Qt-4.8.7-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/q/Qt/Qt-4.8.7-intel-2015b-Python-2.7.11.eb
@@ -16,7 +16,7 @@ sources = ['%(namelower)s-everywhere-opensource-src-%(version)s.tar.gz']
 patches = ['Qt-%(version)s_phonon-export.patch']
 
 dependencies = [
-    ('GLib', '2.46.0'),
+    ('GLib', '2.46.0', versionsuffix),
     ('libX11', '1.6.3', versionsuffix),
     ('libXt', '1.1.5', versionsuffix),
     ('libXrender', '0.9.9', versionsuffix),

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.5.1-intel-2015b-Mesa-11.0.8.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.5.1-intel-2015b-Mesa-11.0.8.eb
@@ -18,7 +18,7 @@ sources = ['qt-everywhere-opensource-src-%(version)s.tar.xz']
 
 pysuff = '-Python-2.7.11'
 dependencies = [
-    ('GLib', '2.46.0'),
+    ('GLib', '2.46.0', pysuff),
     ('libX11', '1.6.3', pysuff),
     ('libXt', '1.1.5', pysuff),
     ('libXi', '1.7.4', pysuff),


### PR DESCRIPTION
builds on top of #2638 by @nathanhaigh, fixes conflict on libxml2 version in DOLFIN dependency tree