### PR TITLE
{toolchain}[dummy] foss/2016.04

### DIFF
--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016.04.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016.04.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'FFTW'
+version = '3.3.4'
+
+homepage = 'http://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+ in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'gompi', 'version': '2016.04'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [homepage]
+
+common_configopts = "--enable-threads --enable-openmp --with-pic"
+
+configopts = [
+    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    common_configopts + " --enable-long-double --enable-mpi",
+    common_configopts + " --enable-quad-precision",
+    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+]
+
+sanity_check_paths = {
+    'files': ['bin/fftw%s' % x for x in ['-wisdom', '-wisdom-to-conf', 'f-wisdom', 'l-wisdom', 'q-wisdom']] +
+             ['include/fftw3%s' % x for x in ['-mpi.f03', '-mpi.h', '.f', '.f03',
+                                              '.h', 'l-mpi.f03', 'l.f03', 'q.f03']] +
+             ['lib/libfftw3%s%s.a' % (x, y) for x in ['', 'f', 'l'] for y in ['', '_mpi', '_omp', '_threads']] +
+             ['lib/libfftw3q.a', 'lib/libfftw3q_omp.a'],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/f/foss/foss-2016.04.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2016.04.eb
@@ -1,0 +1,35 @@
+easyblock = 'Toolchain'
+
+name = 'foss'
+version = '2016.04'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain, including
+ OpenMPI for MPI support, OpenBLAS (BLAS and LAPACK support), FFTW and ScaLAPACK."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+gccver = '5.3.0-2.26'
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.18'
+blas = '%s-%s' % (blaslib, blasver)
+blassuff = '-LAPACK-3.6.0'
+
+# toolchain used to build foss dependencies
+comp_mpi_tc_name = 'gompi'
+comp_mpi_tc = (comp_mpi_tc_name, version)
+
+# compiler toolchain depencies
+# we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
+# because of toolchain preperation functions
+# For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
+dependencies = [
+    ('GCC', gccver),
+    ('OpenMPI', '1.10.2', '', ('GCC', gccver)),
+    (blaslib, blasver, blassuff, ('GCC', gccver)),
+    ('FFTW', '3.3.4', '', comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2016.04.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2016.04.eb
@@ -1,0 +1,20 @@
+easyblock = "Toolchain"
+
+name = 'gompi'
+version = '2016.04'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain,
+ including OpenMPI for MPI support."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+gccver = '5.3.0-2.26'
+
+# compiler toolchain dependencies
+dependencies = [
+    ('GCC', gccver),  # includes both GCC 5.3.0 and binutils 2.26
+    ('OpenMPI', '1.10.2', '', ('GCC', gccver)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/h/HPL/HPL-2.1-foss-2016.04.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.1-foss-2016.04.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.1'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'optarch': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.3-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.3-GCC-5.3.0-2.26.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'hwloc'
+version = '1.11.3'
+
+homepage = 'http://www.open-mpi.org/projects/hwloc/'
+description = """The Portable Hardware Locality (hwloc) software package provides a portable abstraction
+ (across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including
+ NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading. It also gathers various
+ system attributes such as cache and memory information as well as the locality of I/O devices such as
+ network interfaces, InfiniBand HCAs or GPUs. It primarily aims at helping applications with gathering
+ information about modern computing hardware so as to exploit it accordingly and efficiently."""
+
+toolchain = {'name': 'GCC', 'version': '5.3.0-2.26'}
+
+source_urls = ['http://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/']
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [('numactl', '2.0.11')]
+
+configopts = "--enable-libnuma=$EBROOTNUMACTL"
+
+moduleclass = 'system'

--- a/easybuild/easyconfigs/n/numactl/numactl-2.0.11-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/n/numactl/numactl-2.0.11-GCC-5.3.0-2.26.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'numactl'
+version = '2.0.11'
+
+homepage = 'http://oss.sgi.com/projects/libnuma/'
+description = """The numactl program allows you to run your application program on specific cpu's and memory nodes.
+ It does this by supplying a NUMA memory policy to the operating system before running your program.
+ The libnuma library provides convenient ways for you to add NUMA memory policies into your own program."""
+
+toolchain = {'name': 'GCC', 'version': '5.3.0-2.26'}
+
+source_urls = ['ftp://oss.sgi.com/www/projects/libnuma/download/']
+sources = [SOURCE_TAR_GZ]
+
+checksums = ['d3bc88b7ddb9f06d60898f4816ae9127']
+
+sanity_check_paths = {
+    'files': ['bin/numactl', 'bin/numastat', 'lib/libnuma.%s' % SHLIB_EXT, 'lib/libnuma.a'],
+    'dirs': ['share/man', 'include']
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.3.0-2.26-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.3.0-2.26-LAPACK-3.6.0.eb
@@ -1,0 +1,51 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenBLAS'
+version = '0.2.18'
+
+lapackver = '3.6.0'
+versionsuffix = '-LAPACK-%s' % lapackver
+
+homepage = 'http://xianyi.github.com/OpenBLAS/'
+description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
+
+toolchain = {'name': 'GCC', 'version': '5.3.0-2.26'}
+
+lapack_src = 'lapack-%s.tgz' % lapackver
+large_src = 'large.tgz'
+timing_src = 'timing.tgz'
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
+source_urls = [
+    # order matters, trying to download the LAPACK tarball from GitHub causes trouble
+    "http://www.netlib.org/lapack/",
+    "http://www.netlib.org/lapack/timing/",
+    "https://github.com/xianyi/OpenBLAS/archive/",
+]
+
+patches = [
+    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    (large_src, '.'),
+    (timing_src, '.'),
+]
+
+skipsteps = ['configure']
+
+buildopts = 'BINARY=64 USE_THREAD=1 CC="$CC" FC="$F77" NO_AFFINITY=1'
+installopts = "USE_THREAD=1 PREFIX=%(installdir)s"
+
+# extensive testing can be enabled by uncommenting the line below
+#runtest = 'PATH=.:$PATH lapack-timing'
+
+sanity_check_paths = {
+    'files': ['include/cblas.h', 'include/f77blas.h', 'include/lapacke_config.h', 'include/lapacke.h',
+              'include/lapacke_mangling.h', 'include/lapacke_utils.h', 'include/openblas_config.h',
+              'lib/libopenblas.a', 'lib/libopenblas.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-5.3.0-2.26.eb
@@ -1,0 +1,32 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '1.10.2'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'GCC', 'version': '5.3.0-2.26'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+
+dependencies = [('hwloc', '1.11.3')]
+
+configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+
+# needed for --with-verbs
+osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+
+libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.04-OpenBLAS-0.2.18-LAPACK-3.6.0.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.04-OpenBLAS-0.2.18-LAPACK-3.6.0.eb
@@ -1,0 +1,25 @@
+name = 'ScaLAPACK'
+version = '2.0.2'
+
+homepage = 'http://www.netlib.org/scalapack/'
+description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
+ redesigned for distributed memory MIMD parallel computers."""
+
+toolchain = {'name': 'gompi', 'version': '2016.04'}
+toolchainopts = {'pic': True}
+
+source_urls = [homepage]
+sources = [SOURCELOWER_TGZ]
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.18'
+blassuff = '-LAPACK-3.6.0'
+
+versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+
+dependencies = [(blaslib, blasver, blassuff, ('GCC', '5.3.0-2.26'))]
+
+# parallel build tends to fail, so disabling it
+parallel = 1
+
+moduleclass = 'numlib'


### PR DESCRIPTION
requires ~~#2524~~

note: this is the first version of the `foss` toolchain that uses GCC 5.x (5.3, to be exact)