### PR TITLE
{math,lib}[foss/2016a] LinBox 1.4.0, FFLAS-FFPACK 2.2.0, Givaro 4.0.1 (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/f/FFLAS-FFPACK/FFLAS-FFPACK-2.2.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/FFLAS-FFPACK/FFLAS-FFPACK-2.2.0-foss-2016a.eb
@@ -1,0 +1,70 @@
+##
+# This file is an EasyBuild recipe; see https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright (c) 2016 Riccardo Murri <riccardo.murri@gmail.com>
+# Authors::   Riccardo Murri <riccardo.murri@gmail.com>
+# License::   GPL
+#
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'FFLAS-FFPACK'
+version = '2.2.0'
+
+homepage = 'https://linbox-team.github.io/fflas-ffpack/'
+description = "Finite Field Linear Algebra Subroutines / Package"
+
+toolchain = {'version': '2016a', 'name': 'foss'}
+
+sources = ['v2.2.0.zip']
+source_urls = ['https://github.com/linbox-team/%(namelower)s/archive']
+
+builddependencies = [
+    ('Autoconf', '2.69', '', True),
+    ('Automake', '1.15', '', True),
+    ('libtool', '2.4.6', '', True),
+]
+dependencies = [
+    ('GMP', '6.1.0', '', ('GCC', '4.9.3-2.25')),
+    ('Givaro', '4.0.1'),
+]
+
+preconfigopts = "env NOCONFIGURE=1 ./autogen.sh && "
+configopts = '--with-gmp=$EBROOTGMP --with-givaro=$EBROOTGIVARO --with-blas-cflags="-I$BLAS_INC_DIR" --with-blas-libs="-L$BLAS_LIB_DIR $LIBBLAS" --enable-openmp'
+
+parallel = 4
+
+unwanted_env_vars = {}
+start_dir = '%(builddir)s/%(namelower)s-%(version)s/'
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s-config', 'include/%(namelower)s/%(namelower)s.h'],
+    'dirs': ['bin', 'include', 'lib'],
+}
+
+moduleclass = 'math'
+# Build statistics
+buildstats = [{
+    "easybuild-framework_version": "2.8.0dev0",
+    "easybuild-easyblocks_version": "2.8.0dev0",
+    "timestamp": 1459270041,
+    "build_time": 30.84,
+    "install_size": 1762928,
+    "command_line": ['--add-dummy-to-minimal-toolchains', '--buildpath=/tmp', '--experimental', '--github-user=riccardomurri', '--installpath=/home/rmurri/w/easybuild', '--minimal-toolchains', '--module-syntax=Lua', '--modules-tool=Lmod', '--packagepath=/home/rmurri/w/easybuild/packages', '--prefix=/home/rmurri/w/easybuild', '--repositorypath=ebfiles', '--robot=/home/rmurri/w/easybuild/ebfiles:/home/rmurri/w/easybuild/easyconfigs/easybuild/easyconfigs/', '--robot-paths=/home/rmurri/w/easybuild/ebfiles:/home/rmurri/w/easybuild/easyconfigs/easybuild/easyconfigs/', '--skip-test-cases', '--sourcepath=/home/rmurri/w/easybuild/sources', '--try-toolchain="[\'foss\', \'2016a\']"', 'FFLAS-FFPACK-2.2.0-foss-2015a.eb'],
+    "modules_tool": ('Lmod', '/usr/share/lmod/lmod/libexec/lmod', '5.8'),
+    "core_count": 4,
+    "cpu_model": "Intel(R) Core(TM) i5 CPU       M 520  @ 2.40GHz",
+    "cpu_speed": 2400.0,
+    "cpu_vendor": "Intel",
+    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/home/rmurri/w/easybuild/software/GCCcore/4.9.3/libexec/gcc/x86_64-unknown-linux-gnu/4.9.3/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/home/rmurri/w/easybuild/software/GCCcore/4.9.3 --with-local-prefix=/home/rmurri/w/easybuild/software/GCCcore/4.9.3; Thread model: posix; gcc version 4.9.3 (GCC) ; ",
+    "glibc_version": "2.21",
+    "hostname": "xenia",
+    "os_name": "ubuntu",
+    "os_type": "Linux",
+    "os_version": "15.10",
+    "platform_name": "x86_64-unknown-linux",
+    "python_version": "2.7.10 (default, Oct 14 2015, 16:09:02) ; [GCC 5.2.1 20151010]",
+    "system_gcc_path": "/home/rmurri/w/easybuild/software/GCCcore/4.9.3/bin/gcc",
+    "system_python_path": "/home/rmurri/.virtualenvs/easybuild/bin/python",
+}]

