### PR TITLE
Builddependencies fixed for GObject-introspection

### DIFF
--- a/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.42.0-intel-2014b.eb
+++ b/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.42.0-intel-2014b.eb
@@ -18,9 +18,11 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('Python', '2.7.8'),
     ('GLib', '2.40.0'),
-    ('Bison', '3.0.2'),
 ]
 
+builddependencies = [
+    ('Bison', '3.0.2'),
+]
 sanity_check_paths = {
     'files': ['bin/g-ir-%s' % x for x in ['annotation-tool', 'compiler', 'generate', 'scanner']] +
              ['lib/libgirepository-1.0.%s' % x for x in ['so', 'a']],

--- a/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.44.0-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.44.0-intel-2015a.eb
@@ -18,6 +18,9 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('Python', '2.7.10'),
     ('GLib', '2.44.1'),
+]
+
+builddependencies = [
     ('Bison', '3.0.4', '', ('GCC', '4.9.2')),
 ]
 

--- a/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.47.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.47.1-intel-2015b.eb
@@ -18,6 +18,9 @@ sources = [SOURCELOWER_TAR_XZ]
 dependencies = [
     ('Python', '2.7.10'),
     ('GLib', '2.47.1'),
+]
+
+builddependencies = [
     ('Bison', '3.0.4'),
 ]
 

--- a/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.47.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.47.1-intel-2016a.eb
@@ -20,13 +20,15 @@ pyver = '2.7.11'
 dependencies = [
     ('Python', pyver),
     ('GLib', '2.47.5'),
-    ('flex', '2.6.0'),
-    ('Bison', '3.0.4'),
-    ('cairo', '1.14.6'),
     ('libffi', '3.2.1'),
 ]
 
-builddependencies = [('Autotools', '20150215')]
+builddependencies = [
+    ('Autotools', '20150215'),
+    ('flex', '2.6.0'),
+    ('Bison', '3.0.4'),
+    ('cairo', '1.14.6'),
+]
 
 preconfigopts = "GI_SCANNER_DISABLE_CACHE=true "
 


### PR DESCRIPTION
Check:
https://packages.debian.org/source/sid/gobject-introspection
and
https://packages.debian.org/sid/gobject-introspection
