### PR TITLE
Numpy 1.11.0

### DIFF
--- a/easybuild/easyconfigs/n/numpy/numpy-1.11.0-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/n/numpy/numpy-1.11.0-intel-2016a-Python-2.7.11.eb
@@ -1,0 +1,26 @@
+name = 'numpy'
+version = '1.11.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.numpy.org'
+description = """NumPy is the fundamental package for scientific computing with Python. It contains among other things:
+ a powerful N-dimensional array object, sophisticated (broadcasting) functions, tools for integrating C/C++ and Fortran
+ code, useful linear algebra, Fourier transform, and random number capabilities. Besides its obvious scientific uses,
+ NumPy can also be used as an efficient multi-dimensional container of generic data. Arbitrary data-types can be 
+ defined. This allows NumPy to seamlessly and speedily integrate with a wide variety of databases."""
+
+toolchain = {'name': 'intel', 'version': '2016a'}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+patches = [
+    'numpy-1.8.0-mkl.patch',
+    'numpy-%(version)s-sse42.patch',
+]
+
+dependencies = [
+    ('Python', '2.7.11'),
+]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/n/numpy/numpy-1.11.0-sse42.patch
+++ b/easybuild/easyconfigs/n/numpy/numpy-1.11.0-sse42.patch
@@ -1,0 +1,25 @@
+#Remove hard coded -xSSE4.2 compilation flag for Intel compilers (add the usual -xHOST)
+#compilation would fail on non-SSE4.2 CPUs, and for further CPUs/compilers it would restrict the generated code to SSE4.2
+# February 19th, 2016 by B. Hajgato - Free University Brussels (VUB)
+--- ./numpy/distutils/intelccompiler.py.orig	2016-01-06 22:07:54.000000000 +0100
++++ ./numpy/distutils/intelccompiler.py	2016-02-19 15:07:00.438235792 +0100
+@@ -54,7 +54,7 @@
+     def __init__(self, verbose=0, dry_run=0, force=0):
+         UnixCCompiler.__init__(self, verbose, dry_run, force)
+         self.cc_exe = ('icc -m64 -fPIC -fp-model strict -O3 '
+-                       '-fomit-frame-pointer -openmp -xSSE4.2')
++                       '-fomit-frame-pointer -openmp -xHOST')
+         compiler = self.cc_exe
+         if platform.system() == 'Darwin':
+             shared_flag = '-Wl,-undefined,dynamic_lookup'
+--- ./numpy/distutils/fcompiler/intel.py.orig	2016-01-07 03:16:25.000000000 +0100
++++ ./numpy/distutils/fcompiler/intel.py	2016-02-19 15:07:16.424220745 +0100
+@@ -123,7 +123,7 @@
+         return ['-openmp -fp-model strict']
+ 
+     def get_flags_arch(self):
+-        return ['-xSSE4.2']
++        return ['-xHOST']
+ 
+ # Is there no difference in the version string between the above compilers
+ # and the Visual compilers?


### PR DESCRIPTION
The change from distutils to setuptools in numpy 1.11.0 seems to cause problems. In the install step the package is seems to be installed in a path under /tmp, and the installation fails since the setup checks if that path is in $PYTHONPATH