### PR TITLE
add patch for matplotlib 1.5.1 to fix Tcl/Tk library paths being used

### DIFF
--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2015b-Python-2.7.10.eb
@@ -28,6 +28,7 @@ exts_list = [
     }),
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
+        'patches': ['matplotlib-1.5.1_fix-Tcl-Tk-libdir.patch'],
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2016a-Python-2.7.11.eb
@@ -28,6 +28,7 @@ exts_list = [
     }),
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
+        'patches': ['matplotlib-1.5.1_fix-Tcl-Tk-libdir.patch'],
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2015b-Python-2.7.11.eb
@@ -28,6 +28,7 @@ exts_list = [
     }),
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
+        'patches': ['matplotlib-1.5.1_fix-Tcl-Tk-libdir.patch'],
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016a-Python-2.7.11.eb
@@ -28,6 +28,7 @@ exts_list = [
     }),
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
+        'patches': ['matplotlib-1.5.1_fix-Tcl-Tk-libdir.patch'],
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-intel-2016a-Python-3.5.1.eb
@@ -29,6 +29,7 @@ exts_list = [
     }),
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
+        'patches': ['matplotlib-1.5.1_fix-Tcl-Tk-libdir.patch'],
     }),
 ]
 

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1_fix-Tcl-Tk-libdir.patch
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1_fix-Tcl-Tk-libdir.patch
@@ -1,0 +1,26 @@
+ensure that Tcl/Tk library paths are correct, to fix segmentation fault that occurs when plotting because system
+libraries are picked up;
+the problem is that the query_tcktl method guesses the Tk library path based on the Tcl library path by simply
+replacing 'Tcl'/'tcl' with 'Tk'/'tk', which doesn't work if the Tk install prefix is different (e.g. due to a
+versionsuffix)
+author: Kenneth Hoste (HPC-UGent)
+-- matplotlib-1.5.1.orig/setupext.py	2016-01-11 04:06:08.000000000 +0100
++++ matplotlib-1.5.1/setupext.py	2016-04-29 15:43:21.280170000 +0200
+@@ -1560,7 +1560,16 @@
+ 
+             # Query Tcl/Tk system for library paths and version string
+             try:
+-                tcl_lib_dir, tk_lib_dir, tk_ver = self.query_tcltk()
++                tcl_lib_dir, tk_lib_dir, tk_ver = None, None, None
++                if 'EBROOTTCL' in os.environ and 'EBVERSIONTCL' in os.environ:
++                    tcl_ver = '.'.join(os.environ['EBVERSIONTCL'].split('.')[:2])
++                    tcl_lib_dir = os.path.join(os.environ['EBROOTTCL'], 'lib', 'tcl%s' % tcl_ver)
++                if 'EBROOTTK' in os.environ and 'EBVERSIONTK' in os.environ:
++                    tk_ver = '.'.join(os.environ['EBVERSIONTK'].split('.')[:2])
++                    tk_lib_dir = os.path.join(os.environ['EBROOTTK'], 'lib', 'tk%s' % tk_ver)
++
++                if tcl_lib_dir is None or tk_lib_dir is None or tk_ver is None:
++                        tcl_lib_dir, tk_lib_dir, tk_ver = self.query_tcltk()
+             except:
+                 tk_ver = ''
+                 result = self.hardcoded_tcl_config()


### PR DESCRIPTION
This fixes a segmentation fault that occurs when using `matplotlib` on a system where Tcl/Tk are also available on the OS; this also fixes #2659

Without the patch:

```
$ ldd $EBROOTMATPLOTLIB/lib/python2.7/site-packages/matplotlib-1.5.1-py2.7-linux-x86_64.egg/matplotlib/backends/_tkagg.so | egrep 'tcl|tk'
	libtcl8.5.so => /usr/lib64/libtcl8.5.so (0x00002b78b64f1000)
	libtk8.5.so => /usr/lib64/libtk8.5.so (0x00002b78b681a000)

$ python -c "import matplotlib.pyplot as plt; plt.plot(range(0,100000)); plt.show()"
Segmentation fault
$ echo $?
139
```

With the patch:

```
$ ldd $EBROOTMATPLOTLIB/lib/python2.7/site-packages/matplotlib-1.5.1-py2.7-linux-x86_64.egg/matplotlib/backends/_tkagg.so | egrep 'tcl|tk'
	libtcl8.6.so => /user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/SL6/sandybridge/software/Tcl/8.6.4-intel-2016a/lib/libtcl8.6.so (0x00002b2989818000)
	libtk8.6.so => /user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/SL6/sandybridge/software/Tk/8.6.4-intel-2016a-no-X11/lib/libtk8.6.so (0x00002b2989c38000)

$ python -c "import matplotlib.pyplot as plt; plt.plot(range(0,100000)); plt.show()"
# X11 window is opened
```