### PR TITLE
enable XML::Bare in all Perl easyconfigs

### DIFF
--- a/easybuild/easyconfigs/p/Perl/Perl-5.20.3-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.20.3-foss-2015b.eb
@@ -419,11 +419,10 @@ exts_list = [
         'source_tmpl': 'Sub-Uplevel-0.25.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
     }),
-    # fails: uses 'gcc'
-    #('XML::Bare', '0.53', {
-    #    'source_tmpl': 'XML-Bare-0.53.tar.gz',
-    #    'source_urls': ['http://cpan.metacpan.org/authors/id/C/CO/CODECHILD'],
-    #}),
+    ('XML::Bare', '0.53', {
+        'source_tmpl': 'XML-Bare-0.53.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CO/CODECHILD/'],
+    }),
     ('Dist::CheckConflicts', '0.11', {
         'source_tmpl': 'Dist-CheckConflicts-0.11.tar.gz',
         'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY'],

--- a/easybuild/easyconfigs/p/Perl/Perl-5.20.3-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.20.3-foss-2016a.eb
@@ -419,11 +419,10 @@ exts_list = [
         'source_tmpl': 'Sub-Uplevel-0.25.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
     }),
-    # fails: uses 'gcc'
-    #('XML::Bare', '0.53', {
-    #    'source_tmpl': 'XML-Bare-0.53.tar.gz',
-    #    'source_urls': ['http://cpan.metacpan.org/authors/id/C/CO/CODECHILD'],
-    #}),
+    ('XML::Bare', '0.53', {
+        'source_tmpl': 'XML-Bare-0.53.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CO/CODECHILD/'],
+    }),
     ('Dist::CheckConflicts', '0.11', {
         'source_tmpl': 'Dist-CheckConflicts-0.11.tar.gz',
         'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY'],

--- a/easybuild/easyconfigs/p/Perl/Perl-5.20.3-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.20.3-intel-2015b.eb
@@ -419,11 +419,11 @@ exts_list = [
         'source_tmpl': 'Sub-Uplevel-0.25.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
     }),
-    # fails: uses 'gcc'
-    #('XML::Bare', '0.53', {
-    #    'source_tmpl': 'XML-Bare-0.53.tar.gz',
-    #    'source_urls': ['http://cpan.metacpan.org/authors/id/C/CO/CODECHILD'],
-    #}),
+    ('XML::Bare', '0.53', {
+        'source_tmpl': 'XML-Bare-0.53.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CO/CODECHILD/'],
+        'patches': ['XML-Bare-0.53_icc.patch'],
+    }),
     ('Dist::CheckConflicts', '0.11', {
         'source_tmpl': 'Dist-CheckConflicts-0.11.tar.gz',
         'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY'],

--- a/easybuild/easyconfigs/p/Perl/Perl-5.20.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.20.3-intel-2016a.eb
@@ -419,11 +419,11 @@ exts_list = [
         'source_tmpl': 'Sub-Uplevel-0.25.tar.gz',
         'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
     }),
-    # fails: uses 'gcc'
-    #('XML::Bare', '0.53', {
-    #    'source_tmpl': 'XML-Bare-0.53.tar.gz',
-    #    'source_urls': ['http://cpan.metacpan.org/authors/id/C/CO/CODECHILD'],
-    #}),
+    ('XML::Bare', '0.53', {
+        'source_tmpl': 'XML-Bare-0.53.tar.gz',
+        'source_urls': ['http://cpan.metacpan.org/authors/id/C/CO/CODECHILD/'],
+        'patches': ['XML-Bare-0.53_icc.patch'],
+    }),
     ('Dist::CheckConflicts', '0.11', {
         'source_tmpl': 'Dist-CheckConflicts-0.11.tar.gz',
         'source_urls': ['http://cpan.metacpan.org/authors/id/D/DO/DOY'],


### PR DESCRIPTION
a patch was already available to make `XML::Bare` build with `icc`, but it wasn't used everywhere...