### PR TITLE
New EasyConfig for flex 2.5.39 with the GCCcore 4.9.2 toolchain

### DIFF
--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCCcore-4.9.2.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCCcore-4.9.2.eb
@@ -1,0 +1,19 @@
+name = 'flex'
+version = '2.5.39'
+
+homepage = 'http://flex.sourceforge.net/'
+description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners. A scanner,
+ sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.2'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [
+    ('M4', '1.4.17'),
+    ('binutils', '2.25', '', True)
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
Requires ~~#2911~~ and ~~#2913~~