--- a/easybuild/easyconfigs/f/FFLAS-FFPACK/FFLAS-FFPACK-2.2.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/FFLAS-FFPACK/FFLAS-FFPACK-2.2.0-foss-2016a.eb
@@ -44,27 +44,3 @@ sanity_check_paths = {
 }
 
 moduleclass = 'math'
-# Build statistics
-buildstats = [{
-    "easybuild-framework_version": "2.8.0dev0",
-    "easybuild-easyblocks_version": "2.8.0dev0",
-    "timestamp": 1459270041,
-    "build_time": 30.84,
-    "install_size": 1762928,
-    "command_line": ['--add-dummy-to-minimal-toolchains', '--buildpath=/tmp', '--experimental', '--github-user=riccardomurri', '--installpath=/home/rmurri/w/easybuild', '--minimal-toolchains', '--module-syntax=Lua', '--modules-tool=Lmod', '--packagepath=/home/rmurri/w/easybuild/packages', '--prefix=/home/rmurri/w/easybuild', '--repositorypath=ebfiles', '--robot=/home/rmurri/w/easybuild/ebfiles:/home/rmurri/w/easybuild/easyconfigs/easybuild/easyconfigs/', '--robot-paths=/home/rmurri/w/easybuild/ebfiles:/home/rmurri/w/easybuild/easyconfigs/easybuild/easyconfigs/', '--skip-test-cases', '--sourcepath=/home/rmurri/w/easybuild/sources', '--try-toolchain="[\'foss\', \'2016a\']"', 'FFLAS-FFPACK-2.2.0-foss-2015a.eb'],
-    "modules_tool": ('Lmod', '/usr/share/lmod/lmod/libexec/lmod', '5.8'),
-    "core_count": 4,
-    "cpu_model": "Intel(R) Core(TM) i5 CPU       M 520  @ 2.40GHz",
-    "cpu_speed": 2400.0,
-    "cpu_vendor": "Intel",
-    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/home/rmurri/w/easybuild/software/GCCcore/4.9.3/libexec/gcc/x86_64-unknown-linux-gnu/4.9.3/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/home/rmurri/w/easybuild/software/GCCcore/4.9.3 --with-local-prefix=/home/rmurri/w/easybuild/software/GCCcore/4.9.3; Thread model: posix; gcc version 4.9.3 (GCC) ; ",
-    "glibc_version": "2.21",
-    "hostname": "xenia",
-    "os_name": "ubuntu",
-    "os_type": "Linux",
-    "os_version": "15.10",
-    "platform_name": "x86_64-unknown-linux",
-    "python_version": "2.7.10 (default, Oct 14 2015, 16:09:02) ; [GCC 5.2.1 20151010]",
-    "system_gcc_path": "/home/rmurri/w/easybuild/software/GCCcore/4.9.3/bin/gcc",
-    "system_python_path": "/home/rmurri/.virtualenvs/easybuild/bin/python",
-}]

