### PR TITLE
correct install location of OpenCV Python bindings

### DIFF
--- a/easybuild/easyconfigs/o/OpenCV/OpenCV-2.4.12-intel-2016a.eb
+++ b/easybuild/easyconfigs/o/OpenCV/OpenCV-2.4.12-intel-2016a.eb
@@ -39,7 +39,7 @@ preconfigopts = 'export IPPROOT=$EBROOTICC/ipp && '
 
 configopts = '-DCMAKE_BUILD_TYPE=RELEASE '
 configopts += '-DBUILD_PYTHON_SUPPORT=ON '
-configopts += '-DPYTHON_PACKAGES_PATH=$EBROOTPYTHON/lib/python%(pyshortver)s/site-packages '
+configopts += '-DPYTHON_PACKAGES_PATH=%(installdir)s/lib/python%(pyshortver)s/site-packages '
 configopts += '-DBUILD_NEW_PYTHON_SUPPORT=ON '
 configopts += '-DZLIB_LIBRARY=$EBROOTZLIB/lib/libz.so '
 configopts += '-DZLIB_INCLUDE_DIR=$EBROOTZLIB/include '
@@ -56,7 +56,7 @@ configopts += '-DENABLE_SSE=ON -DENABLE_SSE2=ON -DENABLE_SSE3=ON '
 configopts += '-DWITH_CUDA=OFF '
 
 sanity_check_paths = {
-    'files': ['lib/libopencv_core.%s' % SHLIB_EXT] +
+    'files': ['lib/libopencv_core.%s' % SHLIB_EXT, 'lib/python%(pyshortver)s/site-packages/cv2.so'] +
              ['bin/opencv_%s' % x for x in ['haartraining', 'createsamples', 'performance', 'traincascade']],
     'dirs': ['include']
 }

--- a/easybuild/easyconfigs/o/OpenCV/OpenCV-2.4.9-intel-2014.06.eb
+++ b/easybuild/easyconfigs/o/OpenCV/OpenCV-2.4.9-intel-2014.06.eb
@@ -23,22 +23,16 @@ builddependencies = [
     ('CMake', '3.0.0'),
 ]
 
-python = 'Python'
-pythonver = '2.7.8'
-pythonshortver = '.'.join(pythonver.split('.')[0:2])
-java = 'Java'
-javaver = '1.7.0_79'
-
 dependencies = [
-    (python, pythonver),
+    ('Python', '2.7.8'),
     ('zlib', '1.2.8'),
     ('FFmpeg', '2.4'),
     ('libjpeg-turbo', '1.3.1'),
     ('libpng', '1.6.12'),
     ('LibTIFF', '4.0.3'),
     ('JasPer', '1.900.1'),
-    (java, javaver, '', True),
-    ('ant', '1.9.3', '-%s-%s' % (java, javaver), True),
+    ('Java', '1.7.0_79', '', True),
+    ('ant', '1.9.3', '-Java-%(javaver)s', True),
     ('GLib', '2.40.0')
 ]
 
@@ -46,7 +40,7 @@ preconfigopts = 'export IPPROOT=$EBROOTICC/ipp && '
 
 configopts = '-DCMAKE_BUILD_TYPE=RELEASE '
 configopts += '-DBUILD_PYTHON_SUPPORT=ON '
-configopts += '-DPYTHON_PACKAGES_PATH=$EBROOTPYTHON/lib/python%s/site-packages ' % pythonshortver
+configopts += '-DPYTHON_PACKAGES_PATH=%(installdir)s/lib/python%(pyshortver)s/site-packages '
 configopts += '-DBUILD_NEW_PYTHON_SUPPORT=ON '
 configopts += '-DZLIB_LIBRARY=$EBROOTZLIB/lib/libz.so '
 configopts += '-DZLIB_INCLUDE_DIR=$EBROOTZLIB/include '
@@ -63,13 +57,13 @@ configopts += '-DENABLE_SSE=ON -DENABLE_SSE2=ON -DENABLE_SSE3=ON '
 configopts += '-DWITH_CUDA=OFF '
 
 sanity_check_paths = {
-    'files': ['lib/libopencv_core.%s' % SHLIB_EXT] +
+    'files': ['lib/libopencv_core.%s' % SHLIB_EXT, 'lib/python%(pyshortver)s/site-packages/cv2.so'] +
              ['bin/opencv_%s' % x for x in ['haartraining', 'createsamples', 'performance', 'traincascade']],
     'dirs': ['include']
 }
 
 modextrapaths = {
-    'PYTHONPATH': 'lib/python%s/site-packages' % pythonshortver,
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
     'CLASSPATH': 'share/OpenCV/java',
 }
 

--- a/easybuild/easyconfigs/o/OpenCV/OpenCV-2.4.9-intel-2014b.eb
+++ b/easybuild/easyconfigs/o/OpenCV/OpenCV-2.4.9-intel-2014b.eb
@@ -23,22 +23,16 @@ builddependencies = [
     ('CMake', '3.0.0'),
 ]
 
-python = 'Python'
-pythonver = '2.7.8'
-pythonshortver = '.'.join(pythonver.split('.')[0:2])
-java = 'Java'
-javaver = '1.7.0_60'
-
 dependencies = [
-    (python, pythonver),
+    ('Python', '2.7.8'),
     ('zlib', '1.2.8'),
     ('FFmpeg', '2.4'),
     ('libjpeg-turbo', '1.3.1'),
     ('libpng', '1.6.12'),
     ('LibTIFF', '4.0.3'),
     ('JasPer', '1.900.1'),
-    (java, javaver, '', True),
-    ('ant', '1.9.3', '-%s-%s' % (java, javaver), True),
+    ('Java', '1.7.0_60', '', True),
+    ('ant', '1.9.3', '-Java-%(javaver)s', True),
     ('GLib', '2.40.0')
 ]
 
@@ -46,7 +40,7 @@ preconfigopts = 'export IPPROOT=$EBROOTICC/ipp && '
 
 configopts = '-DCMAKE_BUILD_TYPE=RELEASE '
 configopts += '-DBUILD_PYTHON_SUPPORT=ON '
-configopts += '-DPYTHON_PACKAGES_PATH=$EBROOTPYTHON/lib/python%s/site-packages ' % pythonshortver
+configopts += '-DPYTHON_PACKAGES_PATH=%(installdir)s/lib/python%(pyshortver)s/site-packages '
 configopts += '-DBUILD_NEW_PYTHON_SUPPORT=ON '
 configopts += '-DZLIB_LIBRARY=$EBROOTZLIB/lib/libz.so '
 configopts += '-DZLIB_INCLUDE_DIR=$EBROOTZLIB/include '
@@ -63,13 +57,13 @@ configopts += '-DENABLE_SSE=ON -DENABLE_SSE2=ON -DENABLE_SSE3=ON '
 configopts += '-DWITH_CUDA=OFF '
 
 sanity_check_paths = {
-    'files': ['lib/libopencv_core.%s' % SHLIB_EXT] +
+    'files': ['lib/libopencv_core.%s' % SHLIB_EXT, 'lib/python%(pyshortver)s/site-packages/cv2.so'] +
              ['bin/opencv_%s' % x for x in ['haartraining', 'createsamples', 'performance', 'traincascade']],
     'dirs': ['include']
 }
 
 modextrapaths = {
-    'PYTHONPATH': 'lib/python%s/site-packages' % pythonshortver,
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
     'CLASSPATH': 'share/OpenCV/java',
 }
 


### PR DESCRIPTION
without this, `cv2.so` gets installed in the installation prefix of the Python that is listed as a dependency...

another nice example of why specifying `sanity_check_paths` is useful :)