### PR TITLE
OpenSSL-1.0.2g-GCCcore-4.9.3

### DIFF
--- a/easybuild/easyconfigs/o/OpenSSL/OpenSSL-1.0.2g-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/o/OpenSSL/OpenSSL-1.0.2g-GCCcore-4.9.3.eb
@@ -1,0 +1,24 @@
+name = 'OpenSSL'
+version = '1.0.2g'
+
+homepage = 'http://www.openssl.org/'
+description = """The OpenSSL Project is a collaborative effort to develop a robust, commercial-grade, full-featured,
+ and Open Source toolchain implementing the Secure Sockets Layer (SSL v2/v3) and Transport Layer Security (TLS v1) 
+ protocols as well as a full-strength general purpose cryptography library. """
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.openssl.org/source/']
+
+builddependencies = [
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.25', '', True),
+]
+
+dependencies = [('zlib', '1.2.8')]
+
+runtest = 'test'
+
+moduleclass = 'system'


### PR DESCRIPTION
Add latest version of OpenSSL built with lowest appropriate compiler toolchain that can be used as dependency with `--minimal-toolchains`.