### PR TITLE
h5py 2.5.0 built using the foss-2016a toolchain

### DIFF
--- a/easybuild/easyconfigs/h/h5py/h5py-2.5.0-foss-2016a-Python-2.7.11-HDF5-1.8.16.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.5.0-foss-2016a-Python-2.7.11-HDF5-1.8.16.eb
@@ -1,0 +1,34 @@
+easyblock = "PythonPackage"
+
+name = 'h5py'
+version = '2.5.0'
+
+homepage = 'http://www.h5py.org/'
+description = """HDF5 for Python (h5py) is a general-purpose Python interface to the Hierarchical Data Format library,
+ version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
+ amounts of data."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+toolchainopts = {'usempi': True}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+hdf5ver = '1.8.16'
+versionsuffix = '-Python-%%(pyver)s-HDF5-%s' % hdf5ver
+
+# to really use mpi enabled hdf5 we now seem to need a configure step
+prebuildopts = ' python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
+
+dependencies = [
+    ('Python', '2.7.11'),
+    ('HDF5', hdf5ver),
+    ('pkgconfig', '1.1.0', '-Python-%(pyver)s'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.5.0-foss-2016a-Python-3.5.1-HDF5-1.8.16.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.5.0-foss-2016a-Python-3.5.1-HDF5-1.8.16.eb
@@ -1,0 +1,36 @@
+easyblock = "PythonPackage"
+
+name = 'h5py'
+version = '2.5.0'
+
+homepage = 'http://www.h5py.org/'
+description = """HDF5 for Python (h5py) is a general-purpose Python interface to the Hierarchical Data Format library,
+ version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
+ amounts of data."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+toolchainopts = {'usempi': True}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+hdf5ver = '1.8.16'
+versionsuffix = '-Python-%%(pyver)s-HDF5-%s' % hdf5ver
+
+# to really use mpi enabled hdf5 we now seem to need a configure step
+prebuildopts = ' python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
+
+patches = ['h5py-2.5.0-foss-2016a-Python-3.5.1-HDF5-1.8.16.patch']
+
+dependencies = [
+    ('Python', '3.5.1'),
+    ('HDF5', hdf5ver),
+    ('pkgconfig', '1.1.0', '-Python-%(pyver)s'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.5.0-foss-2016a-Python-3.5.1-HDF5-1.8.16.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.5.0-foss-2016a-Python-3.5.1-HDF5-1.8.16.eb
@@ -2,6 +2,8 @@ easyblock = "PythonPackage"
 
 name = 'h5py'
 version = '2.5.0'
+hdf5ver = '1.8.16'
+versionsuffix = '-Python-%%(pyver)s-HDF5-%s' % hdf5ver
 
 homepage = 'http://www.h5py.org/'
 description = """HDF5 for Python (h5py) is a general-purpose Python interface to the Hierarchical Data Format library,
@@ -14,19 +16,16 @@ toolchainopts = {'usempi': True}
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
-hdf5ver = '1.8.16'
-versionsuffix = '-Python-%%(pyver)s-HDF5-%s' % hdf5ver
-
-# to really use mpi enabled hdf5 we now seem to need a configure step
-prebuildopts = ' python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
-
-patches = ['h5py-2.5.0-foss-2016a-Python-3.5.1-HDF5-1.8.16.patch']
+patches = ['h5py-%%(version)s-foss-2016a-Python-%%(pyver)s-HDF5-%s.patch' % hdf5ver]
 
 dependencies = [
     ('Python', '3.5.1'),
     ('HDF5', hdf5ver),
     ('pkgconfig', '1.1.0', '-Python-%(pyver)s'),
 ]
+
+# to really use mpi enabled hdf5 we now seem to need a configure step
+prebuildopts = ' python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
 
 sanity_check_paths = {
     'files': [],

--- a/easybuild/easyconfigs/h/h5py/h5py-2.5.0-foss-2016a-Python-3.5.1-HDF5-1.8.16.patch
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.5.0-foss-2016a-Python-3.5.1-HDF5-1.8.16.patch
@@ -1,0 +1,39 @@
+# Fix to get h5py built using Python 3.5.1 and mpi4py 2.0.0
+# Issue described at: https://github.com/h5py/h5py/issues/567
+# Patch taken from:
+# https://github.com/rdhyee/h5py/commit/f2e3f132fdc1c2308b74e8428c063ac6a8118439.diff
+# Fokke Dijkstra - June 21 2016
+diff --git a/h5py/h5p.pyx b/h5py/h5p.pyx
+index da175dd..42fe4ed 100644
+--- a/h5py/h5p.pyx
++++ b/h5py/h5p.pyx
+@@ -25,7 +25,8 @@ from h5py import _objects
+ from ._objects import phil, with_phil
+ 
+ if MPI:
+-    from mpi4py.mpi_c cimport MPI_Comm, MPI_Info, MPI_Comm_dup, MPI_Info_dup, \
++    # reverse https://github.com/h5py/h5py/commit/bdd573ff73711ccce339a91ac82a058cdd910498
++    from mpi4py.libmpi cimport MPI_Comm, MPI_Info, MPI_Comm_dup, MPI_Info_dup, \
+                                MPI_Comm_free, MPI_Info_free
+ 
+ # Initialization
+diff --git a/setup_build.py b/setup_build.py
+index bc3a8b0..6a360ec 100644
+--- a/setup_build.py
++++ b/setup_build.py
+@@ -169,7 +169,16 @@ def run(self):
+         
+         # Run Cython
+         print("Executing cythonize()")
++
++        # https://github.com/h5py/h5py/issues/532#issuecomment-73631137
++        try:
++            import mpi4py
++            include_path = [mpi4py.get_include(),]
++        except:
++            include_path = []
++
+         self.extensions = cythonize(self._make_extensions(config),
++                            include_path=include_path, 
+                             force=config.rebuild_required or self.force)
+         self.check_rerun_cythonize()


### PR DESCRIPTION
h5py 2.5.0 built using the foss-2016a toolchain. Both for python 2.7.11 and 3.5.1. The latter requires a patch in order for it to built correctly.