### PR TITLE
ASE-3.10.0 with intel-2016.02-GCC-4.9 toolchain

### DIFF
--- a/easybuild/easyconfigs/a/ASE/ASE-3.10.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.10.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
@@ -2,6 +2,7 @@ easyblock = 'PythonPackage'
 
 name = 'ASE'
 version = '3.10.0'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://wiki.fysik.dtu.dk/ase/'
 description = """ASE is a python package providing an open source Atomic Simulation Environment
@@ -12,17 +13,15 @@ toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 source_urls = ['https://pypi.python.org/packages/source/a/ase/']
 sources = ['%(namelower)s-%(version)s.tar.gz']
 
-pyver = '2.7.11'
-pyshortver = '.'.join(pyver.split('.')[:2])
 versionsuffix = '-Python-%s' % pyver
 
 dependencies = [
-    ('Python', pyver),
+    ('Python', '2.7.11'),
 ]
 
 sanity_check_paths = {
     'files': ['bin/ase-build', 'bin/ase-db', 'bin/ase-gui', 'bin/ase-info', 'bin/ase-run'],
-    'dirs': ['lib/python%s/site-packages/%%(namelower)s' % pyshortver],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(namelower)s'],
 }
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/a/ASE/ASE-3.10.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.10.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
@@ -13,8 +13,6 @@ toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 source_urls = [PYPI_LOWER_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 
-versionsuffix = '-Python-%s' % pyver
-
 dependencies = [
     ('Python', '2.7.11'),
 ]

--- a/easybuild/easyconfigs/a/ASE/ASE-3.10.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.10.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
@@ -10,8 +10,8 @@ description = """ASE is a python package providing an open source Atomic Simulat
 
 toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 
-source_urls = ['https://pypi.python.org/packages/source/a/ase/']
-sources = ['%(namelower)s-%(version)s.tar.gz']
+source_urls = [PYPI_LOWER_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
 
 versionsuffix = '-Python-%s' % pyver
 

--- a/easybuild/easyconfigs/a/ASE/ASE-3.10.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.10.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
@@ -4,7 +4,7 @@ name = 'ASE'
 version = '3.10.0'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'https://wiki.fysik.dtu.dk/ase/'
+homepage = 'http://wiki.fysik.dtu.dk/ase'
 description = """ASE is a python package providing an open source Atomic Simulation Environment
  in the Python scripting language."""
 

--- a/easybuild/easyconfigs/a/ASE/ASE-3.10.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.10.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
@@ -1,0 +1,28 @@
+easyblock = 'PythonPackage'
+
+name = 'ASE'
+version = '3.10.0'
+
+homepage = 'https://wiki.fysik.dtu.dk/ase/'
+description = """ASE is a python package providing an open source Atomic Simulation Environment
+ in the Python scripting language."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+
+source_urls = ['https://pypi.python.org/packages/source/a/ase/']
+sources = ['%(namelower)s-%(version)s.tar.gz']
+
+pyver = '2.7.11'
+pyshortver = '.'.join(pyver.split('.')[:2])
+versionsuffix = '-Python-%s' % pyver
+
+dependencies = [
+    ('Python', pyver),
+]
+
+sanity_check_paths = {
+    'files': ['bin/ase-build', 'bin/ase-db', 'bin/ase-gui', 'bin/ase-info', 'bin/ase-run'],
+    'dirs': ['lib/python%s/site-packages/%%(namelower)s' % pyshortver],
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
Adapted from ASE-3.9.1.4567-intel-2016a-Python-2.7.11.eb (besides toolchain and version, source url and source name are now different)

Should this explicitly depend on Python-2.7.11 with the same toolchain or is that handled automatically?

edit: requires ~~#2895~~