### PR TITLE
include XZ as dependency for libunwind

### DIFF
--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-ictce-5.3.0.eb
@@ -1,0 +1,33 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'Automake'
+version = "1.15"
+
+homepage = 'http://www.gnu.org/software/automake/automake.html'
+description = "Automake: GNU Standards-compliant Makefile generator"
+
+toolchain = {'name': 'ictce', 'version': '5.3.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('Autoconf', '2.69')]
+
+sanity_check_paths = {
+    'files': ['bin/automake', 'bin/aclocal'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Autotools/Autotools-20150215-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/a/Autotools/Autotools-20150215-ictce-5.3.0.eb
@@ -1,0 +1,17 @@
+easyblock = 'Bundle'
+
+name = 'Autotools'
+version = '20150215'  # date of the most recent change
+
+homepage = 'http://autotools.io'
+description = """This bundle collect the standard GNU build tools: Autoconf, Automake and libtool"""
+
+toolchain = {'name': 'ictce', 'version': '5.3.0'}
+
+dependencies = [
+    ('Autoconf', '2.69'),  # 20120424
+    ('Automake', '1.15'),  # 20150105
+    ('libtool', '2.4.6'),  # 20150215
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/libtool/libtool-2.4.6-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libtool/libtool-2.4.6-ictce-5.3.0.eb
@@ -1,0 +1,17 @@
+easyblock = 'ConfigureMake'
+
+name = 'libtool'
+version = '2.4.6'
+
+homepage = 'http://www.gnu.org/software/libtool'
+description = """GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries
+ behind a consistent, portable interface."""
+
+toolchain = {'name': 'ictce', 'version': '5.3.0'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [('M4', '1.4.16')]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libunwind/libunwind-1.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/l/libunwind/libunwind-1.1-foss-2015a.eb
@@ -15,6 +15,16 @@ toolchain = {'version': '2015a', 'name': 'foss'}
 sources = [SOURCE_TAR_GZ]
 source_urls = [GNU_SAVANNAH_SOURCE]
 
+checksums = [
+    'fb4ea2f6fbbe45bf032cd36e586883ce',     # libunwind-1.1.tar.gz
+]
+
+dependencies = [
+    ('XZ', '5.2.2'),
+]
+
+preconfigopts = 'export LIBS="$LIBS -llzma" && '
+
 sanity_check_paths = {
     'files': ["include/libunwind.h", "lib/libunwind.%s" % SHLIB_EXT],
     'dirs': []

--- a/easybuild/easyconfigs/l/libunwind/libunwind-1.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libunwind/libunwind-1.1-goolf-1.4.10.eb
@@ -15,6 +15,16 @@ toolchain = {'version': '1.4.10', 'name': 'goolf'}
 sources = [SOURCE_TAR_GZ]
 source_urls = [GNU_SAVANNAH_SOURCE]
 
+checksums = [
+    'fb4ea2f6fbbe45bf032cd36e586883ce',     # libunwind-1.1.tar.gz
+]
+
+dependencies = [
+    ('XZ', '5.2.2'),
+]
+
+preconfigopts = 'export LIBS="$LIBS -llzma" && '
+
 sanity_check_paths = {
     'files': ["include/libunwind.h", "lib/libunwind.%s" % SHLIB_EXT],
     'dirs': []

--- a/easybuild/easyconfigs/l/libunwind/libunwind-1.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libunwind/libunwind-1.1-ictce-5.3.0.eb
@@ -15,6 +15,16 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCE_TAR_GZ]
 source_urls = [GNU_SAVANNAH_SOURCE]
 
+checksums = [
+    'fb4ea2f6fbbe45bf032cd36e586883ce',     # libunwind-1.1.tar.gz
+]
+
+dependencies = [
+    ('XZ', '5.2.2'),
+]
+
+preconfigopts = 'export LIBS="$LIBS -llzma" && '
+
 sanity_check_paths = {
     'files': ["include/libunwind.h", "lib/libunwind.%s" % SHLIB_EXT],
     'dirs': []

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2015a.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'XZ'
+version = '5.2.2'
+
+homepage = 'http://tukaani.org/xz/'
+description = "xz: XZ utilities"
+
+toolchain = {'name': 'foss', 'version': '2015a'}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = ['http://tukaani.org/xz/']
+
+builddependencies = [
+    ('Autotools', '20150215'),
+]
+
+dependencies = [
+    ('gettext', '0.19.4'),
+]
+
+# may become useful in non-x86 archs
+#configopts = ' --disable-assembler '
+
+sanity_check_paths = {
+    'files': ["bin/xz", "bin/lzmainfo"],
+    'dirs': []
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-goolf-1.4.10.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'XZ'
+version = '5.2.2'
+
+homepage = 'http://tukaani.org/xz/'
+description = "xz: XZ utilities"
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = ['http://tukaani.org/xz/']
+
+builddependencies = [
+    ('Autotools', '20150215', '', ('GCC', '4.7.2')),
+]
+
+dependencies = [
+    ('gettext', '0.18.2'),
+]
+
+# may become useful in non-x86 archs
+#configopts = ' --disable-assembler '
+
+sanity_check_paths = {
+    'files': ["bin/xz", "bin/lzmainfo"],
+    'dirs': []
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-ictce-5.3.0.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'XZ'
+version = '5.2.2'
+
+homepage = 'http://tukaani.org/xz/'
+description = "xz: XZ utilities"
+
+toolchain = {'name': 'ictce', 'version': '5.3.0'}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = ['http://tukaani.org/xz/']
+
+builddependencies = [
+    ('Autotools', '20150215'),
+]
+
+dependencies = [
+    ('gettext', '0.18.2'),
+]
+
+# may become useful in non-x86 archs
+#configopts = ' --disable-assembler '
+
+sanity_check_paths = {
+    'files': ["bin/xz", "bin/lzmainfo"],
+    'dirs': []
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
run into this while testing https://github.com/hpcugent/easybuild-easyconfigs/pull/2892

workaround with `LIBS` is easier than patching the broken `Makefile`, cfr. https://bugs.gentoo.org/show_bug.cgi?id=444050