### PR TITLE
Dependency not loaded for Lmod built with dummy

### DIFF
--- a/easybuild/easyconfigs/l/Lmod/Lmod-6.4.2.eb
+++ b/easybuild/easyconfigs/l/Lmod/Lmod-6.4.2.eb
@@ -9,7 +9,7 @@ description = """Lmod is a Lua based module system. Modules allow for dynamic mo
  for a complete description. Lmod is a new implementation that easily handles the MODULEPATH
  Hierarchical problem. It is drop-in replacement for TCL/C modules and reads TCL modulefiles directly."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['%(version)s.tar.gz']
 source_urls = [


### PR DESCRIPTION
`dummy` toolchain version causes dependency not to be loaded at build time