### PR TITLE
Use `env` wherever `prebuildopts is used to set environmental variables.

### DIFF
--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.2-binutils-2.25.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.2-binutils-2.25.eb
@@ -22,7 +22,7 @@ builddependencies = [
 
 # statically link with zlib, to avoid runtime dependency on zlib
 preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
-prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+prebuildopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
 
 # make sure that system libraries are also considered by ld and ld.gold is also built
 # --enable-plugins should be used whenever --enable-gold is used, see http://llvm.org/docs/GoldPlugin.html

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.2.eb
@@ -21,7 +21,7 @@ builddependencies = [
 
 # statically link with zlib, to avoid runtime dependency on zlib
 preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
-prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+prebuildopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
 
 # make sure that system libraries are also considered by ld and ld.gold is also built
 # --enable-plugins should be used whenever --enable-gold is used, see http://llvm.org/docs/GoldPlugin.html

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.3-binutils-2.25.eb
@@ -22,7 +22,7 @@ builddependencies = [
 
 # statically link with zlib, to avoid runtime dependency on zlib
 preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
-prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+prebuildopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
 
 # make sure that system libraries are also considered by ld and ld.gold is also built
 # --enable-plugins should be used whenever --enable-gold is used, see http://llvm.org/docs/GoldPlugin.html

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-4.9.3.eb
@@ -21,7 +21,7 @@ builddependencies = [
 
 # statically link with zlib, to avoid runtime dependency on zlib
 preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
-prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+prebuildopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
 
 # make sure that system libraries are also considered by ld and ld.gold is also built
 # --enable-plugins should be used whenever --enable-gold is used, see http://llvm.org/docs/GoldPlugin.html

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-5.1.0-binutils-2.25.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCC-5.1.0-binutils-2.25.eb
@@ -22,7 +22,7 @@ builddependencies = [
 
 # statically link with zlib, to avoid runtime dependency on zlib
 preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
-prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+prebuildopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
 
 # make sure that system libraries are also considered by ld and ld.gold is also built
 # --enable-plugins should be used whenever --enable-gold is used, see http://llvm.org/docs/GoldPlugin.html

--- a/easybuild/easyconfigs/b/binutils/binutils-2.25-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.25-GCCcore-4.9.3.eb
@@ -23,7 +23,7 @@ builddependencies = [
 
 # statically link with zlib, to avoid runtime dependency on zlib
 preconfigopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
-prebuildopts = 'LIBS="$EBROOTZLIB/lib/libz.a"'
+prebuildopts = 'env LIBS="$EBROOTZLIB/lib/libz.a"'
 
 # make sure that system libraries are also considered by ld and ld.gold is also built
 # --enable-plugins should be used whenever --enable-gold is used, see http://llvm.org/docs/GoldPlugin.html

--- a/easybuild/easyconfigs/f/FDS/FDS-6.3.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-6.3.0-intel-2015b.eb
@@ -23,7 +23,7 @@ start_dir = 'FDS_Compilation'
 skipsteps = ['configure', 'install']
 buildininstalldir = True
 
-prebuildopts = 'FFLAGS="$FFLAGS -fpp"'
+prebuildopts = 'env FFLAGS="$FFLAGS -fpp"'
 
 modextrapaths = {'PATH': 'FDS_Compilation'}
 

--- a/easybuild/easyconfigs/m/Mesa/Mesa-10.4.5-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-10.4.5-intel-2015a-Python-2.7.9.eb
@@ -59,7 +59,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --disable-egl"
 # package-config files for os dependencies are in an os specific place
 #preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-10.5.5-intel-2015a-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-10.5.5-intel-2015a-Python-2.7.10.eb
@@ -57,7 +57,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='swrast' --disabl
 #preconfigopts = 'libtoolize && PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 preconfigopts = ' libtoolize &&  '
 
-prebuildopts = 'CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libOSMesa.%s' % SHLIB_EXT,

--- a/easybuild/easyconfigs/m/Mesa/Mesa-11.0.2-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-11.0.2-intel-2015b-Python-2.7.10.eb
@@ -56,7 +56,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='swrast' --disabl
 #preconfigopts = 'libtoolize && PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 preconfigopts = ' libtoolize &&  '
 
-prebuildopts = 'CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libOSMesa.%s' % SHLIB_EXT,

--- a/easybuild/easyconfigs/m/Mesa/Mesa-11.0.8-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-11.0.8-intel-2015b-Python-2.7.11.eb
@@ -56,7 +56,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='swrast' --disabl
 #preconfigopts = 'libtoolize && PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 preconfigopts = ' libtoolize &&  '
 
-prebuildopts = 'CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.so', 'lib/libOSMesa.so',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-11.1.2-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-11.1.2-gimkl-2.11.5.eb
@@ -53,7 +53,7 @@ configopts += " --with-osmesa-bits=32 --enable-texture-float "
 #preconfigopts = 'libtoolize && PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 preconfigopts = ' libtoolize &&  '
 
-prebuildopts = 'CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libOSMesa.%s' % SHLIB_EXT, 'lib/libGLESv1_CM.%s' % SHLIB_EXT,

--- a/easybuild/easyconfigs/m/Mesa/Mesa-11.1.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-11.1.2-intel-2016a.eb
@@ -53,7 +53,7 @@ configopts += " --with-osmesa-bits=32 --enable-texture-float "
 #preconfigopts = 'libtoolize && PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 preconfigopts = ' libtoolize &&  '
 
-prebuildopts = 'CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libOSMesa.%s' % SHLIB_EXT, 'lib/libGLESv1_CM.%s' % SHLIB_EXT,

--- a/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -44,7 +44,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --without-demo
 # package-config files for os dependencies are in an os specific place
 preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libGLU.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-goolf-1.4.10-Python-2.7.3.eb
@@ -43,7 +43,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --without-demo
 # package-config files for os dependencies are in an os specific place
 preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libGLU.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-4.0.6-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-4.0.6-Python-2.7.3.eb
@@ -44,7 +44,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --without-demo
 # package-config files for os dependencies are in an os specific place
 preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libGLU.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-4.1.13-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-4.1.13-Python-2.7.3.eb
@@ -44,7 +44,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --without-demo
 # package-config files for os dependencies are in an os specific place
 preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libGLU.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-5.3.0-Python-2.7.3.eb
@@ -45,7 +45,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --without-demo
 # package-config files for os dependencies are in an os specific place
 preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libGLU.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-5.5.0-Python-2.7.6.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-5.5.0-Python-2.7.6.eb
@@ -45,7 +45,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --without-demo
 # package-config files for os dependencies are in an os specific place
 preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libGLU.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',

--- a/easybuild/easyconfigs/m/Minimac3/Minimac3-1.0.10-foss-2015a.eb
+++ b/easybuild/easyconfigs/m/Minimac3/Minimac3-1.0.10-foss-2015a.eb
@@ -15,7 +15,7 @@ sources = ['%(name)s.v%(version)s.tar.gz']
 
 dependencies = [('zlib', '1.2.8')]
 
-prebuildopts = 'CFLAGS="$CFLAGS -L$EBROOTZLIB/lib"'
+prebuildopts = 'env CFLAGS="$CFLAGS -L$EBROOTZLIB/lib"'
 buildopts = 'CC="$CC" CXX="$CXX" F77="$F77" OPTFLAG_OPT="$CFLAGS"'
 
 files_to_copy = [(['bin/Minimac3'], 'bin')]

--- a/easybuild/easyconfigs/m/Minimac3/Minimac3-1.0.10-intel-2015a.eb
+++ b/easybuild/easyconfigs/m/Minimac3/Minimac3-1.0.10-intel-2015a.eb
@@ -15,7 +15,7 @@ sources = ['%(name)s.v%(version)s.tar.gz']
 
 dependencies = [('zlib', '1.2.8')]
 
-prebuildopts = 'CFLAGS="$CFLAGS -wd751 -L$EBROOTZLIB/lib"'
+prebuildopts = 'env CFLAGS="$CFLAGS -wd751 -L$EBROOTZLIB/lib"'
 buildopts = 'CC="$CC" CXX="$CXX" F77="$F77" OPTFLAG_OPT="$CFLAGS"'
 
 files_to_copy = [(['bin/Minimac3'], 'bin')]

--- a/easybuild/easyconfigs/m/motif/motif-2.2.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/m/motif/motif-2.2.4-goolf-1.4.10.eb
@@ -38,7 +38,7 @@ builddependencies = [
 ]
 
 # make has problems with utf8
-prebuildopts = "LANG=C "
+prebuildopts = "env LANG=C "
 
 # motif ships a broken automake and libtool
 preconfigopts = "rm -f libtool install-sh missing depcomp config.guess config.sub && "

--- a/easybuild/easyconfigs/m/motif/motif-2.2.4-ictce-4.1.13.eb
+++ b/easybuild/easyconfigs/m/motif/motif-2.2.4-ictce-4.1.13.eb
@@ -38,7 +38,7 @@ dependencies = [
 ]
 
 # make has problems with utf8
-prebuildopts = "LANG=C "
+prebuildopts = "env LANG=C "
 
 # motif ships a broken automake and libtool
 preconfigopts = "rm -f libtool install-sh missing depcomp config.guess config.sub && "

--- a/easybuild/easyconfigs/m/multitail/multitail-6.2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/m/multitail/multitail-6.2.1-intel-2015a.eb
@@ -21,7 +21,7 @@ files_to_copy = [
 
 dependencies = [("ncurses", "5.9")]
 
-prebuildopts = 'DESTDIR=%(installdir)s '
+prebuildopts = 'env DESTDIR=%(installdir)s '
 
 sanity_check_paths = {
     'files': ['bin/multitail'],


### PR DESCRIPTION
As requested by @boegel in PR #2807 