--- a/easybuild/easyconfigs/f/FFLAS-FFPACK/FFLAS-FFPACK-2.2.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/FFLAS-FFPACK/FFLAS-FFPACK-2.2.0-foss-2016a.eb
@@ -24,17 +24,17 @@ builddependencies = [
     ('Autotools', '20150215'),
 ]
 dependencies = [
-    ('GMP',    '6.1.0'),
+    ('GMP', '6.1.0'),
     ('Givaro', '4.0.1'),
 ]
 
 preconfigopts = "env NOCONFIGURE=1 ./autogen.sh && "
-configopts = ('--with-gmp=$EBROOTGMP --with-givaro=$EBROOTGIVARO'
-              ' --with-blas-cflags="-I$BLAS_INC_DIR" --with-blas-libs="-L$BLAS_LIB_DIR $LIBBLAS" --enable-openmp')
+configopts = '--with-gmp=$EBROOTGMP --with-givaro=$EBROOTGIVARO'
+configopts += ' --with-blas-cflags="-I$BLAS_INC_DIR" --with-blas-libs="-L$BLAS_LIB_DIR $LIBBLAS" --enable-openmp'
 
 sanity_check_paths = {
     'files': ['bin/fflas-ffpack-config', 'include/fflas-ffpack/fflas-ffpack.h'],
-    'dirs':  ['bin', 'include', 'lib'],
+    'dirs': ['bin', 'include', 'lib'],
 }
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/f/FFLAS-FFPACK/FFLAS-FFPACK-2.2.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/FFLAS-FFPACK/FFLAS-FFPACK-2.2.0-foss-2016a.eb
@@ -17,30 +17,26 @@ description = "Finite Field Linear Algebra Subroutines / Package"
 
 toolchain = {'version': '2016a', 'name': 'foss'}
 
-sources = ['v2.2.0.zip']
-source_urls = ['https://github.com/linbox-team/%(namelower)s/archive']
+sources = ['v%(version)s.zip']
+source_urls = ['https://github.com/linbox-team/fflas-ffpack/archive']
 
 builddependencies = [
-    ('Autoconf', '2.69', '', True),
-    ('Automake', '1.15', '', True),
-    ('libtool', '2.4.6', '', True),
+    ('Autoconf', '2.69'),
+    ('Automake', '1.15'),
+    ('libtool', '2.4.6'),
 ]
 dependencies = [
-    ('GMP', '6.1.0', '', ('GCC', '4.9.3-2.25')),
+    ('GMP',    '6.1.0'),
     ('Givaro', '4.0.1'),
 ]
 
 preconfigopts = "env NOCONFIGURE=1 ./autogen.sh && "
