### PR TITLE
IPython-4.2 fix so it can be installed offline

### DIFF
--- a/easybuild/easyconfigs/i/IPython/IPython-4.2.0-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-4.2.0-intel-2016a-Python-2.7.11.eb
@@ -58,6 +58,10 @@ exts_list = [
     ('tornado', '4.3', {
         'source_urls': ['https://pypi.python.org/packages/source/t/tornado/'],
     }),
+    ('MarkupSafe', '0.23', {
+        'source_urls': ['https://pypi.io/packages/source/M/MarkupSafe/'],
+	'modulename': 'markupsafe',
+    }),
     ('Jinja2', '2.8', {
         'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2/'],
     }),

--- a/easybuild/easyconfigs/i/IPython/IPython-4.2.0-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-4.2.0-intel-2016a-Python-2.7.11.eb
@@ -97,6 +97,9 @@ exts_list = [
     ('ipython_genutils', '0.1.0', {
         'source_urls': ['https://pypi.python.org/packages/source/i/ipython_genutils/'],
     }),
+    ('pathlib2', '2.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pathlib2/'],
+    }),
     ('pickleshare', '0.7.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pickleshare/'],
     }),
@@ -117,9 +120,6 @@ exts_list = [
     }),
     ('backports.shutil_get_terminal_size', '1.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/b/backports.shutil_get_terminal_size/'],
-    }),
-    ('pathlib2', '2.1.0', {
-        'source_urls': ['https://pypi.python.org/packages/source/p/pathlib2/'],
     }),
     ('ipython', version, {
         'source_urls': ['https://pypi.python.org/packages/source/i/ipython/'],


### PR DESCRIPTION
pathlib is required by pickleshare so it has to be installed before