### PR TITLE
add dependency extensions for MarkupSafe and jsonscheme in IPython 3.2.3 easyconfigs + use %(pyver)s and %(pyshortver)s

### DIFF
--- a/easybuild/easyconfigs/i/IPython/IPython-3.2.3-foss-2015a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-3.2.3-foss-2015a-Python-2.7.11.eb
@@ -2,6 +2,7 @@ easyblock = 'Bundle'
 
 name = 'IPython'
 version = '3.2.3'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://ipython.org/index.html'
 description = """IPython provides a rich architecture for interactive computing with:
@@ -13,13 +14,8 @@ description = """IPython provides a rich architecture for interactive computing 
 
 toolchain = {'name': 'foss', 'version': '2015a'}
 
-python = 'Python'
-pyver = '2.7.11'
-pyshortver = '.'.join(pyver.split('.')[:2])
-versionsuffix = '-%s-%s' % (python, pyver)
-
 dependencies = [
-    (python, pyver),
+    ('Python', '2.7.11'),
     ('PyZMQ', '15.2.0', '%s-zmq4' % versionsuffix),
 ]
 
@@ -82,11 +78,11 @@ exts_list = [
     }),
 ]
 
-modextrapaths = {'PYTHONPATH': ['lib/python%s/site-packages' % pyshortver]}
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 sanity_check_paths = {
     'files': ['bin/ipython'],
-    'dirs': ['lib/python%s/site-packages/IPython' % pyshortver],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/IPython'],
 }
 
 sanity_check_commands = [

--- a/easybuild/easyconfigs/i/IPython/IPython-3.2.3-foss-2015a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-3.2.3-foss-2015a-Python-2.7.11.eb
@@ -52,8 +52,17 @@ exts_list = [
     ('tornado', '4.3', {
         'source_urls': ['https://pypi.python.org/packages/source/t/tornado/'],
     }),
+    ('MarkupSafe', '0.23', {
+        'source_urls': ['https://pypi.python.org/packages/source/M/MarkupSafe/'],
+    }),
     ('Jinja2', '2.8', {
         'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2/'],
+    }),
+    ('vcversioner', '2.16.0.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/vcversioner/'],
+    }),
+    ('functools32', '3.2.3-2', {
+        'source_urls': ['https://pypi.python.org/packages/source/f/functools32/'],
     }),
     ('jsonschema', '2.5.1', {
         'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema/'],

--- a/easybuild/easyconfigs/i/IPython/IPython-3.2.3-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-3.2.3-intel-2015b-Python-2.7.10.eb
@@ -2,6 +2,7 @@ easyblock = 'Bundle'
 
 name = 'IPython'
 version = '3.2.3'
+versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://ipython.org/index.html'
 description = """IPython provides a rich architecture for interactive computing with:
@@ -13,13 +14,8 @@ description = """IPython provides a rich architecture for interactive computing 
 
 toolchain = {'name': 'intel', 'version': '2015b'}
 
-python = 'Python'
-pyver = '2.7.10'
-pyshortver = '.'.join(pyver.split('.')[:2])
-versionsuffix = '-%s-%s' % (python, pyver)
-
 dependencies = [
-    (python, pyver),
+    ('Python', '2.7.10'),
     ('PyZMQ', '15.1.0', '%s-zmq4' % versionsuffix),
 ]
 
@@ -82,11 +78,11 @@ exts_list = [
     }),
 ]
 
-modextrapaths = {'PYTHONPATH': ['lib/python%s/site-packages' % pyshortver]}
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 sanity_check_paths = {
     'files': ['bin/ipython'],
-    'dirs': ['lib/python%s/site-packages/IPython' % pyshortver],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/IPython'],
 }
 
 sanity_check_commands = [

--- a/easybuild/easyconfigs/i/IPython/IPython-3.2.3-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-3.2.3-intel-2015b-Python-2.7.10.eb
@@ -52,8 +52,17 @@ exts_list = [
     ('tornado', '4.3', {
         'source_urls': ['https://pypi.python.org/packages/source/t/tornado/'],
     }),
+    ('MarkupSafe', '0.23', {
+        'source_urls': ['https://pypi.python.org/packages/source/M/MarkupSafe/'],
+    }),
     ('Jinja2', '2.8', {
         'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2/'],
+    }),
+    ('vcversioner', '2.16.0.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/vcversioner/'],
+    }),
+    ('functools32', '3.2.3-2', {
+        'source_urls': ['https://pypi.python.org/packages/source/f/functools32/'],
     }),
     ('jsonschema', '2.5.1', {
         'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema/'],


### PR DESCRIPTION
cfr. #2909