### PR TITLE
Fix Xerces-C++ download location

### DIFF
--- a/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.1.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.1.1-foss-2015a.eb
@@ -10,7 +10,7 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 
 sources = ['xerces-c-%(version)s.tar.gz']
 source_urls = [
-    'http://apache.belnet.be/xerces/c/3/sources/'
+    'http://archive.apache.org/dist/xerces/c/%(version_major)s/sources/'
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.1.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.1.1-intel-2015a.eb
@@ -10,8 +10,9 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 
 sources = ['xerces-c-%(version)s.tar.gz']
 source_urls = [
-    'http://apache.belnet.be/xerces/c/3/sources/'
+    'http://archive.apache.org/dist/xerces/c/%(version_major)s/sources/'
 ]
+
 
 dependencies = [
     ('cURL', '7.40.0'),

--- a/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.1.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.1.2-foss-2015a.eb
@@ -15,7 +15,7 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 
 sources = ['xerces-c-%(version)s.tar.gz']
 source_urls = [
-    'http://apache.belnet.be/xerces/c/%(version_major)s/sources/'
+    'http://archive.apache.org/dist/xerces/c/%(version_major)s/sources/'
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.1.2-foss-2015b.eb
+++ b/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.1.2-foss-2015b.eb
@@ -11,7 +11,7 @@ read and write XML data. A shared library is provided for parsing, generating,
 manipulating, and validating XML documents using the DOM, SAX, and SAX2
 APIs."""
 
-toolchain = {'name': 'intel', 'version': '2015a'}
+toolchain = {'name': 'foss', 'version': '2015b'}
 
 sources = ['xerces-c-%(version)s.tar.gz']
 source_urls = [

--- a/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.1.2-foss-2015b.eb
+++ b/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.1.2-foss-2015b.eb
@@ -19,7 +19,7 @@ source_urls = [
 ]
 
 dependencies = [
-    ('cURL', '7.44.0'),
+    ('cURL', '7.45.0'),
 ]
 
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.1.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/x/Xerces-C++/Xerces-C++-3.1.2-goolf-1.7.20.eb
@@ -15,7 +15,7 @@ toolchain = {'name': 'goolf', 'version': '1.7.20'}
 
 sources = ['xerces-c-%(version)s.tar.gz']
 source_urls = [
-    'http://apache.belnet.be/xerces/c/%(version_major)s/sources/'
+    'http://archive.apache.org/dist/xerces/c/%(version_major)s/sources/'
 ]
 
 dependencies = [


### PR DESCRIPTION
The old `apache.belnet.be` location wasn't working. 

There's also been a new release, which means it will work better to use the "archive" location, which should include all releases.

I changed this for all the existing easyconfigs and for the new `foss-2015b` version. 