### PR TITLE
Hdf4 foss 2015a

### DIFF
--- a/easybuild/easyconfigs/h/HDF/HDF-4.2.11-foss-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF/HDF-4.2.11-foss-2015a.eb
@@ -1,0 +1,32 @@
+easyblock = 'ConfigureMake'
+
+name = 'HDF'
+version = '4.2.11'
+
+homepage = 'http://www.hdfgroup.org/products/hdf4/'
+description = """HDF4 (also known as HDF) is a library and multi-object file 
+format for storing and managing data between machines."""
+
+toolchain = {'name': 'foss', 'version': '2015a'}
+toolchainopts = {'opt': True, 'pic': True}
+
+dependencies = [
+    ('flex', '2.5.39'),
+    ('Bison', '3.0.2'),
+    ('Szip', '2.1'),
+    ('JasPer', '1.900.1'),
+]
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://www.hdfgroup.org/ftp/HDF/releases/HDF%(version)s/src']
+
+
+configopts = "--with-szlib=$EBROOTSZIP --includedir=%(installdir)s/include/%(namelower)s"
+
+sanity_check_paths = {
+    'files': ['lib/libdf.a', 'lib/libhdf4.settings', 'lib/libmfhdf.a'],
+    'dirs': ['bin', 'include/hdf'],
+}
+
+
+moduleclass = 'data'


### PR DESCRIPTION
Added hdf4 libraries to foss 2014a.  HDF4 is needed to read NASA EOS  data files from Terra and Aqua (Aura uses h5).