### PR TITLE
add sed command to worker easyconfig files to fix module_path in conf/worker.conf

### DIFF
--- a/easybuild/easyconfigs/w/worker/worker-1.5.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/w/worker/worker-1.5.1-intel-2015a.eb
@@ -21,11 +21,12 @@ dependencies = [
 # adjust worker configuration file
 # note: tweak this to your local setup
 postinstallcmds = [
-    'sed -i "s/ cores_per_node = .*/ cores_per_node = 16/g" %(installdir)s/conf/worker.conf',  # tweak this
+    'sed -i "s/ cores_per_node = .*/ cores_per_node = 16/g" %(installdir)s/conf/worker.conf',
     'sed -i "s@ qsub = .*@ qsub = `which qsub`@g" %(installdir)s/conf/worker.conf',
-    'sed -i "s/ email = .*/ email = hpc-support@example.com/g" %(installdir)s/conf/worker.conf',  # tweak this
-    'sed -i "s/ unload_modules = .*/ unload_modules = intel/g" %(installdir)s/conf/worker.conf',  # tweak this (maybe)
-    'sed -i "s@ mpi_module = .*@ mpi_module = intel/2015a@g" %(installdir)s/conf/worker.conf',  # tweak this (maybe)
+    'sed -i "s/ email = .*/ email = hpc-support@example.com/g" %(installdir)s/conf/worker.conf',
+    'sed -i "s/ unload_modules = .*/ unload_modules = intel/g" %(installdir)s/conf/worker.conf',
+    'sed -i "s@ mpi_module = .*@ mpi_module = intel/2016a@g" %(installdir)s/conf/worker.conf',
+    'sed -i "s@ module_path = .*@ module_path = %(installdir)s/../../modules/all@g" %(installdir)s/conf/worker.conf',
 ]
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/w/worker/worker-1.6.4-intel-2016a.eb
+++ b/easybuild/easyconfigs/w/worker/worker-1.6.4-intel-2016a.eb
@@ -21,11 +21,12 @@ dependencies = [
 # adjust worker configuration file
 # note: tweak this to your local setup
 postinstallcmds = [
-    'sed -i "s/ cores_per_node = .*/ cores_per_node = 16/g" %(installdir)s/conf/worker.conf',  # tweak this
+    'sed -i "s/ cores_per_node = .*/ cores_per_node = 16/g" %(installdir)s/conf/worker.conf',
     'sed -i "s@ qsub = .*@ qsub = `which qsub`@g" %(installdir)s/conf/worker.conf',
-    'sed -i "s/ email = .*/ email = hpc-support@example.com/g" %(installdir)s/conf/worker.conf',  # tweak this
-    'sed -i "s/ unload_modules = .*/ unload_modules = intel/g" %(installdir)s/conf/worker.conf',  # tweak this (maybe)
-    'sed -i "s@ mpi_module = .*@ mpi_module = intel/2016a@g" %(installdir)s/conf/worker.conf',  # tweak this (maybe)
+    'sed -i "s/ email = .*/ email = hpc-support@example.com/g" %(installdir)s/conf/worker.conf',
+    'sed -i "s/ unload_modules = .*/ unload_modules = intel/g" %(installdir)s/conf/worker.conf',
+    'sed -i "s@ mpi_module = .*@ mpi_module = intel/2016a@g" %(installdir)s/conf/worker.conf',
+    'sed -i "s@ module_path = .*@ module_path = %(installdir)s/../../modules/all@g" %(installdir)s/conf/worker.conf',
 ]
 
 moduleclass = 'tools'


### PR DESCRIPTION
I'm making the assumption that the default module naming scheme and default location of modules relative to install directory is used here, but since the other commands may need to be changed too according to site settings, that is OK-ish.

@cc gjbex