### PR TITLE
add missing dependencines in Python 3.5.x easyconfigs

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.5.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.0-intel-2015b.eb
@@ -19,6 +19,9 @@ dependencies = [
     ('zlib', '1.2.8'),
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
+    ('SQLite', '3.9.2'),
+    ('Tk', '8.6.4', '-no-X11'),
+    ('GMP', '6.1.0'),
     #   ('OpenSSL', '1.0.1p'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2016a.eb
@@ -19,6 +19,9 @@ dependencies = [
     ('zlib', '1.2.8'),
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
+    ('SQLite', '3.9.2'),
+    ('Tk', '8.6.4', '-no-X11'),
+    ('GMP', '6.1.0'),
 #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
 #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-3.5.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.1-intel-2016a.eb
@@ -19,6 +19,9 @@ dependencies = [
     ('zlib', '1.2.8'),
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
+    ('SQLite', '3.9.2'),
+    ('Tk', '8.6.4', '-no-X11'),
+    ('GMP', '6.1.0'),
 #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
 #   nice to have an up to date openssl for security reasons
 ]


### PR DESCRIPTION
This syncs up the dependencies with the Python 2.7.11 easyconfigs.