### PR TITLE
stick to pydot 1.1.0 for Python 2.6 in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ addons:
     packages:
       - tcl8.5
 install:
+    # pydot (dep for python-graph-dot) 1.2.0 and more recent doesn't work with Python 2.6
+    - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install pydot==1.1.0; else pip install pydot; fi
     # required for test_dep_graph
     - pip install python-graph-core python-graph-dot
     # install easybuild-framework/easybuild-easyblocks (and dependencies)


### PR DESCRIPTION
pydot 1.2.x that was released over the weekend is no longer compatible with Python 2.6