### PR TITLE
Use `env` wherever `preinstallopts` is used to set env. vars

### DIFF
--- a/easybuild/easyconfigs/p/p4vasp/p4vasp-0.3.29-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/p4vasp/p4vasp-0.3.29-intel-2016a-Python-2.7.11.eb
@@ -22,7 +22,7 @@ dependencies = [
 skipsteps = ['configure', 'build']
 
 # redefine $HOME to specify installation prefix O_o
-preinstallopts = "HOME=%(installdir)s make local &&"
+preinstallopts = "env HOME=%(installdir)s make local &&"
 
 sanity_check_paths = {
     'files': ['p4vasp/bin/p4v', 'p4vasp/lib/libODP.a', 'p4vasp/lib/libp4vasp.a'],


### PR DESCRIPTION
As requested by @boegel in PR #2807 