### PR TITLE
add XZ as dependency in Python 3.5.1 easyconfigs, required for lzma

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2016a.eb
@@ -22,6 +22,7 @@ dependencies = [
     ('SQLite', '3.9.2'),
     ('Tk', '8.6.4', '-no-X11'),
     ('GMP', '6.1.0'),
+    ('XZ', '5.2.2'),
 #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
 #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-3.5.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.1-intel-2016a.eb
@@ -22,6 +22,7 @@ dependencies = [
     ('SQLite', '3.9.2'),
     ('Tk', '8.6.4', '-no-X11'),
     ('GMP', '6.1.0'),
+    ('XZ', '5.2.2'),
 #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
 #   nice to have an up to date openssl for security reasons
 ]


### PR DESCRIPTION
Issue encountered in https://github.com/hpcugent/easybuild-easyconfigs/pull/2885

cfr. http://www.devsumo.com/technotes/2013/04/building-python-3-3-with-lzma-on-linux-and-os-x/