### PR TITLE
{math}[foss/2016a] JAGS 4.2.0

### DIFF
--- a/easybuild/easyconfigs/j/JAGS/JAGS-4.2.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/j/JAGS/JAGS-4.2.0-foss-2016a.eb
@@ -17,7 +17,7 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 source_urls = [('http://sourceforge.net/projects/mcmc-jags/files/JAGS/%(version_major)s.x/Source/', 'download')]
 sources = [SOURCE_TAR_GZ]
 
-configopts = ' --with-blas="-lopenblas" --with-lapack="-lopenblas" '
+configopts = ' --with-blas="$LIBBLAS" --with-lapack="$LIBLAPACK" '
 
 sanity_check_paths = {
     'files': ["bin/jags", "libexec/jags-terminal", "lib/libjags.%s" % SHLIB_EXT],

--- a/easybuild/easyconfigs/j/JAGS/JAGS-4.2.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/j/JAGS/JAGS-4.2.0-foss-2016a.eb
@@ -17,7 +17,7 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 source_urls = [('http://sourceforge.net/projects/mcmc-jags/files/JAGS/%(version_major)s.x/Source/', 'download')]
 sources = [SOURCE_TAR_GZ]
 
-configopts = ' --with-blas="-lopenblas" --with-lapack="-llapack" '
+configopts = ' --with-blas="-lopenblas" --with-lapack="-lopenblas" '
 
 sanity_check_paths = {
     'files': ["bin/jags", "libexec/jags-terminal", "lib/libjags.%s" % SHLIB_EXT],

--- a/easybuild/easyconfigs/j/JAGS/JAGS-4.2.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/j/JAGS/JAGS-4.2.0-foss-2016a.eb
@@ -1,0 +1,32 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics
+# Biozentrum - University of Basel
+
+easyblock = 'ConfigureMake'
+
+name = 'JAGS'
+version = '4.2.0'
+
+homepage = 'http://mcmc-jags.sourceforge.net/'
+description = """JAGS is Just Another Gibbs Sampler.  It is a program for analysis 
+ of Bayesian hierarchical models using Markov Chain Monte Carlo (MCMC) simulation  """
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = [('http://sourceforge.net/projects/mcmc-jags/files/JAGS/%(version_major)s.x/Source/', 'download')]
+sources = [SOURCE_TAR_GZ]
+
+configopts = ' --with-blas="-lopenblas" --with-lapack="-llapack" '
+
+sanity_check_paths = {
+    'files': ["bin/jags", "libexec/jags-terminal", "lib/libjags.%s" % SHLIB_EXT],
+    'dirs': []
+}
+
+modextrapaths = {
+    'JAGS_INCLUDE': 'include/JAGS',
+    'JAGS_LIB': 'lib',
+}
+
+moduleclass = 'math'


### PR DESCRIPTION
Based on the existing easyconfig for intel/2016a.

I did replace the hardcoded library names for BLAS and LAPACK by $LIBBLAS and $LIBLAPACK: this also means that OpenBLAS is now used for both BLAS and LAPACK functionality for this version, instead of linking to a separate LAPACK library as was done in an older easyconfig for the goolf toolchain.