### PR TITLE
also include vsc-install in list of sources, to support offline installation

### DIFF
--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-2.8.1.eb
@@ -11,6 +11,8 @@ description = """EasyBuild is a software build and installation framework
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
+    # vsc-install
+    'https://pypi.python.org/packages/18/7a/c983e61bb91687ad74faab0edd7471b5e78f12cf3c71087581eedc6dd9e5/',
     # vsc-base
     'https://pypi.python.org/packages/c2/b9/8686ca09c21d59d49ce5964cea035d158d84447fdd0c7d1bfc1d2701c17d/',
     # easybuild-framework
@@ -22,6 +24,7 @@ source_urls = [
 ]
 # order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
 sources = [
+    'vsc-install-0.10.6.tar.gz',
     'vsc-base-2.5.1.tar.gz',
     'easybuild-framework-%(version)s.tar.gz',
     'easybuild-easyblocks-%(version)s.tar.gz',


### PR DESCRIPTION
requires https://github.com/hpcugent/easybuild-easyblocks/pull/957 to actually be picked up