### PR TITLE
remove custom exts_filter in GC3Pie easyconfigs, since PythonPackage will use right filter by default

### DIFF
--- a/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.2.3.eb
+++ b/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.2.3.eb
@@ -11,7 +11,6 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
-exts_filter = ('python -c"import %(ext_name)s"', '')
 
 # allow use of system Python
 allow_system_deps = [('Python', SYS_PYTHON_VERSION)]

--- a/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.3.eb
+++ b/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.3.eb
@@ -11,7 +11,6 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
-exts_filter = ('python -c"import %(ext_name)s"', '')
 
 # allow use of system Python
 allow_system_deps = [('Python', SYS_PYTHON_VERSION)]

--- a/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.4.0.eb
+++ b/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.4.0.eb
@@ -11,7 +11,6 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
-exts_filter = ('python -c"import %(ext_name)s"', '')
 
 # allow use of system Python
 allow_system_deps = [('Python', SYS_PYTHON_VERSION)]

--- a/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.4.1.eb
+++ b/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.4.1.eb
@@ -11,7 +11,6 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
-exts_filter = ('python -c"import %(ext_name)s"', '')
 
 # allow use of system Python
 allow_system_deps = [('Python', SYS_PYTHON_VERSION)]

--- a/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.4.2.eb
+++ b/easybuild/easyconfigs/g/GC3Pie/GC3Pie-2.4.2.eb
@@ -11,7 +11,6 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
-exts_filter = ('python -c"import %(ext_name)s"', '')
 
 # allow use of system Python
 allow_system_deps = [('Python', SYS_PYTHON_VERSION)]


### PR DESCRIPTION
including the custom filter which is the same as the default breaks installation on a system where `python` is Python 3.x

related to https://github.com/hpcugent/easybuild-easyblocks/pull/861