### PR TITLE
Abinit-7.10.5 with intel-2016.02-GCC-4.9 toolchain

### DIFF
--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9-libxc.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9-libxc.eb
@@ -2,7 +2,7 @@ easyblock = 'ConfigureMake'
 
 name = 'ABINIT'
 version = "7.10.5"
-versionsuffix = "_libxc"
+versionsuffix = "-libxc"
 
 homepage = 'http://www.abinit.org/'
 description = """ABINIT is a package whose main program allows one to find the total energy,

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9-libxc.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9-libxc.eb
@@ -21,9 +21,6 @@ configopts = '--with-fc-vendor=intel --with-linalg-flavor=mkl --enable-mpi '
 configopts += '--with-fft-flavor=fftw3-mkl '
 configopts += '--with-fft-libs="$LIBFFT" '
 
-# there are variants (e.g. --with-dft-flavor), but is an easyconfig file needed for all?
-# eb --try-amend can be used to install those variants from the same easyconfig file...
-
 # libxc variant
 configopts += '--with-dft-flavor=libxc '
 

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
@@ -20,7 +20,7 @@ sources = [SOURCELOWER_TAR_GZ]
 # ensure mpi and intel toolchain
 configopts = '--with-fc-vendor=intel --with-linalg-flavor=mkl --enable-mpi ' \
              '--with-fft-flavor=fftw3-mkl ' \
-             '--with-fft-libs="-lmkl_intel_lp64 -lmkl_sequential -lmkl_core"'
+             '--with-fft-libs="$LIBFFT"' 
 
 # there are variants (e.g. --with-dft-flavor), but is an easyconfig file needed for all?
 # eb --try-amend can be used to install those variants from the same easyconfig file...

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
@@ -16,9 +16,9 @@ source_urls = ['http://ftp.abinit.org/']
 sources = [SOURCELOWER_TAR_GZ]
 
 # ensure mpi and intel toolchain
-configopts = '--with-fc-vendor=intel --with-linalg-flavor=mkl --enable-mpi ' \
-             '--with-fft-flavor=fftw3-mkl ' \
-             '--with-fft-libs="$LIBFFT"'
+configopts = '--with-fc-vendor=intel --with-linalg-flavor=mkl --enable-mpi '
+configopts += '--with-fft-flavor=fftw3-mkl '
+configopts += '--with-fft-libs="$LIBFFT"'
 
 # there are variants (e.g. --with-dft-flavor), but is an easyconfig file needed for all?
 # eb --try-amend can be used to install those variants from the same easyconfig file...

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
@@ -16,7 +16,6 @@ toolchainopts = {'usempi': True}
 
 source_urls = ['http://ftp.abinit.org/']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = []
 
 # ensure mpi and intel toolchain
 configopts = '--with-fc-vendor=intel --with-linalg-flavor=mkl --enable-mpi ' \

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
@@ -20,9 +20,6 @@ configopts = '--with-fc-vendor=intel --with-linalg-flavor=mkl --enable-mpi '
 configopts += '--with-fft-flavor=fftw3-mkl '
 configopts += '--with-fft-libs="$LIBFFT"'
 
-# there are variants (e.g. --with-dft-flavor), but is an easyconfig file needed for all?
-# eb --try-amend can be used to install those variants from the same easyconfig file...
-
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['abinit', 'aim', 'cut3d', 'conducti', 'mrgddb', 'mrgscr', 'optic']],
     'dirs': ['lib/pkgconfig'],

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
@@ -18,14 +18,13 @@ sources = [SOURCELOWER_TAR_GZ]
 # ensure mpi and intel toolchain
 configopts = '--with-fc-vendor=intel --with-linalg-flavor=mkl --enable-mpi ' \
              '--with-fft-flavor=fftw3-mkl ' \
-             '--with-fft-libs="$LIBFFT"' 
+             '--with-fft-libs="$LIBFFT"'
 
 # there are variants (e.g. --with-dft-flavor), but is an easyconfig file needed for all?
 # eb --try-amend can be used to install those variants from the same easyconfig file...
 
 sanity_check_paths = {
-    'files': ['bin/%s' % x for x in ['abinit', 'aim', 'cut3d',
-                                     'conducti', 'mrgddb', 'mrgscr', 'optic']],
+    'files': ['bin/%s' % x for x in ['abinit', 'aim', 'cut3d', 'conducti', 'mrgddb', 'mrgscr', 'optic']],
     'dirs': ['lib/pkgconfig'],
 }
 

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
@@ -1,5 +1,3 @@
-# initially generated with eb ABINIT-7.10.4-intel-2015a.eb --try-software-version=7.10.5
-# --try-toolchain=intel,2016.02-GCC-4.9, then added intel mpi and fft support
 easyblock = 'ConfigureMake'
 
 name = 'ABINIT'

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,24 @@
+# initially generated with eb ABINIT-7.10.4-intel-2015a.eb --try-software-version=7.10.5 
+# --try-toolchain=intel,2016.02-GCC-4.9, worked but it seems to at least lack mpi support
+easyblock = 'ConfigureMake'
+
+name = 'ABINIT'
+version = "7.10.5"
+
+homepage = 'http://www.abinit.org/'
+description = """ABINIT is a package whose main program allows one to find the total energy, charge density and
+ electronic structure of systems made of electrons and nuclei (molecules and periodic solids) within Density Functional
+ Theory (DFT), using pseudopotentials and a planewave or wavelet basis."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+
+source_urls = ['http://ftp.abinit.org/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = []
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['abinit', 'aim', 'cut3d', 'conducti', 'mrgddb', 'mrgscr', 'optic']],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'chem'
+

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9.eb
@@ -1,24 +1,35 @@
-# initially generated with eb ABINIT-7.10.4-intel-2015a.eb --try-software-version=7.10.5 
-# --try-toolchain=intel,2016.02-GCC-4.9, worked but it seems to at least lack mpi support
+# initially generated with eb ABINIT-7.10.4-intel-2015a.eb --try-software-version=7.10.5
+# --try-toolchain=intel,2016.02-GCC-4.9, then added intel mpi and fft support
 easyblock = 'ConfigureMake'
 
 name = 'ABINIT'
 version = "7.10.5"
 
 homepage = 'http://www.abinit.org/'
