### PR TITLE
New EasyConfig for Bison 3.0.4 with the GCCcore 4.9.2 toolchain

### DIFF
--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.4-GCCcore-4.9.2.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.4-GCCcore-4.9.2.eb
@@ -1,0 +1,27 @@
+easyblock = 'ConfigureMake'
+
+name = 'Bison'
+version = '3.0.4'
+
+homepage = 'http://www.gnu.org/software/bison'
+description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
+ into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.2'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+builddependencies = [
+    ('M4', '1.4.17'),
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.25', '', True),
+]
+
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["bison", "yacc"]] + ["lib/liby.a"],
+    'dirs': [],
+}
+
+moduleclass = 'lang'


### PR DESCRIPTION
Requires ~~#2911~~ and ~~#2913~~