### PR TITLE
Version of Junit using Java 1.8.0_77

### DIFF
--- a/easybuild/easyconfigs/j/JUnit/JUnit-4.12-Java-1.8.0_77.eb
+++ b/easybuild/easyconfigs/j/JUnit/JUnit-4.12-Java-1.8.0_77.eb
@@ -2,6 +2,7 @@ easyblock = 'JAR'
 
 name = 'JUnit'
 version = '4.12'
+versionsuffix = '-Java-%(javaver)s'
 
 homepage = 'http://sourceforge.net/projects/junit'
 description = """A programmer-oriented testing framework for Java."""
@@ -11,11 +12,7 @@ toolchain = {'name': 'dummy', 'version': ''}
 sources = ['%(namelower)s-%(version)s.jar']
 source_urls = ['http://search.maven.org/remotecontent?filepath=junit/junit/%(version)s/']
 
-java = 'Java'
-javaver = '1.8.0_77'
-versionsuffix = '-%s-%s' % (java, javaver)
-
-dependencies = [(java, javaver)]
+dependencies = [('Java', '1.8.0_77')]
 
 sanity_check_paths = {
     'files': sources,

--- a/easybuild/easyconfigs/j/JUnit/JUnit-4.12-Java-1.8.0_77.eb
+++ b/easybuild/easyconfigs/j/JUnit/JUnit-4.12-Java-1.8.0_77.eb
@@ -1,0 +1,25 @@
+easyblock = 'JAR'
+
+name = 'JUnit'
+version = '4.12'
+
+homepage = 'http://sourceforge.net/projects/junit'
+description = """A programmer-oriented testing framework for Java."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+sources = ['%(namelower)s-%(version)s.jar']
+source_urls = ['http://search.maven.org/remotecontent?filepath=junit/junit/%(version)s/']
+
+java = 'Java'
+javaver = '1.8.0_77'
+versionsuffix = '-%s-%s' % (java, javaver)
+
+dependencies = [(java, javaver)]
+
+sanity_check_paths = {
+    'files': sources,
+    'dirs': [],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Version of Junit using Java 1.8.0_77.

One of the things I am now running into, is that Java is a moving target. Is it possible to create dependencies on Java 1.7 or 1.8 excluding the subversion? That would make it easy to upgrade Java without having to update configs and reinstall a lot of software.