-configopts = '--with-gmp=$EBROOTGMP --with-givaro=$EBROOTGIVARO --with-blas-cflags="-I$BLAS_INC_DIR" --with-blas-libs="-L$BLAS_LIB_DIR $LIBBLAS" --enable-openmp'
-
-parallel = 4
-
-unwanted_env_vars = {}
-start_dir = '%(builddir)s/%(namelower)s-%(version)s/'
+configopts = ('--with-gmp=$EBROOTGMP --with-givaro=$EBROOTGIVARO'
+              ' --with-blas-cflags="-I$BLAS_INC_DIR" --with-blas-libs="-L$BLAS_LIB_DIR $LIBBLAS" --enable-openmp')
 
 sanity_check_paths = {
-    'files': ['bin/%(namelower)s-config', 'include/%(namelower)s/%(namelower)s.h'],
-    'dirs': ['bin', 'include', 'lib'],
+    'files': ['bin/fflas-ffpack-config', 'include/fflas-ffpack/fflas-ffpack.h'],
+    'dirs':  ['bin', 'include', 'lib'],
 }
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/f/FFLAS-FFPACK/FFLAS-FFPACK-2.2.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/FFLAS-FFPACK/FFLAS-FFPACK-2.2.0-foss-2016a.eb
@@ -21,9 +21,7 @@ sources = ['v%(version)s.zip']
 source_urls = ['https://github.com/linbox-team/fflas-ffpack/archive']
 
 builddependencies = [
-    ('Autoconf', '2.69'),
-    ('Automake', '1.15'),
-    ('libtool', '2.4.6'),
+    ('Autotools', '20150215'),
 ]
 dependencies = [
     ('GMP',    '6.1.0'),

--- a/easybuild/easyconfigs/g/Givaro/Givaro-4.0.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/Givaro/Givaro-4.0.1-foss-2016a.eb
@@ -1,0 +1,45 @@
+##
+# This file is an EasyBuild recipe; see https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright (c) 2016 Riccardo Murri <riccardo.murri@gmail.com>
+# Authors::   Riccardo Murri <riccardo.murri@gmail.com>
+# License::   GPL
+#
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'Givaro'
+version = '4.0.1'
+
+homepage = 'http://givaro.forge.imag.fr/'
+description = "C++ library for arithmetic and algebraic computations"
+
+toolchain = {'version': '2016a', 'name': 'foss'}
+
+sources = ['v4.0.1.zip']
+source_urls = ['https://github.com/linbox-team/%(namelower)s/archive']
+
+builddependencies = [
+    ('Autoconf', '2.69', '', True),
+    ('Automake', '1.15', '', True),
+    ('libtool', '2.4.6', '', True),
+]
+dependencies = [
+    ('GMP', '6.1.0', '', ('GCC', '4.9.3-2.25')),
+]
+
+preconfigopts = "env NOCONFIGURE=1 ./autogen.sh && "
+configopts = "--with-gmp=$EBROOTGMP --enable-inline"
+
+parallel = 4
+
+unwanted_env_vars = {}
+start_dir = '%(builddir)s/%(namelower)s-%(version)s/'
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s-config', 'include/%(namelower)s-config.h'],
+    'dirs': ['bin', 'include', 'lib'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/g/Givaro/Givaro-4.0.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/Givaro/Givaro-4.0.1-foss-2016a.eb
@@ -21,9 +21,7 @@ sources = ['v%(version)s.zip']
 source_urls = ['https://github.com/linbox-team/givaro/archive']
 
 builddependencies = [
-    ('Autoconf', '2.69'),
-    ('Automake', '1.15'),
-    ('libtool', '2.4.6'),
+    ('Autotools', '20150215'),
 ]
 dependencies = [
     ('GMP', '6.1.0'),

--- a/easybuild/easyconfigs/g/Givaro/Givaro-4.0.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/Givaro/Givaro-4.0.1-foss-2016a.eb
@@ -17,29 +17,24 @@ description = "C++ library for arithmetic and algebraic computations"
 
 toolchain = {'version': '2016a', 'name': 'foss'}
 
-sources = ['v4.0.1.zip']
-source_urls = ['https://github.com/linbox-team/%(namelower)s/archive']
+sources = ['v%(version)s.zip']
+source_urls = ['https://github.com/linbox-team/givaro/archive']
 
 builddependencies = [
-    ('Autoconf', '2.69', '', True),
-    ('Automake', '1.15', '', True),
-    ('libtool', '2.4.6', '', True),
+    ('Autoconf', '2.69'),
+    ('Automake', '1.15'),
+    ('libtool', '2.4.6'),
 ]
 dependencies = [
-    ('GMP', '6.1.0', '', ('GCC', '4.9.3-2.25')),
+    ('GMP', '6.1.0'),
 ]
 
 preconfigopts = "env NOCONFIGURE=1 ./autogen.sh && "
 configopts = "--with-gmp=$EBROOTGMP --enable-inline"
 
-parallel = 4
-
-unwanted_env_vars = {}
-start_dir = '%(builddir)s/%(namelower)s-%(version)s/'
-
 sanity_check_paths = {
-    'files': ['bin/%(namelower)s-config', 'include/%(namelower)s-config.h'],
-    'dirs': ['bin', 'include', 'lib'],
+    'files': ['bin/givaro-config', 'include/givaro-config.h'],
+    'dirs':  ['bin', 'include', 'lib'],
 }
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/g/Givaro/Givaro-4.0.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/Givaro/Givaro-4.0.1-foss-2016a.eb
@@ -32,7 +32,7 @@ configopts = "--with-gmp=$EBROOTGMP --enable-inline"
 
 sanity_check_paths = {
     'files': ['bin/givaro-config', 'include/givaro-config.h'],
-    'dirs':  ['bin', 'include', 'lib'],
+    'dirs': ['bin', 'include', 'lib'],
 }
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/l/LinBox/LinBox-1.4.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/LinBox/LinBox-1.4.0-foss-2016a.eb
@@ -44,27 +44,3 @@ sanity_check_paths = {
 }
 
 moduleclass = 'math'
-# Build statistics
-buildstats = [{
-    "easybuild-framework_version": "2.8.0dev0",
-    "easybuild-easyblocks_version": "2.8.0dev0",
-    "timestamp": 1459270157,
-    "build_time": 64.4,
-    "install_size": 8769443,
-    "command_line": ['--add-dummy-to-minimal-toolchains', '--buildpath=/tmp', '--experimental', '--github-user=riccardomurri', '--installpath=/home/rmurri/w/easybuild', '--minimal-toolchains', '--module-syntax=Lua', '--modules-tool=Lmod', '--packagepath=/home/rmurri/w/easybuild/packages', '--prefix=/home/rmurri/w/easybuild', '--repositorypath=ebfiles', '--robot=/home/rmurri/w/easybuild/ebfiles:/home/rmurri/w/easybuild/easyconfigs/easybuild/easyconfigs/', '--robot-paths=/home/rmurri/w/easybuild/ebfiles:/home/rmurri/w/easybuild/easyconfigs/easybuild/easyconfigs/', '--skip-test-cases', '--sourcepath=/home/rmurri/w/easybuild/sources', '--try-toolchain="[\'foss\', \'2016a\']"', 'LinBox-1.4.0-foss-2015a.eb'],
-    "modules_tool": ('Lmod', '/usr/share/lmod/lmod/libexec/lmod', '5.8'),
-    "core_count": 4,
-    "cpu_model": "Intel(R) Core(TM) i5 CPU       M 520  @ 2.40GHz",
-    "cpu_speed": 2400.0,
-    "cpu_vendor": "Intel",
-    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/home/rmurri/w/easybuild/software/GCCcore/4.9.3/libexec/gcc/x86_64-unknown-linux-gnu/4.9.3/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/home/rmurri/w/easybuild/software/GCCcore/4.9.3 --with-local-prefix=/home/rmurri/w/easybuild/software/GCCcore/4.9.3; Thread model: posix; gcc version 4.9.3 (GCC) ; ",
-    "glibc_version": "2.21",
-    "hostname": "xenia",
-    "os_name": "ubuntu",
-    "os_type": "Linux",
-    "os_version": "15.10",
-    "platform_name": "x86_64-unknown-linux",
-    "python_version": "2.7.10 (default, Oct 14 2015, 16:09:02) ; [GCC 5.2.1 20151010]",
-    "system_gcc_path": "/home/rmurri/w/easybuild/software/GCCcore/4.9.3/bin/gcc",
-    "system_python_path": "/home/rmurri/.virtualenvs/easybuild/bin/python",
-}]

--- a/easybuild/easyconfigs/l/LinBox/LinBox-1.4.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/LinBox/LinBox-1.4.0-foss-2016a.eb
@@ -1,0 +1,70 @@
+##
+# This file is an EasyBuild recipe; see https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright (c) 2016 Riccardo Murri <riccardo.murri@gmail.com>
+# Authors::   Riccardo Murri <riccardo.murri@gmail.com>
+# License::   GPL
+#
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'LinBox'
+version = '1.4.0'
+
+homepage = 'http://linalg.org/'
+description = "C++ library for exact, high-performance linear algebra"
+
+toolchain = {'version': '2016a', 'name': 'foss'}
+
+sources = ['v1.4.0.zip']
+source_urls = ['https://github.com/%(namelower)s-team/%(namelower)s/archive']
+
+builddependencies = [
+    ('Autoconf', '2.69', '', True),
+    ('Automake', '1.15', '', True),
+    ('libtool', '2.4.6', '', True),
+]
+dependencies = [
+    ('FFLAS-FFPACK', '2.2.0'),
+    ('Givaro', '4.0.1'),
+]
+
+preconfigopts = "env NOCONFIGURE=1 ./autogen.sh && "
+configopts = "--with-givaro=$EBROOTGIVARO --with-fflas-ffpack=$EBROOTFFLASMINFFPACK --enable-openmp"
+
+parallel = 4
+
+unwanted_env_vars = {}
+start_dir = '%(builddir)s/%(namelower)s-%(version)s/'
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s-config', 'include/%(namelower)s/%(namelower)s-config.h', 'lib/liblinbox.a'],
+    'dirs': ['bin', 'include', 'lib'],
+}
+
+moduleclass = 'math'
+# Build statistics
+buildstats = [{
+    "easybuild-framework_version": "2.8.0dev0",
+    "easybuild-easyblocks_version": "2.8.0dev0",
+    "timestamp": 1459270157,
+    "build_time": 64.4,
+    "install_size": 8769443,
+    "command_line": ['--add-dummy-to-minimal-toolchains', '--buildpath=/tmp', '--experimental', '--github-user=riccardomurri', '--installpath=/home/rmurri/w/easybuild', '--minimal-toolchains', '--module-syntax=Lua', '--modules-tool=Lmod', '--packagepath=/home/rmurri/w/easybuild/packages', '--prefix=/home/rmurri/w/easybuild', '--repositorypath=ebfiles', '--robot=/home/rmurri/w/easybuild/ebfiles:/home/rmurri/w/easybuild/easyconfigs/easybuild/easyconfigs/', '--robot-paths=/home/rmurri/w/easybuild/ebfiles:/home/rmurri/w/easybuild/easyconfigs/easybuild/easyconfigs/', '--skip-test-cases', '--sourcepath=/home/rmurri/w/easybuild/sources', '--try-toolchain="[\'foss\', \'2016a\']"', 'LinBox-1.4.0-foss-2015a.eb'],
+    "modules_tool": ('Lmod', '/usr/share/lmod/lmod/libexec/lmod', '5.8'),
+    "core_count": 4,
+    "cpu_model": "Intel(R) Core(TM) i5 CPU       M 520  @ 2.40GHz",
+    "cpu_speed": 2400.0,
+    "cpu_vendor": "Intel",
+    "gcc_version": "Using built-in specs.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/home/rmurri/w/easybuild/software/GCCcore/4.9.3/libexec/gcc/x86_64-unknown-linux-gnu/4.9.3/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/home/rmurri/w/easybuild/software/GCCcore/4.9.3 --with-local-prefix=/home/rmurri/w/easybuild/software/GCCcore/4.9.3; Thread model: posix; gcc version 4.9.3 (GCC) ; ",
+    "glibc_version": "2.21",
+    "hostname": "xenia",
+    "os_name": "ubuntu",
+    "os_type": "Linux",
+    "os_version": "15.10",
+    "platform_name": "x86_64-unknown-linux",
+    "python_version": "2.7.10 (default, Oct 14 2015, 16:09:02) ; [GCC 5.2.1 20151010]",
+    "system_gcc_path": "/home/rmurri/w/easybuild/software/GCCcore/4.9.3/bin/gcc",
+    "system_python_path": "/home/rmurri/.virtualenvs/easybuild/bin/python",
+}]

--- a/easybuild/easyconfigs/l/LinBox/LinBox-1.4.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/LinBox/LinBox-1.4.0-foss-2016a.eb
@@ -25,7 +25,7 @@ builddependencies = [
 ]
 dependencies = [
     ('FFLAS-FFPACK', '2.2.0'),
-    ('Givaro',       '4.0.1'),
+    ('Givaro', '4.0.1'),
 ]
 
 preconfigopts = "env NOCONFIGURE=1 ./autogen.sh && "
@@ -33,7 +33,7 @@ configopts = "--with-givaro=$EBROOTGIVARO --with-fflas-ffpack=$EBROOTFFLASMINFFP
 
 sanity_check_paths = {
     'files': ['bin/linbox-config', 'include/linbox/linbox-config.h', 'lib/liblinbox.a'],
-    'dirs':  ['bin', 'include', 'lib'],
+    'dirs': ['bin', 'include', 'lib'],
 }
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/l/LinBox/LinBox-1.4.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/LinBox/LinBox-1.4.0-foss-2016a.eb
@@ -17,30 +17,25 @@ description = "C++ library for exact, high-performance linear algebra"
 
 toolchain = {'version': '2016a', 'name': 'foss'}
 
-sources = ['v1.4.0.zip']
-source_urls = ['https://github.com/%(namelower)s-team/%(namelower)s/archive']
+sources = ['v%(version)s.zip']
+source_urls = ['https://github.com/linbox-team/linbox/archive']
 
 builddependencies = [
-    ('Autoconf', '2.69', '', True),
-    ('Automake', '1.15', '', True),
-    ('libtool', '2.4.6', '', True),
+    ('Autoconf', '2.69'),
+    ('Automake', '1.15'),
+    ('libtool', '2.4.6'),
 ]
 dependencies = [
     ('FFLAS-FFPACK', '2.2.0'),
-    ('Givaro', '4.0.1'),
+    ('Givaro',       '4.0.1'),
 ]
 
 preconfigopts = "env NOCONFIGURE=1 ./autogen.sh && "
 configopts = "--with-givaro=$EBROOTGIVARO --with-fflas-ffpack=$EBROOTFFLASMINFFPACK --enable-openmp"
 
-parallel = 4
-
-unwanted_env_vars = {}
-start_dir = '%(builddir)s/%(namelower)s-%(version)s/'
-
 sanity_check_paths = {
-    'files': ['bin/%(namelower)s-config', 'include/%(namelower)s/%(namelower)s-config.h', 'lib/liblinbox.a'],
-    'dirs': ['bin', 'include', 'lib'],
+    'files': ['bin/linbox-config', 'include/linbox/linbox-config.h', 'lib/liblinbox.a'],
+    'dirs':  ['bin', 'include', 'lib'],
 }
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/l/LinBox/LinBox-1.4.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/LinBox/LinBox-1.4.0-foss-2016a.eb
@@ -21,9 +21,7 @@ sources = ['v%(version)s.zip']
 source_urls = ['https://github.com/linbox-team/linbox/archive']
 
 builddependencies = [
-    ('Autoconf', '2.69'),
-    ('Automake', '1.15'),
-    ('libtool', '2.4.6'),
+    ('Autotools', '20150215'),
 ]
 dependencies = [
     ('FFLAS-FFPACK', '2.2.0'),


### PR DESCRIPTION
This PR adds `.eb` recipes for building [LinBox][1] 1.4.0 and its
(minimal) dependencies [FFLAS-FFPACK][2] and [Givaro][3].

The `.eb` files build successfully with toolchains `foss-2016a` and
`foss-2015a`, and probably with any other toolchain that can
successfully build GMP and supports C++11.

[1]: http://linalg.org/
[2]: http://github.com/linbox-team/fflas-ffpack/
[3]: http://github.com/linbox-team/givaro/
