### PR TITLE
Use `env` wherever `preconfigopts` is used to set environmental vars

### DIFF
--- a/easybuild/easyconfigs/a/ABySS/ABySS-1.3.7-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/a/ABySS/ABySS-1.3.7-intel-2015a-Python-2.7.9.eb
@@ -31,7 +31,7 @@ dependencies = [
     ('Boost', '1.58.0', versionsuffix),
 ]
 
-preconfigopts = 'CPPFLAGS=-I$EBROOTSPARSEHASH/include'
+preconfigopts = 'env CPPFLAGS=-I$EBROOTSPARSEHASH/include'
 
 sanity_check_paths = {
     'files': ["bin/ABYSS", "bin/ABYSS-P"],

--- a/easybuild/easyconfigs/a/a2ps/a2ps-4.14-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/a/a2ps/a2ps-4.14-goalf-1.1.0-no-OFED.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('gperf', '3.0.4'),
 ]
 
-preconfigopts = 'EMACS=no'
+preconfigopts = 'env EMACS=no'
 configopts = '--with-gnu-gettext'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/a2ps/a2ps-4.14-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/a/a2ps/a2ps-4.14-goolf-1.4.10.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('gperf', '3.0.4'),
 ]
 
-preconfigopts = 'EMACS=no'
+preconfigopts = 'env EMACS=no'
 configopts = '--with-gnu-gettext'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/a2ps/a2ps-4.14-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/a/a2ps/a2ps-4.14-ictce-4.0.6.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('gperf', '3.0.4'),
 ]
 
-preconfigopts = 'EMACS=no'
+preconfigopts = 'env EMACS=no'
 configopts = '--with-gnu-gettext'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/a/a2ps/a2ps-4.14-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/a/a2ps/a2ps-4.14-ictce-5.3.0.eb
@@ -26,7 +26,7 @@ dependencies = [
     ('gperf', '3.0.4'),
 ]
 
-preconfigopts = 'EMACS=no'
+preconfigopts = 'env EMACS=no'
 configopts = '--with-gnu-gettext'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.2-binutils-2.25.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.2-binutils-2.25.eb
@@ -21,7 +21,7 @@ builddependencies = [
 ]
 
 # statically link with zlib, to avoid runtime dependency on zlib
-preconfigopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
 prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
 
 # make sure that system libraries are also considered by ld and ld.gold is also built

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.2.eb
@@ -20,7 +20,7 @@ builddependencies = [
 ]
 
 # statically link with zlib, to avoid runtime dependency on zlib
-preconfigopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
 prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
 
 # make sure that system libraries are also considered by ld and ld.gold is also built

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.3-binutils-2.25.eb
@@ -21,7 +21,7 @@ builddependencies = [
 ]
 
 # statically link with zlib, to avoid runtime dependency on zlib
-preconfigopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
 prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
 
 # make sure that system libraries are also considered by ld and ld.gold is also built

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.3.eb
@@ -20,7 +20,7 @@ builddependencies = [
 ]
 
 # statically link with zlib, to avoid runtime dependency on zlib
-preconfigopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
 prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
 
 # make sure that system libraries are also considered by ld and ld.gold is also built

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-5.1.0-binutils-2.25.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-5.1.0-binutils-2.25.eb
@@ -21,7 +21,7 @@ builddependencies = [
 ]
 
 # statically link with zlib, to avoid runtime dependency on zlib
-preconfigopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
 prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
 
 # make sure that system libraries are also considered by ld and ld.gold is also built

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCCcore-4.9.3.eb
@@ -22,7 +22,7 @@ builddependencies = [
 ]
 
 # statically link with zlib, to avoid runtime dependency on zlib
-preconfigopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
 prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
 
 # make sure that system libraries are also considered by ld and ld.gold is also built

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25.1.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25.1.eb
@@ -21,7 +21,7 @@ builddependencies = [
 # statically link with zlib, to avoid runtime dependency on zlib
 # further, add the system library path in the rpath: this should 'harden' the
 # resulting binutils to bootstrap GCC (no trouble when other libstdc++ is build etc)
-preconfigopts = 'LIBS="$EBROOTZLIB/lib/libz.a -Wl,-rpath=/lib64 -Wl,-rpath=/usr/lib64 -Wl,-rpath=/lib -Wl,-rpath=/usr/lib"'
+preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a -Wl,-rpath=/lib64 -Wl,-rpath=/usr/lib64 -Wl,-rpath=/lib -Wl,-rpath=/usr/lib"'
 prebuildopts = preconfigopts
 
 # make sure that system libraries are also considered by ld and ld.gold is also built

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25.eb
@@ -22,7 +22,7 @@ builddependencies = [
 # statically link with zlib, to avoid runtime dependency on zlib
 # further, add the system library path in the rpath: this should 'harden' the
 # resulting binutils to bootstrap GCC (no trouble when other libstdc++ is build etc)
-preconfigopts = 'LIBS="$EBROOTZLIB/lib/libz.a -Wl,-rpath=/lib64 -Wl,-rpath=/usr/lib64 -Wl,-rpath=/lib -Wl,-rpath=/usr/lib"'
+preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a -Wl,-rpath=/lib64 -Wl,-rpath=/usr/lib64 -Wl,-rpath=/lib -Wl,-rpath=/usr/lib"'
 prebuildopts = preconfigopts
 
 # make sure that system libraries are also considered by ld and ld.gold is also built

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-1.3.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-1.3.0-goolf-1.4.10.eb
@@ -34,7 +34,7 @@ patches = [
     'cufflinks-1.x-ldflags.patch'
 ]
 
-preconfigopts = 'CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
+preconfigopts = 'env CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
 configopts = '--with-boost=$EBROOTBOOST --with-bam-libdir=${EBROOTSAMTOOLS}/lib'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.0.2-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.0.2-goalf-1.1.0-no-OFED.eb
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 configopts = '--with-boost=$EBROOTBOOST --with-bam-libdir=${EBROOTSAMTOOLS}/lib'
-preconfigopts = 'CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
+preconfigopts = 'env CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
 
 sanity_check_paths = {
     'files': ['bin/cufflinks'],

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.0.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.0.2-goolf-1.4.10.eb
@@ -32,7 +32,7 @@ dependencies = [
 patches = ['Cufflinks_GCC-4.7.patch']
 
 configopts = '--with-boost=$EBROOTBOOST --with-bam-libdir=${EBROOTSAMTOOLS}/lib'
-preconfigopts = 'CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
+preconfigopts = 'env CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
 
 sanity_check_paths = {
     'files': ['bin/cufflinks'],

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.0.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.0.2-ictce-5.3.0.eb
@@ -34,7 +34,7 @@ dependencies = [
 
 configopts = '--with-boost=$EBROOTBOOST --with-bam-libdir=${EBROOTSAMTOOLS}/lib'
 configopts += ' --enable-intel64 '
-preconfigopts = 'CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
+preconfigopts = 'env CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
 
 sanity_check_paths = {
     'files': ['bin/cufflinks'],

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.1.1-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.1.1-ictce-5.5.0.eb
@@ -33,7 +33,7 @@ dependencies = [
 ]
 
 configopts = '--enable-intel64 --with-boost=$EBROOTBOOST --with-bam-libdir=${EBROOTSAMTOOLS}/lib'
-preconfigopts = 'CPPFLAGS=-I$EBROOTEIGEN/include'
+preconfigopts = 'env CPPFLAGS=-I$EBROOTEIGEN/include'
 
 sanity_check_paths = {
     'files': ['bin/cufflinks'],

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.2.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.2.1-foss-2015a.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
-preconfigopts = 'CPPFLAGS=-I$EBROOTEIGEN/include'
+preconfigopts = 'env CPPFLAGS=-I$EBROOTEIGEN/include'
 configopts = '--with-boost=$EBROOTBOOST --with-bam-libdir=${EBROOTSAMTOOLS}/lib'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.2.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.2.1-goolf-1.4.10.eb
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 configopts = '--with-boost=$EBROOTBOOST --with-bam-libdir=${EBROOTSAMTOOLS}/lib'
-preconfigopts = 'CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
+preconfigopts = 'env CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
 
 sanity_check_paths = {
     'files': ['bin/cufflinks'],

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.2.1-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.2.1-goolf-1.7.20.eb
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 configopts = '--with-boost=$EBROOTBOOST --with-bam-libdir=${EBROOTSAMTOOLS}/lib'
-preconfigopts = 'CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
+preconfigopts = 'env CPPFLAGS="-I$EBROOTEIGEN/include $CPPFLAGS" LDFLAGS="-lboost_system $LDFLAGS" '
 
 sanity_check_paths = {
     'files': ['bin/cufflinks'],

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.2.1-intel-2015a.eb
@@ -19,7 +19,7 @@ dependencies = [
 ]
 
 configopts = '--enable-intel64 --with-boost=$EBROOTBOOST --with-bam-libdir=${EBROOTSAMTOOLS}/lib'
-preconfigopts = 'CPPFLAGS=-I$EBROOTEIGEN/include'
+preconfigopts = 'env CPPFLAGS=-I$EBROOTEIGEN/include'
 
 sanity_check_paths = {
     'files': ['bin/cufflinks'],

--- a/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.2.1-intel-2015b-Python-2.7.10-Boost-1.59.0.eb
+++ b/easybuild/easyconfigs/c/Cufflinks/Cufflinks-2.2.1-intel-2015b-Python-2.7.10-Boost-1.59.0.eb
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 configopts = '--enable-intel64 --with-boost=$EBROOTBOOST --with-bam-libdir=${EBROOTSAMTOOLS}/lib'
-preconfigopts = 'CPPFLAGS=-I${EBROOTEIGEN}/include'
+preconfigopts = 'env CPPFLAGS=-I${EBROOTEIGEN}/include'
 
 sanity_check_paths = {
     'files': ['bin/cufflinks'],

--- a/easybuild/easyconfigs/g/grib_api/grib_api-1.10.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/grib_api/grib_api-1.10.0-goolf-1.4.10.eb
@@ -17,7 +17,7 @@ dependencies = [
     ('JasPer', '1.900.1'),
 ]
 
-preconfigopts = 'FC=$F90'
+preconfigopts = 'env FC=$F90'
 configopts = '--with-jasper=$EBROOTJASPER'
 
 parallel = 1

--- a/easybuild/easyconfigs/g/grib_api/grib_api-1.10.0-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/g/grib_api/grib_api-1.10.0-ictce-4.1.13.eb
@@ -17,7 +17,7 @@ dependencies = [
     ('JasPer', '1.900.1'),
 ]
 
-preconfigopts = 'FC=$F90'
+preconfigopts = 'env FC=$F90'
 configopts = '--with-jasper=$EBROOTJASPER'
 
 parallel = 1

--- a/easybuild/easyconfigs/g/grib_api/grib_api-1.10.0-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/g/grib_api/grib_api-1.10.0-ictce-5.3.0.eb
@@ -17,7 +17,7 @@ dependencies = [
     ('JasPer', '1.900.1'),
 ]
 
-preconfigopts = 'FC=$F90'
+preconfigopts = 'env FC=$F90'
 configopts = '--with-jasper=$EBROOTJASPER'
 
 parallel = 1

--- a/easybuild/easyconfigs/g/grib_api/grib_api-1.9.18-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/g/grib_api/grib_api-1.9.18-goalf-1.1.0-no-OFED.eb
@@ -17,7 +17,7 @@ dependencies = [
     ('JasPer', '1.900.1'),
 ]
 
-preconfigopts = 'FC=$F90'
+preconfigopts = 'env FC=$F90'
 configopts = '--with-jasper=$EBROOTJASPER'
 
 parallel = 1

--- a/easybuild/easyconfigs/g/grib_api/grib_api-1.9.18-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/grib_api/grib_api-1.9.18-goolf-1.4.10.eb
@@ -16,7 +16,7 @@ dependencies = [
     ('JasPer', '1.900.1'),
 ]
 
-preconfigopts = 'FC=$F90'
+preconfigopts = 'env FC=$F90'
 configopts = '--with-jasper=$EBROOTJASPER'
 
 parallel = 1

--- a/easybuild/easyconfigs/g/grib_api/grib_api-1.9.18-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/g/grib_api/grib_api-1.9.18-ictce-4.1.13.eb
@@ -17,7 +17,7 @@ dependencies = [
     ('JasPer', '1.900.1'),
 ]
 
-preconfigopts = 'FC=$F90'
+preconfigopts = 'env FC=$F90'
 configopts = '--with-jasper=$EBROOTJASPER'
 
 parallel = 1

--- a/easybuild/easyconfigs/g/grib_api/grib_api-1.9.18-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/g/grib_api/grib_api-1.9.18-ictce-5.3.0.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('JasPer', '1.900.1'),
 ]
 
-preconfigopts = 'FC=$F90'
+preconfigopts = 'env FC=$F90'
 configopts = '--with-jasper=$EBROOTJASPER'
 
 parallel = 1

--- a/easybuild/easyconfigs/l/libdwarf/libdwarf-20140805-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/l/libdwarf/libdwarf-20140805-GCC-4.9.2.eb
@@ -15,7 +15,7 @@ source_urls = ['http://www.prevanders.net']
 dependencies = [('libelf', '0.8.13')]
 
 with_configure = True
-preconfigopts = 'CFLAGS="-fPIC $CFLAGS" '
+preconfigopts = 'env CFLAGS="-fPIC $CFLAGS" '
 configopts = "--enable-shared "
 
 # This is dirty but libdwarf cannot find it's own library in the build process...

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-GCC-4.7.2.eb
@@ -16,7 +16,7 @@ builddependencies = [
     ('xorg-macros', '1.17'),
 ]
 
-preconfigopts = "ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
+preconfigopts = "env ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
 
 sanity_check_paths = {
     'files': ['include/pciaccess.h', 'lib/libpciaccess.a'],

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-goalf-1.1.0-no-OFED.eb
@@ -16,7 +16,7 @@ builddependencies = [
     ('xorg-macros', '1.17'),
 ]
 
-preconfigopts = "ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
+preconfigopts = "env ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
 
 sanity_check_paths = {
     'files': ['include/pciaccess.h', 'lib/libpciaccess.a'],

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-goolf-1.4.10.eb
@@ -16,7 +16,7 @@ builddependencies = [
     ('xorg-macros', '1.17'),
 ]
 
-preconfigopts = "ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
+preconfigopts = "env ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
 
 sanity_check_paths = {
     'files': ['include/pciaccess.h', 'lib/libpciaccess.a'],

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-ictce-4.0.6.eb
@@ -16,7 +16,7 @@ builddependencies = [
     ('xorg-macros', '1.17'),
 ]
 
-preconfigopts = "ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
+preconfigopts = "env ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
 
 sanity_check_paths = {
     'files': ['include/pciaccess.h', 'lib/libpciaccess.a'],

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-ictce-4.1.13.eb
@@ -16,7 +16,7 @@ builddependencies = [
     ('xorg-macros', '1.17'),
 ]
 
-preconfigopts = "ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
+preconfigopts = "env ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
 
 sanity_check_paths = {
     'files': ['include/pciaccess.h', 'lib/libpciaccess.a'],

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-ictce-5.3.0.eb
@@ -16,7 +16,7 @@ builddependencies = [
     ('xorg-macros', '1.17'),
 ]
 
-preconfigopts = "ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
+preconfigopts = "env ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
 
 sanity_check_paths = {
     'files': ['include/pciaccess.h', 'lib/libpciaccess.a'],

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-ictce-5.5.0.eb
@@ -16,7 +16,7 @@ builddependencies = [
     ('xorg-macros', '1.17'),
 ]
 
-preconfigopts = "ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
+preconfigopts = "env ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
 
 sanity_check_paths = {
     'files': ['include/pciaccess.h', 'lib/libpciaccess.a'],

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-intel-2015a.eb
@@ -16,7 +16,7 @@ builddependencies = [
     ('xorg-macros', '1.17'),
 ]
 
-preconfigopts = "ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
+preconfigopts = "env ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
 
 sanity_check_paths = {
     'files': ['include/pciaccess.h', 'lib/libpciaccess.a'],

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.3-intel-2015a.eb
@@ -16,7 +16,7 @@ builddependencies = [
     ('xorg-macros', '1.19.0'),
 ]
 
-preconfigopts = "ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
+preconfigopts = "env ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
 
 sanity_check_paths = {
     'files': ['include/pciaccess.h', 'lib/libpciaccess.a'],

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-gimkl-2.11.5.eb
@@ -16,7 +16,7 @@ builddependencies = [
     ('xorg-macros', '1.19.0'),
 ]
 
-preconfigopts = "ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
+preconfigopts = "env ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
 
 sanity_check_paths = {
     'files': ['include/pciaccess.h', 'lib/libpciaccess.a'],

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-intel-2015b.eb
@@ -16,7 +16,7 @@ builddependencies = [
     ('xorg-macros', '1.19.0'),
 ]
 
-preconfigopts = "ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
+preconfigopts = "env ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
 
 sanity_check_paths = {
     'files': ['include/pciaccess.h', 'lib/libpciaccess.a'],

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-intel-2016a.eb
@@ -16,7 +16,7 @@ builddependencies = [
     ('xorg-macros', '1.19.0'),
 ]
 
-preconfigopts = "ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
+preconfigopts = "env ACLOCAL='aclocal -I $EBROOTXORGMINMACROS/share/aclocal' ./autogen.sh && "
 
 sanity_check_paths = {
     'files': ['include/pciaccess.h', 'lib/libpciaccess.a'],

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmpolf-1.1.6.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmpolf-1.1.6.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9-20130406')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmvolf-1.1.12rc1.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmvolf-1.1.12rc1.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9-20130406')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmvolf-1.2.7.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgmvolf-1.2.7.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9-20130406')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgoolf-1.1.7.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-cgoolf-1.1.7.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9-20130406')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-foss-2015b.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-foss-2015b.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmpolf-1.4.8.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmpolf-1.4.8.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmvolf-1.7.12.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmvolf-1.7.12.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9-20130406')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmvolf-1.7.12rc1.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gmvolf-1.7.12rc1.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9-20130406')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goalf-1.1.0-no-OFED.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goalf-1.5.12-no-OFED.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goalf-1.5.12-no-OFED.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gompi-1.4.12-no-OFED.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-gompi-1.4.12-no-OFED.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goolf-1.4.10.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-goolf-1.5.14.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.0.10.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.0.10.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.0.6.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-4.1.13.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.2.0.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.3.0.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.4.0.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-ictce-5.5.0.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-intel-2015a.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iomkl-4.6.13.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iomkl-4.6.13.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iqacml-3.7.3.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iqacml-3.7.3.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iqacml-4.4.13.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.2-iqacml-4.4.13.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-CrayGNU-2015.06.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-CrayGNU-2015.11.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GCC-4.8.2.eb
@@ -17,7 +17,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GCC-4.9.2.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GCCcore-4.9.3.eb
@@ -19,7 +19,7 @@ builddependencies = [('binutils', '2.25')]
 dependencies = [('ncurses', '6.0')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-GNU-4.9.3-2.25.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2014b.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2014b.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015.05.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015.05.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015a.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015a.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015b.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2015b.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2016a.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '6.0')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-gimkl-2.11.5.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-gompi-1.5.16.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-gompi-1.5.16.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-goolf-1.4.10.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-goolf-1.5.14.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-goolf-1.7.20.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-6.2.5.eb
@@ -20,7 +20,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-6.3.5.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-6.3.5.eb
@@ -20,7 +20,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-7.1.2.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-ictce-7.3.5.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2014.06.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2014.06.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2014b.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2014b.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2015a.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2015b.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '5.9')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2016a.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '6.0')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9-iccifort-2011.13.367.eb
+++ b/easybuild/easyconfigs/m/MVAPICH2/MVAPICH2-1.9-iccifort-2011.13.367.eb
@@ -15,6 +15,6 @@ checksums = ['5dc58ed08fd3142c260b70fe297e127c']
 builddependencies = [('Bison', '2.7')]
 
 # the hydra launcher start's before LD_LIBRARY_PATH is forwarded, so we provide this hint on where to find some libs
-preconfigopts = 'LDFLAGS="-Wl,-rpath,$EBROOTICC/compiler/lib/intel64 $LDFLAGS"'
+preconfigopts = 'env LDFLAGS="-Wl,-rpath,$EBROOTICC/compiler/lib/intel64 $LDFLAGS"'
 
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.1.4-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.1.4-foss-2015b.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('libmatheval', '1.1.11'),
 ]
 
-preconfigopts = 'FC=$MPIF90 LIBS="$LIBLAPACK $LIBS" '
+preconfigopts = 'env FC=$MPIF90 LIBS="$LIBLAPACK $LIBS" '
 configopts = ' --exec-prefix=%(installdir)s --enable-gsl'
 prebuildopts = 'source sourceme.sh && '
 

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.2.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.2.0-intel-2015b.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('libmatheval', '1.1.11'),
 ]
 
-preconfigopts = 'FC=$MPIF90 LIBS="$LIBLAPACK $LIBS" '
+preconfigopts = 'env FC=$MPIF90 LIBS="$LIBLAPACK $LIBS" '
 configopts = ' --exec-prefix=%(installdir)s --enable-gsl'
 prebuildopts = 'source sourceme.sh && '
 

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.2.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.2.1-foss-2015b.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('libmatheval', '1.1.11'),
 ]
 
-preconfigopts = 'FC=$MPIF90 LIBS="$LIBLAPACK $LIBS" '
+preconfigopts = 'env FC=$MPIF90 LIBS="$LIBLAPACK $LIBS" '
 configopts = ' --exec-prefix=%(installdir)s --enable-gsl'
 prebuildopts = 'source sourceme.sh && '
 

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.2.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.2.1-intel-2015b.eb
@@ -25,7 +25,7 @@ dependencies = [
     ('libmatheval', '1.1.11'),
 ]
 
-preconfigopts = 'FC=$MPIF90 LIBS="$LIBLAPACK $LIBS" '
+preconfigopts = 'env FC=$MPIF90 LIBS="$LIBLAPACK $LIBS" '
 configopts = ' --exec-prefix=%(installdir)s --enable-gsl'
 prebuildopts = 'source sourceme.sh && '
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-ictce-7.1.2.eb
@@ -14,7 +14,7 @@ source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
 
 configopts = ' --enable-unicode=ucs4 '
-preconfigopts = ' LDFLAGS="-lstdc++" '
+preconfigopts = 'env LDFLAGS="-lstdc++" '
 
 # libffi build in python is still broken, see http://bugs.python.org/issue4130
 patches = ['python-2.7_libffi-include-xmmintrin.patch']

--- a/easybuild/easyconfigs/r/ROOT/ROOT-v5.34.26-intel-2015a.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-v5.34.26-intel-2015a.eb
@@ -34,7 +34,7 @@ dependencies = [
 ]
 
 # use external ZLIB
-preconfigopts = 'ZLIB=$EBROOTZLIB '
+preconfigopts = 'env ZLIB=$EBROOTZLIB '
 
 # architecture
 arch = 'linuxx8664icc'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-v5.34.34-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-v5.34.34-intel-2016a-Python-2.7.11.eb
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 # use external ZLIB
-preconfigopts = 'ZLIB=$EBROOTZLIB '
+preconfigopts = 'env ZLIB=$EBROOTZLIB '
 
 # architecture
 arch = 'linuxx8664icc'

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-goalf-1.1.0-no-OFED.eb
@@ -29,7 +29,7 @@ source_urls = ['http://www.tbi.univie.ac.at/~ronny/RNA']
 configopts = '--without-perl'
 # Alternatively, you may want to use the following to copy the perl-module to a "local" directory
 # Code NOT yet tested, therefor left here for future recycling
-#preconfigopts = 'PERLPREFIX="/path/where/the/perl/module/shoud/go"'
+#preconfigopts = 'env PERLPREFIX="/path/where/the/perl/module/shoud/go"'
 
 sanity_check_paths = {
     'files': ['bin/RNA%s' % x for x in ['fold', 'eval', 'heat', 'pdist', 'distance',

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-goolf-1.4.10.eb
@@ -29,7 +29,7 @@ source_urls = ['http://www.tbi.univie.ac.at/~ronny/RNA']
 configopts = '--without-perl'
 # Alternatively, you may want to use the following to copy the perl-module to a "local" directory
 # Code NOT yet tested, therefor left here for future recycling
-#preconfigopts = 'PERLPREFIX="/path/where/the/perl/module/shoud/go"'
+#preconfigopts = 'env PERLPREFIX="/path/where/the/perl/module/shoud/go"'
 
 sanity_check_paths = {
     'files': ['bin/RNA%s' % x for x in ['fold', 'eval', 'heat', 'pdist', 'distance',

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-ictce-4.0.6.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-ictce-4.0.6.eb
@@ -31,7 +31,7 @@ patches = ['ViennaRNA_ictce-pragma.patch']
 configopts = '--without-perl'
 # Alternatively, you may want to use the following to copy the perl-module to a "local" directory
 # Code NOT yet tested, therefor left here for future recycling
-#preconfigopts = 'PERLPREFIX="/path/where/the/perl/module/shoud/go"'
+#preconfigopts = 'env PERLPREFIX="/path/where/the/perl/module/shoud/go"'
 
 sanity_check_paths = {
     'files': ['bin/RNA%s' % x for x in ['fold', 'eval', 'heat', 'pdist', 'distance',

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-ictce-5.3.0.eb
@@ -32,7 +32,7 @@ patches = ['ViennaRNA_ictce-pragma.patch']
 configopts = '--without-perl'
 # Alternatively, you may want to use the following to copy the perl-module to a "local" directory
 # Code NOT yet tested, therefor left here for future recycling
-#preconfigopts = 'PERLPREFIX="/path/where/the/perl/module/shoud/go"'
+#preconfigopts = 'env PERLPREFIX="/path/where/the/perl/module/shoud/go"'
 
 sanity_check_paths = {
     'files': ['bin/RNA%s' % x for x in ['fold', 'eval', 'heat', 'pdist', 'distance',

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.1.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.1.6-ictce-5.5.0.eb
@@ -31,7 +31,7 @@ patches = ['ViennaRNA-2.1.6_ictce.patch']
 configopts = '--without-perl'
 # Alternatively, you may want to use the following to copy the perl-module to a "local" directory
 # Code NOT yet tested, therefor left here for future recycling
-#preconfigopts = 'PERLPREFIX="/path/where/the/perl/module/shoud/go"'
+#preconfigopts = 'env PERLPREFIX="/path/where/the/perl/module/shoud/go"'
 
 sanity_check_paths = {
     'files': ['bin/RNA%s' % x for x in ['fold', 'eval', 'heat', 'pdist', 'distance',


### PR DESCRIPTION
Without `env`, we are relying on a syntactical feature of Bourne-type
shells; the `env` utility guarantees that the command-line will continue
to work even with other shells (e.g., `tcsh`).
