### PR TITLE
New EasyConfig for numactl 2.0.11 with the GCCcore toolchain

### DIFF
--- a/easybuild/easyconfigs/n/numactl/numactl-2.0.11-GCCcore-4.9.2.eb
+++ b/easybuild/easyconfigs/n/numactl/numactl-2.0.11-GCCcore-4.9.2.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'numactl'
+version = '2.0.11'
+
+homepage = 'http://oss.sgi.com/projects/libnuma/'
+description = """The numactl program allows you to run your application program on specific cpu's and memory nodes.
+ It does this by supplying a NUMA memory policy to the operating system before running your program.
+ The libnuma library provides convenient ways for you to add NUMA memory policies into your own program."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.2'}
+
+source_urls = ['ftp://oss.sgi.com/www/projects/libnuma/download/']
+sources = [SOURCE_TAR_GZ]
+
+checksums = ['d3bc88b7ddb9f06d60898f4816ae9127']
+
+builddependencies = [('binutils', '2.25')]
+
+sanity_check_paths = {
+    'files': ['bin/numactl', 'bin/numastat', 'lib/libnuma.%s' % SHLIB_EXT, 'lib/libnuma.a'],
+    'dirs': ['share/man', 'include']
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
Requires ~~https://github.com/hpcugent/easybuild-easyconfigs/pull/2911~~ and https://github.com/hpcugent/easybuild-easyconfigs/pull/2916.