### PR TITLE
Python-2.7.11 (and dependencies) with intel-2016.02-GCC-4.9 toolchain

### DIFF
--- a/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'Autoconf'
+version = '2.69'
+
+homepage = 'http://www.gnu.org/software/autoconf/'
+description = """Autoconf is an extensible package of M4 macros that produce shell scripts
+ to automatically configure software source code packages. These scripts can adapt the
+ packages to many kinds of UNIX-like systems without manual user intervention. Autoconf
+ creates a configuration script for a package from a template file that lists the
+ operating system features that the package can use, in the form of M4 macro calls."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('M4', '1.4.17')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["autoconf", "autoheader", "autom4te", "autoreconf", "autoscan",
+                                     "autoupdate", "ifnames"]],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,33 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'Automake'
+version = "1.15"
+
+homepage = 'http://www.gnu.org/software/automake/automake.html'
+description = "Automake: GNU Standards-compliant Makefile generator"
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('Autoconf', '2.69')]
+
+sanity_check_paths = {
+    'files': ['bin/automake', 'bin/aclocal'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Autotools/Autotools-20150215-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/a/Autotools/Autotools-20150215-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,17 @@
+easyblock = 'Bundle'
+
+name = 'Autotools'
+version = '20150215'  # date of the most recent change
+
+homepage = 'http://autotools.io'
+description = """This bundle collect the standard GNU build tools: Autoconf, Automake and libtool"""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+
+dependencies = [
+    ('Autoconf', '2.69'),  # 20120424
+    ('Automake', '1.15'),  # 20150105
+    ('libtool', '2.4.6'),  # 20150215
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,15 @@
+name = 'bzip2'
+version = '1.0.6'
+
+homepage = 'http://www.bzip.org/'
+description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
+ compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
+ compressors), whilst being around twice as fast at compression and six times faster at decompression."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.bzip.org/%(version)s']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/GMP/GMP-6.1.0-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/g/GMP/GMP-6.1.0-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'GMP'
+version = '6.1.0'
+
+homepage = 'http://gmplib.org/'
+description = """GMP is a free library for arbitrary precision arithmetic, 
+operating on signed integers, rational numbers, and floating point numbers. """
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+toolchainopts = {'pic': True, 'precise': True}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = ['http://ftp.gnu.org/gnu/gmp']
+
+builddependencies = [
+    ('Autotools', '20150215'),
+]
+
+# enable C++ interface
+configopts = '--enable-cxx'
+
+runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['lib/libgmp.%s' % SHLIB_EXT, 'include/gmp.h'],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2016.02-GCC-4.9.eb
@@ -18,7 +18,7 @@ source_urls = ['http://ftp.gnu.org/gnu/readline']
 dependencies = [('ncurses', '6.0')]
 
 # for the termcap symbols, use EB ncurses
-preconfigopts = "LDFLAGS='-lncurses'"
+preconfigopts = "env LDFLAGS='-lncurses'"
 
 sanity_check_paths = {
     'files': ['lib/libreadline.a', 'lib/libhistory.a'] +

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'libreadline'
+version = '6.3'
+
+homepage = 'http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html'
+description = """The GNU Readline library provides a set of functions for use by applications that
+ allow users to edit command lines as they are typed in. Both Emacs and vi editing modes are available.
+ The Readline library includes additional functions to maintain a list of previously-entered command lines,
+ to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+toolchainopts = {'pic': True}
+
+sources = ['readline-%(version)s.tar.gz']
+source_urls = ['http://ftp.gnu.org/gnu/readline']
+
+dependencies = [('ncurses', '6.0')]
+
+# for the termcap symbols, use EB ncurses
+preconfigopts = "LDFLAGS='-lncurses'"
+
+sanity_check_paths = {
+    'files': ['lib/libreadline.a', 'lib/libhistory.a'] +
+    ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',
+                                         'rlstdc.h', 'rltypedefs.h', 'tilde.h']],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libtool/libtool-2.4.6-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/l/libtool/libtool-2.4.6-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,17 @@
+easyblock = 'ConfigureMake'
+
+name = 'libtool'
+version = '2.4.6'
+
+homepage = 'http://www.gnu.org/software/libtool'
+description = """GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries
+ behind a consistent, portable interface."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [('M4', '1.4.17')]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016.02-GCC-4.9.eb
@@ -13,7 +13,7 @@ toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
-configopts = "--enable-cxx"
+configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'M4'
+version = '1.4.17'
+
+homepage = 'http://www.gnu.org/software/m4/m4.html'
+description = """GNU M4 is an implementation of the traditional Unix macro processor. It is mostly SVR4 compatible
+  although it has some extensions (for example, handling more than 9 positional parameters to macros).
+ GNU M4 also has built-in functions for including files, running shell commands, doing arithmetic, etc."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+configopts = "--enable-cxx"
+
+sanity_check_paths = {
+    'files': ["bin/m4"],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'ncurses'
+version = '6.0'
+
+homepage = 'http://www.gnu.org/software/ncurses/'
+description = """The Ncurses (new curses) library is a free software emulation of curses in System V Release 4.0,
+ and more. It uses Terminfo format, supports pads and color and multiple highlights and forms characters and
+ function-key mapping, and has all the other SYSV-curses enhancements over BSD Curses."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+configopts = [
+    # default build
+    '--with-shared --enable-overwrite',
+    # the UTF-8 enabled version (ncursesw)
+    '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
+]
+
+libs = ["form", "menu", "ncurses", "panel"]
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
+                                     "reset", "tabs", "tic", "toe", "tput", "tset"]] +
+             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/libncurses++%s.a' % x for x in ['', 'w']],
+    'dirs': ['include', 'include/ncursesw'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,139 @@
+name = 'Python'
+version = '2.7.11'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+ more effectively."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+numpyversion = '1.10.1'
+scipyversion = '0.16.1'
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libreadline', '6.3'),
+    ('ncurses', '6.0'),
+    ('SQLite', '3.9.2'),
+    ('Tk', '8.6.4', '-no-X11'),
+    ('GMP', '6.1.0'),
+    #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
+    #   nice to have an up to date openssl for security reasons
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# order is important!
+# package versions updated May 28th 2015
+exts_list = [
+    ('setuptools', '18.7.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+    }),
+    ('pip', '7.1.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    ('numpy', numpyversion, {
+        'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
+        'patches': [
+            'numpy-1.8.0-mkl.patch',
+            'numpy-%s-sse42.patch' % numpyversion,
+        ],
+    }),
+    ('scipy', scipyversion, {
+        'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+    }),
+    ('mpi4py', '1.3.1', {
+        'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+    }),
+    ('paycheck', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+    }),
+    ('argparse', '1.4.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],
+    }),
+    ('pbr', '1.8.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
+    ('lockfile', '0.12.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+    }),
+    ('Cython', '0.23.4', {
+        'source_urls': ['http://www.cython.org/release/'],
+    }),
+    ('six', '1.10.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+    }),
+    ('dateutil', '2.4.2', {
+        'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+    }),
+    ('deap', '1.0.2', {
+        'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+    }),
+    ('decorator', '4.0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+    }),
+    ('arff', '2.1.0', {
+        'source_tmpl': 'liac-%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+    }),
+    ('paramiko', '1.16.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+    }),
+    ('pyparsing', '2.0.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+    }),
+    ('netifaces', '0.10.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+    }),
+    ('netaddr', '0.7.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('funcsigs', '0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs'],
+    }),
+    ('mock', '1.3.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
+    }),
+    ('pytz', '2015.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
+    }),
+    ('pandas', '0.17.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+    }),
+    ('enum34', '1.1.2', {
+        'modulename': 'enum',
+        'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
+    }),
+    ('bitstring', '3.1.3', {
+        # grab tarball from GitHub rather than PyPi since 3.1.3 release on PyPi disappeared;
+        # cfr. https://github.com/scott-griffiths/bitstring/issues/159
+        'source_tmpl': '%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://github.com/scott-griffiths/bitstring/archive/'],
+    }),
+    ('virtualenv', '14.0.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,40 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'SQLite'
+version = '3.9.2'
+
+homepage = 'http://www.sqlite.org/'
+description = 'SQLite: SQL Database Engine in a C Library'
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+
+# eg. http://www.sqlite.org/2014/sqlite-autoconf-3080600.tar.gz
+source_urls = ['http://www.sqlite.org/2015/']
+version_str = '%%(version_major)s%s00' % ''.join('%02d' % int(x) for x in version.split('.')[1:])
+sources = ['sqlite-autoconf-%s.tar.gz' % version_str]
+
+dependencies = [
+    ('libreadline', '6.3'),
+    ('Tcl', '8.6.4'),
+]
+
+parallel = 1
+
+sanity_check_paths = {
+    'files': ['bin/sqlite3', 'include/sqlite3ext.h', 'include/sqlite3.h', 'lib/libsqlite3.a', 'lib/libsqlite3.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.4-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.4-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'Tcl'
+version = '8.6.4'
+
+homepage = 'http://www.tcl.tk/'
+description = """Tcl (Tool Command Language) is a very powerful but easy to learn dynamic programming language,
+suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+
+source_urls = ["http://prdownloads.sourceforge.net/tcl"]
+sources = ['%(namelower)s%(version)s-src.tar.gz']
+
+dependencies = [
+    ('zlib', '1.2.8'),
+]
+
+configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
+
+runtest = 'test'
+
+start_dir = 'unix'
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2016.02-GCC-4.9-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2016.02-GCC-4.9-no-X11.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'Tk'
+version = '8.6.4'
+versionsuffix = '-no-X11'
+
+homepage = 'http://www.tcl.tk/'
+description = """Tk is an open source, cross-platform widget toolchain that provides a library of basic elements for building
+ a graphical user interface (GUI) in many different programming languages."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+
+source_urls = ["http://prdownloads.sourceforge.net/tcl"]
+sources = ['%(namelower)s%(version)s-src.tar.gz']
+
+patches = ['Tk-%(version)s_different-prefix-with-tcl.patch']
+
+dependencies = [
+    ('Tcl', version),
+]
+
+configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
+
+start_dir = 'unix'
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.8-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.8-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = 'zlib'
+version = '1.2.8'
+
+homepage = 'http://www.zlib.net/'
+description = """zlib is designed to be a free, general-purpose, legally unencumbered -- that is,
+ not covered by any patents -- lossless data-compression library for use on virtually any
+ computer hardware and operating system."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [('http://sourceforge.net/projects/libpng/files/zlib/%(version)s', 'download')]
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
Generated with "eb Python-2.7.11-intel-2016a.eb --try-toolchain=intel,2016.02-GCC-4.9 -r". It's great that this rebuilds all the dependencies with the new toolchain.

So, assuming I'm already running this in my easyconfig clone repo, from a new branch created from develop, and this runs successfully (as it did), and since something like this can in principle generate many eb files, is there already a way to automatically copy the generated files from ebfiles_repo, put them in the correct place, clean up the build metadata and git add them? :) 

Or maybe since this works from the command line without any additional changes to the files, there is no point in adding them to the repository?