### PR TITLE
Create NAMD-2.11-intel-2016a-mpi.eb

### DIFF
--- a/easybuild/easyconfigs/n/NAMD/NAMD-2.11-intel-2016a-mpi.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-2.11-intel-2016a-mpi.eb
@@ -1,0 +1,28 @@
+name = 'NAMD'
+version = '2.11'
+versionsuffix = '-mpi'
+
+homepage = 'http://www.ks.uiuc.edu/Research/namd/'
+description = """NAMD is a parallel molecular dynamics code designed for high-performance simulation of large biomolecular systems."""
+
+toolchain = {'name': 'intel', 'version': '2016a'}
+toolchainopts = {'opt': True, 'pic': True, 'usempi': True}
+
+runtest = False
+
+parallel = 12
+
+sources = ['NAMD_%(version)s_Source.tar.gz']
+
+dependencies = [
+    ('Tcl', '8.6.4'),
+    ('FFTW', '3.3.4'),
+]
+
+charm_arch = 'mpi-linux-x86_64'
+
+namd_cfg_opts = " --with-tcl --tcl-prefix $EBROOTTCL "
+
+prebuildopts = 'echo "TCLLIB=-L\$(TCLDIR)/lib -ltcl8.6 -ldl -lpthread" >> Make.config && '
+
+moduleclass = 'chem'


### PR DESCRIPTION
Proposal for building a NAMD 2.11 cpu version, parallelised using MPI.  Using the Intel 2016a toolchain.
Using input from Alan O'Cais, Jülich Supercomputing centre, communicated via the EasyBuild mailing list.