### PR TITLE
{math} [foss-2016a] sympy-1.0-foss-2016a-Python-2.7.11

### DIFF
--- a/easybuild/easyconfigs/m/mpmath/mpmath-0.19-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/mpmath/mpmath-0.19-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,34 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Author: Adam Huffman
+# adam.huffman@crick.ac.uk
+# The Francis Crick Institute
+
+easyblock = 'PythonPackage'
+
+name = 'mpmath'
+version = '0.19'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://mpmath.org/'
+description = """mpmath can be used as an arbitrary-precision substitute for Python's float/complex 
+ types and math/cmath modules, but also does much more advanced mathematics. Almost any calculation
+ can be performed just as well at 10-digit or 1000-digit precision, with either real or complex 
+ numbers, and in many cases mpmath implements efficient algorithms that scale well for extremely 
+ high precision work."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://github.com/fredrik-johansson/mpmath/archive/']
+sources = ['%(version)s.tar.gz']
+
+dependencies = [('Python', '2.7.11')]
+
+runtest = 'python -c "import mpmath; mpmath.runtests();"'
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/mpmath'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/s/sympy/sympy-1.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/s/sympy/sympy-1.0-foss-2016a-Python-2.7.11.eb
@@ -27,7 +27,7 @@ runtest = 'python setup.py test'
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s-%(version)-py%(pyshortver)s.egg/%(name)s'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s-%(version)s-py%(pyshortver)s.egg/%(name)s'],
 }
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/s/sympy/sympy-1.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/s/sympy/sympy-1.0-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,33 @@
+easyblock = 'PythonPackage'
+
+name = 'sympy'
+version = '1.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://sympy.org/'
+description = """SymPy is a Python library for symbolic mathematics. It aims to
+ become a full-featured computer algebra system (CAS) while keeping the code as
+ simple as possible in order to be comprehensible and easily extensible. SymPy
+ is written entirely in Python and does not require any external libraries."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+#Patch to fix tests
+patches = ['sympy-1.0_tests-unicode.patch']
+
+dependencies = [
+    ('Python', '2.7.11'),
+    ('mpmath', '0.19', '-Python-%(pyver)s'),
+]
+
+runtest = 'python setup.py test'
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s-%(version)-py%(pyshortver)s.egg/%(name)s'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/s/sympy/sympy-1.0_tests-unicode.patch
+++ b/easybuild/easyconfigs/s/sympy/sympy-1.0_tests-unicode.patch
@@ -1,0 +1,19 @@
+Fix for Unicode error that causes one of the tests to fail
+
+For reference, see 
+http://stackoverflow.com/questions/21129020/how-to-fix-unicodedecodeerror-ascii-codec-cant-decode-byte 
+and http://nedbatchelder.com/text/unipain/unipain.html
+
+
+diff -ur sympy-sympy-1.0/sympy/utilities/autowrap.py sympy-sympy-1.0.new/sympy/utilities/autowrap.py
+--- sympy-sympy-1.0/sympy/utilities/autowrap.py	2016-03-08 18:35:33.000000000 +0000
++++ sympy-sympy-1.0.new/sympy/utilities/autowrap.py	2016-05-15 10:54:52.870235379 +0100
+@@ -164,7 +164,7 @@
+         except CalledProcessError as e:
+             raise CodeWrapError(
+                 "Error while executing command: %s. Command output is:\n%s" % (
+-                    " ".join(command), e.output.decode()))
++                    " ".join(command), e.output.decode('ascii', 'ignore')))
+         if not self.quiet:
+             print(retoutput)
+ 

--- a/easybuild/easyconfigs/s/sympy/sympy-1.0_tests-unicode.patch
+++ b/easybuild/easyconfigs/s/sympy/sympy-1.0_tests-unicode.patch
@@ -4,6 +4,10 @@ For reference, see
 http://stackoverflow.com/questions/21129020/how-to-fix-unicodedecodeerror-ascii-codec-cant-decode-byte 
 and http://nedbatchelder.com/text/unipain/unipain.html
 
+Patch created by:
+
+Adam Huffman
+The Francis Crick Institute
 
 diff -ur sympy-sympy-1.0/sympy/utilities/autowrap.py sympy-sympy-1.0.new/sympy/utilities/autowrap.py
 --- sympy-sympy-1.0/sympy/utilities/autowrap.py	2016-03-08 18:35:33.000000000 +0000


### PR DESCRIPTION
Update sympy to 1.0 and add patch to fix Unicode-related test failure.

sympy now has an external dependency on mpmath, so I've included that too.