### PR TITLE
fix source for snappy 1.1.3, drop autogen

### DIFF
--- a/easybuild/easyconfigs/s/snappy/snappy-1.1.3-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/s/snappy/snappy-1.1.3-GCC-4.9.3-2.25.eb
@@ -8,7 +8,7 @@ description = """Snappy is a compression/decompression library. It does not aim
 for maximum compression, or compatibility with any other compression library;
 instead, it aims for very high speeds and reasonable compression."""
 
-toolchain = {'name': 'GCC', 'version': '4.9.3'}
+toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}
 
 source_urls = ['https://github.com/google/snappy/releases/download/%(version)s']
 sources = [SOURCE_TAR_GZ]


### PR DESCRIPTION
fixing to a commit for 1.1.2 but naming it 1.1.3 is kinda wrong...