### PR TITLE
remove custom exts_filter in various easyconfigs for (bundles of) Python packages

### DIFF
--- a/easybuild/easyconfigs/i/IPython/IPython-3.2.1-intel-2015a-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-3.2.1-intel-2015a-Python-2.7.10.eb
@@ -25,7 +25,6 @@ dependencies = [
 
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
-exts_filter = ("python -c 'import %(ext_name)s'", '')
 
 exts_list = [
     ('pysqlite', '2.7.0', {

--- a/easybuild/easyconfigs/i/IPython/IPython-3.2.3-foss-2015a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-3.2.3-foss-2015a-Python-2.7.11.eb
@@ -25,7 +25,6 @@ dependencies = [
 
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
-exts_filter = ("python -c 'import %(ext_name)s'", '')
 
 exts_list = [
     ('pysqlite', '2.8.1', {

--- a/easybuild/easyconfigs/i/IPython/IPython-3.2.3-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-3.2.3-intel-2015b-Python-2.7.10.eb
@@ -25,7 +25,6 @@ dependencies = [
 
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
-exts_filter = ("python -c 'import %(ext_name)s'", '')
 
 exts_list = [
     ('pysqlite', '2.8.1', {

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2015b-Python-2.7.10.eb
@@ -13,7 +13,6 @@ toolchain = {'name': 'foss', 'version': '2015b'}
 
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
-exts_filter = ('python -c "import %(ext_name)s"', '')
 
 dependencies = [
     ('Python', '2.7.10'),

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2015b-Python-2.7.11.eb
@@ -13,7 +13,6 @@ toolchain = {'name': 'intel', 'version': '2015b'}
 
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
-exts_filter = ('python -c "import %(ext_name)s"', '')
 
 dependencies = [
     ('Python', '2.7.11'),

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016a-Python-2.7.11.eb
@@ -13,7 +13,6 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
-exts_filter = ('python -c "import %(ext_name)s"', '')
 
 dependencies = [
     ('Python', '2.7.11'),

--- a/easybuild/easyconfigs/n/numba/numba-0.22.1-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.22.1-intel-2015b-Python-2.7.11.eb
@@ -11,7 +11,6 @@ toolchain = {'name': 'intel', 'version': '2015b'}
 
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
-exts_filter = ('python -c "import %(ext_name)s"', '')
 
 pyver = '2.7.11'
 versionsuffix = '-Python-%s' % pyver

--- a/easybuild/easyconfigs/s/Sphinx/Sphinx-1.3.3-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/s/Sphinx/Sphinx-1.3.3-intel-2015b-Python-2.7.11.eb
@@ -13,7 +13,6 @@ toolchain = {'name': 'intel', 'version': '2015b'}
 
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
-exts_filter = ('python -c "import %(ext_name)s"', '')
 
 pyver = '2.7.11'
 pyshortver = '.'.join(pyver.split('.')[0:2])


### PR DESCRIPTION
similar fix to #2683, but lower impact since a Python dependency is actually included for these