### PR TITLE
define $SVN_REVISION to supress 'Not a git repository' messages in TVB easyconfig

### DIFF
--- a/easybuild/easyconfigs/t/TVB/TVB-1.4.1-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/t/TVB/TVB-1.4.1-intel-2016a-Python-2.7.11.eb
@@ -16,6 +16,7 @@ dependencies = [
     ('tvb-library', '20150922', versionsuffix),
 ]
 
+# SVN revision 7595 corresponds to TVB Distribution v1.4.1
 modextravars = {'SVN_REVISION': '7595'}
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/t/TVB/TVB-1.4.1-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/t/TVB/TVB-1.4.1-intel-2016a-Python-2.7.11.eb
@@ -16,4 +16,6 @@ dependencies = [
     ('tvb-library', '20150922', versionsuffix),
 ]
 
+modextravars = {'SVN_REVISION': '7595'}
+
 moduleclass = 'bio'


### PR DESCRIPTION
without having `$SVN_REVISION` defined, these (alarming looking but actually harmless) warnings are being printed:

```
$ python -c "from tvb.simulator.lab import *"
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
```

cfr. https://groups.google.com/forum/#!topic/tvb-users/ON9kZOeLOX8