### PR TITLE
add easyconfig for cuDNN 5.0 (GA) for CUDA 7.5

### DIFF
--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-5.0-CUDA-7.5.18.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-5.0-CUDA-7.5.18.eb
@@ -21,11 +21,11 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 # Download link: https://developer.nvidia.com/rdp/cudnn-download
 sources = ['%(namelower)s-7.5-linux-x64-v%(version)s-ga.tgz']
 
-dependencies = [('CUDA', cuda_version)]
-
 checksums = [
     '6f9110f66c8a48e15766b1f8c2a1baf3',    # cudnn-7.5-linux-x64-v5.0-ga.tgz
 ]
+
+dependencies = [('CUDA', cuda_version)]
 
 sanity_check_paths = {
     'files': ['include/cudnn.h', 'lib64/libcudnn_static.a'],

--- a/easybuild/easyconfigs/c/cuDNN/cuDNN-5.0-CUDA-7.5.18.eb
+++ b/easybuild/easyconfigs/c/cuDNN/cuDNN-5.0-CUDA-7.5.18.eb
@@ -1,0 +1,35 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Author:    Stephane Thiell <sthiell@stanford.edu>
+##
+easyblock = 'Tarball'
+
+name = 'cuDNN'
+version = '5.0'
+cuda_version = '7.5.18'
+
+versionsuffix = '-CUDA-%s' % cuda_version
+
+homepage = 'https://developer.nvidia.com/cudnn'
+description = """The NVIDIA CUDA Deep Neural Network library (cuDNN) is a GPU-accelerated library of primitives for
+    deep neural networks."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+# Nvidia developer registration required.
+# Download link: https://developer.nvidia.com/rdp/cudnn-download
+sources = ['%(namelower)s-7.5-linux-x64-v%(version)s-ga.tgz']
+
+dependencies = [('CUDA', cuda_version)]
+
+checksums = [
+    '6f9110f66c8a48e15766b1f8c2a1baf3',    # cudnn-7.5-linux-x64-v5.0-ga.tgz
+]
+
+sanity_check_paths = {
+    'files': ['include/cudnn.h', 'lib64/libcudnn_static.a'],
+    'dirs': ['include', 'lib64'],
+}
+
+moduleclass = 'numlib'


### PR DESCRIPTION
We need to specify the CUDA version now as there is a dependency on CUDA (eg. there will be a different cuDNN 5.0 for CUDA 8.0). I still have a 7.5 hardcoded here in the archive name, any idea welcomed to improve it.