### PR TITLE
reinstate Velvet easyconfigs that were removed in #2495

### DIFF
--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2015b-mt-kmer_100.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2015b-mt-kmer_100.eb
@@ -1,0 +1,29 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, 2012-2013 The Cyprus Institute
+# Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>,
+#             Thekla Loizou <t.loizou@cyi.ac.cy>, Andreas Panteli <a.panteli@cyi.ac.cy>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-94.html
+##
+
+name = 'Velvet'
+version = '1.2.10'
+versionsuffix = '-mt-kmer_100'
+
+homepage = 'http://www.ebi.ac.uk/~zerbino/velvet/'
+description = """Sequence assembler for very short reads"""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+toolchainopts = {'optarch': True, 'pic': True, 'openmp': True}
+
+sources = ['%(namelower)s_%(version)s.tgz']
+source_urls = ['http://www.ebi.ac.uk/~zerbino/%(namelower)s']
+
+buildopts = "OPENMP=1 MAXKMERLENGTH=%s" % versionsuffix.split('_')[1]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2015b-mt-kmer_31.eb
+++ b/easybuild/easyconfigs/v/Velvet/Velvet-1.2.10-intel-2015b-mt-kmer_31.eb
@@ -1,0 +1,30 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA, 2012-2013 The Cyprus Institute
+# Authors::   Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>,
+#             Thekla Loizou <t.loizou@cyi.ac.cy>, Andreas Panteli <a.panteli@cyi.ac.cy>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-94.html
+##
+
+name = 'Velvet'
+version = '1.2.10'
+versionsuffix = '-mt-kmer_31'
+
+homepage = 'http://www.ebi.ac.uk/~zerbino/velvet/'
+description = """Sequence assembler for very short reads"""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+toolchainopts = {'optarch': True, 'pic': True, 'openmp': True}
+
+sources = ['%(namelower)s_%(version)s.tgz']
+source_urls = ['http://www.ebi.ac.uk/~zerbino/%(namelower)s']
+
+# by default MAXKMERLENGTH=31 but defined here to keep all the easyconfigs homogeneous
+buildopts = "OPENMP=1 MAXKMERLENGTH=%s" % versionsuffix.split('_')[1]
+
+moduleclass = 'bio'


### PR DESCRIPTION
In #2495, existing easyconfigs were renamed because `Perl`/`BioPerl` was added as a dependency.

But since our policy is not to remove existing easyconfigs from the repository (unless there's a good reason for it), the existing `Velvet` easyconfigs shouldn't have been removed/renamed, but new ones should've been added.

This PR fixes that by readding the original Velvet easyconfigs.