### PR TITLE
clean up dummy bzip2 easyconfig, define buildopts rather than defining $CC and $CFLAGS via os.environ

### DIFF
--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6.eb
@@ -12,8 +12,8 @@ toolchainopts = {'pic': True}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.bzip.org/%(version)s/']
 
-import os
-os.environ['CC'] = 'gcc'
-os.environ['CFLAGS'] = '-O3 -fPIC'
+buildopts = "CC=gcc CFLAGS='-Wall -Winline -O3 -fPIC -g $(BIGFILES)'"
+
+with_shared_libs = False
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6.eb
@@ -14,6 +14,7 @@ source_urls = ['http://www.bzip.org/%(version)s/']
 
 buildopts = "CC=gcc CFLAGS='-Wall -Winline -O3 -fPIC -g $(BIGFILES)'"
 
+# disable building of shared libraries, doesn't work everywhere (e.g. on OS X, where 'gcc' is actually Clang...)
 with_shared_libs = False
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6.eb
@@ -14,7 +14,7 @@ source_urls = ['http://www.bzip.org/%(version)s/']
 
 buildopts = "CC=gcc CFLAGS='-Wall -Winline -O3 -fPIC -g $(BIGFILES)'"
 
-# disable building of shared libraries, doesn't work everywhere (e.g. on OS X, where 'gcc' is actually Clang...)
-with_shared_libs = False
+# building of shared libraries doesn't work on OS X (where 'gcc' is actually Clang...)
+with_shared_libs = OS_TYPE == 'Linux'
 
 moduleclass = 'tools'


### PR DESCRIPTION
mainly done to avoid the `import os`...

this requires ~~https://github.com/hpcugent/easybuild-easyblocks/pull/910~~ (with https://github.com/pescobar/easybuild-easyblocks/pull/5 included)