### PR TITLE
tmux-2.2-GCCcore-4.9.3

### DIFF
--- a/easybuild/easyconfigs/l/libevent/libevent-2.0.22-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/libevent/libevent-2.0.22-GCCcore-4.9.3.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = 'libevent'
+version = '2.0.22'
+
+homepage = 'http://libevent.org/'
+description = """The libevent API provides a mechanism to execute a callback function when a specific
+ event occurs on a file descriptor or after a timeout has been reached.
+ Furthermore, libevent also support callbacks due to signals or regular timeouts."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+
+source_urls = [
+    'https://github.com/downloads/%(name)s/%(name)s/',
+    'https://sourceforge.net/projects/levent/files/%(name)s/%(name)s-%(version_major_minor)s/',
+]
+sources = ['%(name)s-%(version)s-stable.tar.gz']
+
+builddependencies = [
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.25', '', True),
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/tmux/tmux-2.2-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/t/tmux/tmux-2.2-GCCcore-4.9.3.eb
@@ -1,0 +1,31 @@
+easyblock = 'ConfigureMake'
+
+name = 'tmux'
+version = '2.2'
+
+homepage = 'http://tmux.sourceforge.net/'
+description = """tmux is a terminal multiplexer. It lets you switch easily 
+between several programs in one terminal, detach them (they keep running in the background) and reattach them to a different terminal."""
+
+toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'optarch': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['https://github.com/tmux/tmux/releases/download/%(version)s/']
+
+builddependencies = [
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.25', '', True),
+]
+
+dependencies = [
+    ('ncurses', '6.0'),
+    ('libevent', '2.0.22'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/tmux'],
+    'dirs': []
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
`tmux-2.2` and it's required dependency `libevent/2.0.22` built for `GCCcore/4.9.3`.