### PR TITLE
drop 'sources' line from mayavi easyconfigs, since it's a bundle

### DIFF
--- a/easybuild/easyconfigs/m/mayavi/mayavi-4.4.4-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/mayavi/mayavi-4.4.4-intel-2016a-Python-2.7.11.eb
@@ -9,8 +9,6 @@ description = """The Mayavi scientific data 3-dimensional visualizer"""
 
 toolchain = {'name': 'intel', 'version': '2016a'}
 
-sources = [SOURCE_TAR_GZ]
-
 dependencies = [
     ('Python', '2.7.11'),
     ('VTK', '6.3.0', versionsuffix),


### PR DESCRIPTION
this slipped in with #3106, and leads to an error because the source file can not be found (or downloaded, since no source URLs are provided)

the actual source tarball for `mayavi` is downloaded via the extensions