### PR TITLE
don't hard specify toolchain for binutils build dep in likwid easyconfig, since it matches parent toolchain

### DIFF
--- a/easybuild/easyconfigs/l/likwid/likwid-4.1.0-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/l/likwid/likwid-4.1.0-GCCcore-4.9.3.eb
@@ -15,7 +15,7 @@ source_urls = ['https://github.com/RRZE-HPC/likwid/archive/']
 
 patches = ['likwid-%(version)s-config-mk.patch']
 
-builddependencies = [('binutils', '2.25', '', ('GCCcore', '4.9.3'))]
+builddependencies = [('binutils', '2.25')]
 
 skipsteps = ['configure']
 buildopts = 'CC="$CC" CFLAGS="$CFLAGS -std=c99" PREFIX=%(installdir)s'


### PR DESCRIPTION
This is not needed, and makes the unit tests fail because the `toolchain_inherited` value for the parsed deps changes from `False` to `True` in the test for the dumped easyconfig