### PR TITLE
RAxML 8.2.4-hybrid-avx2 for foss 2016a

### DIFF
--- a/easybuild/easyconfigs/r/RAxML/RAxML-8.2.4-foss-2016a-hybrid-avx2.eb
+++ b/easybuild/easyconfigs/r/RAxML/RAxML-8.2.4-foss-2016a-hybrid-avx2.eb
@@ -2,7 +2,7 @@ easyblock = 'MakeCp'
 
 name = 'RAxML'
 version = '8.2.4'
-versionsuffix ='-hybrid-avx2'
+versionsuffix = '-hybrid-avx2'
 
 homepage = 'https://github.com/stamatak/standard-RAxML'
 description = "RAxML search algorithm for maximum likelihood based inference of phylogenetic trees."

--- a/easybuild/easyconfigs/r/RAxML/RAxML-8.2.4-foss-2016a-hybrid-avx2.eb
+++ b/easybuild/easyconfigs/r/RAxML/RAxML-8.2.4-foss-2016a-hybrid-avx2.eb
@@ -13,7 +13,7 @@ toolchainopts = {'usempi': True}
 sources = ['v%(version)s.zip']
 source_urls = ['https://github.com/stamatak/standard-RAxML/archive/']
 
-buildopts = '-f Makefile.AVX2.HYBRID.gcc'
+buildopts = '-f Makefile.AVX2.HYBRID.gcc CC="$CC"'
 
 files_to_copy = [(["raxmlHPC-HYBRID-AVX2"], "bin"), "usefulScripts", "README", "manual"]
 

--- a/easybuild/easyconfigs/r/RAxML/RAxML-8.2.4-foss-2016a-hybrid-avx2.eb
+++ b/easybuild/easyconfigs/r/RAxML/RAxML-8.2.4-foss-2016a-hybrid-avx2.eb
@@ -1,0 +1,25 @@
+easyblock = 'MakeCp'
+
+name = 'RAxML'
+version = '8.2.4'
+versionsuffix ='-hybrid-avx2'
+
+homepage = 'https://github.com/stamatak/standard-RAxML'
+description = "RAxML search algorithm for maximum likelihood based inference of phylogenetic trees."
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+toolchainopts = {'usempi': True}
+
+sources = ['v%(version)s.zip']
+source_urls = ['https://github.com/stamatak/standard-RAxML/archive/']
+
+buildopts = '-f Makefile.AVX2.HYBRID.gcc'
+
+files_to_copy = [(["raxmlHPC-HYBRID-AVX2"], "bin"), "usefulScripts", "README", "manual"]
+
+sanity_check_paths = {
+    'files': ["bin/raxmlHPC-HYBRID-AVX2"],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
Based on the existing easyconfig for the intel 2015b toolchain.