### PR TITLE
fix ImageMagick version used as dep for i-cisTarget, Wand requires ImageMagic 6.x

### DIFF
--- a/easybuild/easyconfigs/i/ImageMagick/ImageMagick-6.9.4-8-intel-2016a.eb
+++ b/easybuild/easyconfigs/i/ImageMagick/ImageMagick-6.9.4-8-intel-2016a.eb
@@ -1,0 +1,40 @@
+easyblock = 'ConfigureMake'
+
+name = 'ImageMagick'
+version = '6.9.4-8'
+
+homepage = 'http://www.imagemagick.org/'
+description = """ImageMagick is a software suite to create, edit, compose, or convert bitmap images"""
+
+toolchain = {'name': 'intel', 'version': '2016a'}
+
+sources = [SOURCE_TAR_XZ]
+source_urls = ['http://www.imagemagick.org/download']
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('freetype', '2.6.3'),
+    ('Ghostscript', '9.19'),
+    ('JasPer', '1.900.1'),
+    ('libjpeg-turbo', '1.4.2'),
+    ('LibTIFF', '4.0.6'),
+    ('libX11', '1.6.3'),
+    ('libXext', '1.3.3'),
+    ('libXt', '1.1.5'),
+    ('LittleCMS', '2.7'),
+]
+
+builddependencies = [
+    ('pkg-config', '0.29'),
+]
+
+configopts = "--with-gslib --with-x"
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['bin', 'etc/%(name)s-%(version_major)s', 'include/%(name)s-%(version_major)s', 'lib', 'share'],
+}
+
+modextravars = {'MAGICK_HOME': '%(installdir)s'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/i/i-cisTarget/i-cisTarget-20160602-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/i-cisTarget/i-cisTarget-20160602-intel-2016a-Python-2.7.11.eb
@@ -14,6 +14,10 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 exts_defaultclass = 'PythonPackage'
 
 exts_list = [
+   # airspeed requires this specific version of cachetools
+    ('cachetools', '0.8.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cachetools/'],
+    }),
     ('airspeed', '0.5.4dev-20150515', {
         'source_urls': ['https://pypi.python.org/packages/source/a/airspeed/'],
     }),

--- a/easybuild/easyconfigs/i/i-cisTarget/i-cisTarget-20160602-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/i-cisTarget/i-cisTarget-20160602-intel-2016a-Python-2.7.11.eb
@@ -23,6 +23,7 @@ exts_list = [
     }),
     ('Wand', '0.4.3', {
         'source_urls': ['https://pypi.python.org/packages/source/W/Wand/'],
+        'modulename': 'wand.image',
     }),
     # i-cisTarget sources are not freely available, contact lcbtools@ls.kuleuven.be
     (name, version, {
@@ -35,7 +36,7 @@ dependencies = [
     ('Python', '2.7.11'),
     ('matplotlib', '1.5.1', versionsuffix + '-freetype-2.6.3'),
     ('MySQL-python', '1.2.5', versionsuffix + '-MariaDB-10.1.14'),
-    ('ImageMagick', '7.0.1-9'),
+    ('ImageMagick', '6.9.4-8'),
     ('STAMP', '1.2'),
     ('Cluster-Buster', '20160106'),
     ('Kent_tools', '20130806', '-linux.x86_64', True),


### PR DESCRIPTION
fix for:

```
python -c "import wand.image"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "build/bdist.linux-x86_64/egg/wand/image.py", line 20, in <module>
  File "build/bdist.linux-x86_64/egg/wand/api.py", line 1394, in <module>
ImportError: MagickWand shared library not found or incompatible
Original exception was raised in:
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/wand/api.py", line 289, in <module>
    ctypes.c_void_p]
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/SL6/sandybridge/software/Python/2.7.11-intel-2016a/lib/python2.7/ctypes/__init__.py", line 378, in __getattr__
    func = self.__getitem__(name)
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/SL6/sandybridge/software/Python/2.7.11-intel-2016a/lib/python2.7/ctypes/__init__.py", line 383, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: /user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/SL6/sandybridge/software/ImageMagick/7.0.1-9-intel-2016a/lib/libMagickWand.so: undefined symbol: MagickGetImageMatteColor
```

see also https://github.com/dahlia/wand/issues/287