-description = """ABINIT is a package whose main program allows one to find the total energy, charge density and
- electronic structure of systems made of electrons and nuclei (molecules and periodic solids) within Density Functional
- Theory (DFT), using pseudopotentials and a planewave or wavelet basis."""
+description = """ABINIT is a package whose main program allows one to find the total energy,
+ charge density and  electronic structure of systems made of electrons and nuclei (molecules
+ and periodic solids) within Density Functional  Theory (DFT), using pseudopotentials and a
+ planewave or wavelet basis."""
 
 toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+toolchainopts = {'usempi': True}
 
 source_urls = ['http://ftp.abinit.org/']
 sources = [SOURCELOWER_TAR_GZ]
 checksums = []
+
+# ensure mpi and intel toolchain
+configopts = '--with-fc-vendor=intel --with-linalg-flavor=mkl --enable-mpi ' \
+             '--with-fft-flavor=fftw3-mkl ' \
+             '--with-fft-libs="-lmkl_intel_lp64 -lmkl_sequential -lmkl_core"'
+
+# there are variants (e.g. --with-dft-flavor), but is an easyconfig file needed for all?
+# eb --try-amend can be used to install those variants from the same easyconfig file...
+
 sanity_check_paths = {
-    'files': ['bin/%s' % x for x in ['abinit', 'aim', 'cut3d', 'conducti', 'mrgddb', 'mrgscr', 'optic']],
+    'files': ['bin/%s' % x for x in ['abinit', 'aim', 'cut3d',
+                                     'conducti', 'mrgddb', 'mrgscr', 'optic']],
     'dirs': ['lib/pkgconfig'],
 }
 
 moduleclass = 'chem'
-

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9_libxc.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-7.10.5-intel-2016.02-GCC-4.9_libxc.eb
@@ -1,0 +1,35 @@
+easyblock = 'ConfigureMake'
+
+name = 'ABINIT'
+version = "7.10.5"
+versionsuffix = "_libxc"
+
+homepage = 'http://www.abinit.org/'
+description = """ABINIT is a package whose main program allows one to find the total energy,
+ charge density and  electronic structure of systems made of electrons and nuclei (molecules
+ and periodic solids) within Density Functional  Theory (DFT), using pseudopotentials and a
+ planewave or wavelet basis."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['http://ftp.abinit.org/']
+sources = [SOURCELOWER_TAR_GZ]
+
+# ensure mpi and intel toolchain
+configopts = '--with-fc-vendor=intel --with-linalg-flavor=mkl --enable-mpi '
+configopts += '--with-fft-flavor=fftw3-mkl '
+configopts += '--with-fft-libs="$LIBFFT" '
+
+# there are variants (e.g. --with-dft-flavor), but is an easyconfig file needed for all?
+# eb --try-amend can be used to install those variants from the same easyconfig file...
+
+# libxc variant
+configopts += '--with-dft-flavor=libxc '
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['abinit', 'aim', 'cut3d', 'conducti', 'mrgddb', 'mrgscr', 'optic']],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
Initially generated with "eb ABINIT-7.10.4-intel-2015a.eb --try-software-version=7.10.5
 --try-toolchain=intel,2016.02-GCC-4.9", then ensured intel mpi and fft support