### PR TITLE
{chem}[intel/2016.02-GCC-4.9] pymatgen 3.5.10 and spglib 1.9.2

### DIFF
--- a/easybuild/easyconfigs/p/pymatgen/pymatgen-3.5.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/pymatgen/pymatgen-3.5.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
@@ -2,6 +2,7 @@ easyblock = "PythonPackage"
 
 name = 'pymatgen'
 version = '3.5.0'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://pypi.python.org/pypi/pymatgen'
 description = """Python Materials Genomics is a robust materials analysis code that defines core object
@@ -9,18 +10,11 @@ description = """Python Materials Genomics is a robust materials analysis code t
 
 toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 
-# source package not (yet?) in url PYPI_SOURCE 
-#source_urls = [PYPI_SOURCE]
-source_urls = ['http://pypi.python.org/packages/7a/ae/c1bbe01227514bec203934d608c7319fec173791b3c58afa8e169affb976/']
+source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
-python = 'Python'
-pythonversion = '2.7.11'
-
-versionsuffix = '-%s-%s' % (python, pythonversion)
-
 dependencies = [
-    (python, pythonversion),
+    ('Python', '2.7.11'),
     ('spglib', '1.9.2'),
 ]
 

--- a/easybuild/easyconfigs/p/pymatgen/pymatgen-3.5.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/pymatgen/pymatgen-3.5.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
@@ -9,7 +9,7 @@ description = """Python Materials Genomics is a robust materials analysis code t
 
 toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 
-# source not in url PYPI_SOURCE ?
+# source package not (yet?) in url PYPI_SOURCE 
 #source_urls = [PYPI_SOURCE]
 source_urls = ['http://pypi.python.org/packages/7a/ae/c1bbe01227514bec203934d608c7319fec173791b3c58afa8e169affb976/']
 sources = [SOURCE_TAR_GZ]
@@ -24,10 +24,9 @@ dependencies = [
     ('spglib', '1.9.2'),
 ]
 
-py_short_ver = '.'.join(pythonversion.split('.')[:2])
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages' % py_short_ver],
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
 }
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/p/pymatgen/pymatgen-3.5.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/pymatgen/pymatgen-3.5.0-intel-2016.02-GCC-4.9-Python-2.7.11.eb
@@ -1,0 +1,33 @@
+easyblock = "PythonPackage"
+
+name = 'pymatgen'
+version = '3.5.0'
+
+homepage = 'https://pypi.python.org/pypi/pymatgen'
+description = """Python Materials Genomics is a robust materials analysis code that defines core object
+ representations for structures and molecules with support for many electronic structure codes."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+
+# source not in url PYPI_SOURCE ?
+#source_urls = [PYPI_SOURCE]
+source_urls = ['http://pypi.python.org/packages/7a/ae/c1bbe01227514bec203934d608c7319fec173791b3c58afa8e169affb976/']
+sources = [SOURCE_TAR_GZ]
+
+python = 'Python'
+pythonversion = '2.7.11'
+
+versionsuffix = '-%s-%s' % (python, pythonversion)
+
+dependencies = [
+    (python, pythonversion),
+    ('spglib', '1.9.2'),
+]
+
+py_short_ver = '.'.join(pythonversion.split('.')[:2])
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages' % py_short_ver],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/s/spglib/spglib-1.9.2-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/s/spglib/spglib-1.9.2-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,21 @@
+easyblock = 'ConfigureMake'
+
+name = 'spglib'
+version = '1.9.2'
+
+homepage = 'http://spglib.sourceforge.net/'
+description = """Spglib is a C library for finding and handling crystal symmetries."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+patches = ['spglib-1.9.2_remove_duplicate.patch']
+
+sanity_check_paths = {
+    'files': ['lib/libsymspg.a', 'lib/libsymspg.%s' % SHLIB_EXT],
+    'dirs': ['include/spglib'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/s/spglib/spglib-1.9.2-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/s/spglib/spglib-1.9.2-intel-2016.02-GCC-4.9.eb
@@ -11,7 +11,7 @@ toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 source_urls = [SOURCEFORGE_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
-patches = ['spglib-1.9.2_remove_duplicate.patch']
+patches = ['spglib-%(version)s_remove_duplicate.patch']
 
 sanity_check_paths = {
     'files': ['lib/libsymspg.a', 'lib/libsymspg.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/s/spglib/spglib-1.9.2_remove_duplicate.patch
+++ b/easybuild/easyconfigs/s/spglib/spglib-1.9.2_remove_duplicate.patch
@@ -1,0 +1,11 @@
+--- src/Makefile.in.orig	2016-04-26 16:21:29.900203000 +0800
++++ src/Makefile.in	2016-04-26 16:21:43.531192514 +0800
+@@ -562,7 +562,7 @@
+ version.h
+ 
+ libsymspg_la_SOURCES = $(spglib_c) $(spglib_h)
+-pkginclude_HEADERS = $(spglib_h) debug.h
++pkginclude_HEADERS = $(spglib_h)
+ # libsymspg_la_LDFLAGS = -version-info 0:1:0
+ libsymspg_la_LIBADD = -lm
+ spglib_test_SOURCES = test.c $(spglib_c) $(spglib_h)

--- a/easybuild/easyconfigs/s/spglib/spglib-1.9.2_remove_duplicate.patch
+++ b/easybuild/easyconfigs/s/spglib/spglib-1.9.2_remove_duplicate.patch
@@ -1,3 +1,5 @@
+debug.h is already in $(spglib_h), which causes make install to fail
+author: Miguel Dias Costa (National University of Singapore)
 --- src/Makefile.in.orig	2016-04-26 16:21:29.900203000 +0800
 +++ src/Makefile.in	2016-04-26 16:21:43.531192514 +0800
 @@ -562,7 +562,7 @@


### PR DESCRIPTION
don't know why pymatgen-3.5.0.tar.gz cannot be found in PYPI_SOURCE url, 3.4.0 can...