### PR TITLE
fix source URLs for Bioconductor 3.2

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.2-foss-2016a-R-3.2.3.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.2-foss-2016a-R-3.2.3.eb
@@ -28,9 +28,9 @@ ext_options = {
 }
 bioconductor_options = {
     'source_urls': [
-        'http://www.bioconductor.org/packages/%(version)s/bioc/src/contrib/',
-        'http://www.bioconductor.org/packages/%(version)s/data/annotation/src/contrib/',
-        'http://www.bioconductor.org/packages/%(version)s/data/experiment/src/contrib/',
+        'http://www.bioconductor.org/packages/3.2/bioc/src/contrib/',
+        'http://www.bioconductor.org/packages/3.2/data/annotation/src/contrib/',
+        'http://www.bioconductor.org/packages/3.2/data/experiment/src/contrib/',
     ],
     'source_tmpl': name_tmpl,
 }

--- a/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.2-intel-2016a-R-3.2.3.eb
+++ b/easybuild/easyconfigs/r/R-bundle-Bioconductor/R-bundle-Bioconductor-3.2-intel-2016a-R-3.2.3.eb
@@ -27,9 +27,9 @@ ext_options = {
 }
 bioconductor_options = {
     'source_urls': [
-        'http://www.bioconductor.org/packages/%(version)s/bioc/src/contrib/',
-        'http://www.bioconductor.org/packages/%(version)s/data/annotation/src/contrib/',
-        'http://www.bioconductor.org/packages/%(version)s/data/experiment/src/contrib/',
+        'http://www.bioconductor.org/packages/3.2/bioc/src/contrib/',
+        'http://www.bioconductor.org/packages/3.2/data/annotation/src/contrib/',
+        'http://www.bioconductor.org/packages/3.2/data/experiment/src/contrib/',
     ],
     'source_tmpl': name_tmpl,
 }


### PR DESCRIPTION
can't use `%(version)s` since it gets templated with the *extension* version on download...