### PR TITLE
PGI: add OpenMPI and pompi toolchain easyconfigs.

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
@@ -1,0 +1,40 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '1.10.2'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'PGI', 'version': '16.3-GCC-4.9.3-2.25'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+
+
+configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--with-cxxrtlib="-lgcc_s -lstdc++"' # for vt-mpi-unify
+
+dependencies = [('hwloc', '1.11.2')]
+
+# needed for --with-verbs
+osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+
+libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
+
+#sanity_check_commands = [
+#    ('mpicc --version | grep pgcc', ''),
+#    ('mpicxx --version | grep pgc++', ''),
+#    ('mpifort --version | grep pgfortran', ''),
+#]
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
@@ -31,10 +31,10 @@ sanity_check_paths = {
     'dirs': ["include/openmpi/ompi/mpi/cxx"],
 }
 
-#sanity_check_commands = [
-#    ('mpicc --version | grep pgcc', ''),
-#    ('mpicxx --version | grep pgc++', ''),
-#    ('mpifort --version | grep pgfortran', ''),
-#]
+sanity_check_commands = [
+    ('mpicc --version | grep pgcc', ''),
+    ('mpicxx --version | grep pgc++', ''),
+    ('mpifort --version | grep pgfortran', ''),
+]
 
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/p/pompi/pompi-2016.03.eb
+++ b/easybuild/easyconfigs/p/pompi/pompi-2016.03.eb
@@ -1,0 +1,19 @@
+easyblock = "Toolchain"
+
+name = 'pompi'
+version = '2016.03'
+pgisuffix = '-GCC-4.9.3-2.25'
+
+homepage = 'http://www.pgroup.com/index.htm'
+description = """Toolchain with PGI C, C++ and Fortran compilers, alongside OpenMPI."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+compver = '16.3'
+
+dependencies = [
+    ('PGI', compver, pgisuffix),
+    ('OpenMPI', '1.10.2', '', ('PGI', '%s%s' % (compver, pgisuffix))),
+]
+
+moduleclass = 'toolchain'


### PR DESCRIPTION
I hope to be able to uncomment the sanity_check_commands. For some strange reason, when they are run, `mpicc` does not find `pgcc` in the PATH; however after loading the module the `mpicc` command works just fine.