### PR TITLE
add patch for Boost 1.60.0 to fix bug resulting in TypeError

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.60.0-foss-2015a.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.60.0-foss-2015a.eb
@@ -10,6 +10,8 @@ toolchainopts = {'pic': True, 'usempi': True}
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 source_urls = [SOURCEFORGE_SOURCE]
 
+patches = ['Boost-%(version)s_fix-auto-pointer-reg.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.8'),

--- a/easybuild/easyconfigs/b/Boost/Boost-1.60.0-foss-2015b.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.60.0-foss-2015b.eb
@@ -10,6 +10,8 @@ toolchainopts = {'pic': True, 'usempi': True}
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 source_urls = [SOURCEFORGE_SOURCE]
 
+patches = ['Boost-%(version)s_fix-auto-pointer-reg.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.8'),

--- a/easybuild/easyconfigs/b/Boost/Boost-1.60.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.60.0-foss-2016a-Python-2.7.11.eb
@@ -11,6 +11,8 @@ toolchainopts = {'pic': True, 'usempi': True}
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 
+patches = ['Boost-%(version)s_fix-auto-pointer-reg.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.8'),

--- a/easybuild/easyconfigs/b/Boost/Boost-1.60.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.60.0-foss-2016a.eb
@@ -10,6 +10,8 @@ toolchainopts = {'pic': True, 'usempi': True}
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 source_urls = [SOURCEFORGE_SOURCE]
 
+patches = ['Boost-%(version)s_fix-auto-pointer-reg.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.8'),

--- a/easybuild/easyconfigs/b/Boost/Boost-1.60.0-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.60.0-intel-2016a-Python-2.7.11.eb
@@ -11,6 +11,8 @@ toolchainopts = {'pic': True, 'usempi': True}
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 
+patches = ['Boost-%(version)s_fix-auto-pointer-reg.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.8'),

--- a/easybuild/easyconfigs/b/Boost/Boost-1.60.0-intel-2016a.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.60.0-intel-2016a.eb
@@ -10,6 +10,8 @@ toolchainopts = {'pic': True, 'usempi': True}
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 
+patches = ['Boost-%(version)s_fix-auto-pointer-reg.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.8'),

--- a/easybuild/easyconfigs/b/Boost/Boost-1.60.0_fix-auto-pointer-reg.patch
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.60.0_fix-auto-pointer-reg.patch
@@ -1,0 +1,31 @@
+see https://github.com/boostorg/python/issues/56 and https://github.com/boostorg/python/pull/59
+diff --git a/include/boost/python/object/class_metadata.hpp b/include/boost/python/object/class_metadata.hpp
+index c71cf67..5009c17 100644
+--- a/include/boost/python/object/class_metadata.hpp
++++ b/include/boost/python/object/class_metadata.hpp
+@@ -164,7 +164,7 @@ struct class_metadata
+     >::type held_type;
+ 
+     // Determine if the object will be held by value
+-    typedef is_convertible<held_type*,T*> use_value_holder;
++    typedef mpl::bool_<is_convertible<held_type*,T*>::value> use_value_holder;
+     
+     // Compute the "wrapped type", that is, if held_type is a smart
+     // pointer, we're talking about the pointee.
+@@ -175,10 +175,12 @@ struct class_metadata
+     >::type wrapped;
+ 
+     // Determine whether to use a "back-reference holder"
+-    typedef mpl::or_<
+-        has_back_reference<T>
+-      , is_same<held_type_arg,T>
+-      , is_base_and_derived<T,wrapped>
++    typedef mpl::bool_<
++        mpl::or_<
++            has_back_reference<T>
++          , is_same<held_type_arg,T>
++          , is_base_and_derived<T,wrapped>
++        >::value
+     > use_back_reference;
+ 
+     // Select the holder.


### PR DESCRIPTION
cfr. https://github.com/boostorg/python/issues/56, patch grabbed from https://github.com/boostorg/python/pull/59

This fixes a problem that occurs with Yade:

```
Traceback (most recent call last):
  File "HPC_Yade_Oedometer_Funk.py", line 319, in <module>
    OedometerMasterFunk(packing = 'Random',frictionAngle_Soil=frictionAngle_Soil,limit = limit)                         # SINGLE NODE
  File "HPC_Yade_Oedometer_Funk.py", line 81, in OedometerMasterFunk
    TopSpheres=pack.regularOrtho(pack.inAlignedBox(B_Corner,T_Corner),radius=TopRadius,gap=TopRadius*0.0,color=(1,1,0),material=FricMat6)
  File "/apps/gent/SL6/sandybridge/software/Yade/1.20.0-intel-2016a-Python-2.7.11/lib64/yade-1.20.0/py/yade/pack.py", line 264, in regularOrtho
    if predicate(xyz,radius): ret+=[utils.sphere(xyz,radius=radius,**kw)]
  File "/apps/gent/SL6/sandybridge/software/Yade/1.20.0-intel-2016a-Python-2.7.11/lib64/yade-1.20.0/py/yade/utils.py", line 206, in sphere
    _commonBodySetup(b,V,Vector3(geomInert,geomInert,geomInert),material,pos=center,dynamic=dynamic,fixed=fixed)
  File "/apps/gent/SL6/sandybridge/software/Yade/1.20.0-intel-2016a-Python-2.7.11/lib64/yade-1.20.0/py/yade/utils.py", line 123, in _commonBodySetup
    if resetState: b.state=b.mat.newAssocState()
TypeError: No to_python (by-value) converter found for C++ type: N5boost10shared_ptrI5StateEE
```