### PR TITLE
add easyconfig for SoX

### DIFF
--- a/easybuild/easyconfigs/s/SoX/SoX-14.4.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/s/SoX/SoX-14.4.2-foss-2015a.eb
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 sanity_check_paths = {
-    'files': ['bin/sox', 'include/sox.h', 'lib/libsox.so'],
+    'files': ['bin/sox', 'include/sox.h', 'lib/libsox.%s' % SHLIB_EXT],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/s/SoX/SoX-14.4.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/s/SoX/SoX-14.4.2-foss-2015a.eb
@@ -1,0 +1,31 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Author:    Stephane Thiell <sthiell@stanford.edu>
+###
+
+easyblock = 'ConfigureMake'
+
+name = 'SoX'
+version = '14.4.2'
+
+homepage = 'http://http://sox.sourceforge.net/'
+description = """Sound eXchange, the Swiss Army knife of audio manipulation"""
+
+toolchain = {'name': 'foss', 'version': '2015a'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://sourceforge.net/projects/sox/files/sox/%(version)s']
+
+# These are not strictly mandatory but add flac and mp3 support to SoX
+dependencies = [
+    ('FLAC', '1.3.1'),
+    ('LAME', '3.99.5')
+]
+
+sanity_check_paths = {
+    'files': ['bin/sox', 'include/sox.h', 'lib/libsox.so'],
+    'dirs': [],
+}
+
+moduleclass = 'data'


### PR DESCRIPTION
libsox is used to manipulate audio files and required for installing Torch (I'm working on an easyconfig)

And yes, it's for HPC, thanks Deep Learning...

edit: depends on ~~#2823~~, ~~#2824~~