### PR TITLE
{bio}[foss/2016a] EIGENSOFT 6.0.1 and 6.1.1

### DIFF
--- a/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.0.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.0.1-foss-2016a.eb
@@ -1,0 +1,45 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Pablo Escobar Lopez
+# sciCORE - University of Basel
+# SIB Swiss Institute of Bioinformatics 
+
+# Provided binaries required OpenBLAS and GSL libraries
+
+easyblock = 'MakeCp'
+
+name = 'EIGENSOFT'
+version = '6.0.1'
+
+homepage = 'http://www.hsph.harvard.edu/alkes-price/software/'
+description = """The EIGENSOFT package combines functionality from our population genetics methods (Patterson et al. 2006) 
+ and our EIGENSTRAT stratification correction method (Price et al. 2006). The EIGENSTRAT method uses principal components 
+ analysis to explicitly model ancestry differences between cases and controls along continuous axes of variation; 
+ the resulting correction is specific to a candidate marker’s variation in frequency across ancestral populations, 
+ minimizing spurious associations while maximizing power to detect true associations. The EIGENSOFT package has a built-in 
+ plotting script and supports multiple file formats and quantitative phenotypes."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = [
+    'https://data.broadinstitute.org/alkesgroup/EIGENSOFT/',
+    'https://data.broadinstitute.org/alkesgroup/EIGENSOFT/OLD/']
+sources = ['EIG%(version)s.tar.gz']
+
+dependencies = [
+	('GSL', '2.1'),
+]
+
+# -lm and -pthread are missing in the Makefile
+# also run "make install" after make to copy all binaries to the bin dir
+buildopts = 'LDLIBS="-lgsl -lopenblas -lgfortran -lrt -lm" LDFLAGS="$LDFLAGS -pthread" && make install'
+
+start_dir = 'src'
+
+files_to_copy = ['bin', 'CONVERTF', 'EIGENSTRAT', 'POPGEN', 'README']
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ["baseprog", "convertf", "eigenstrat", "eigenstratQTL"]],
+    'dirs': []
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.0.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.0.1-foss-2016a.eb
@@ -11,12 +11,12 @@ name = 'EIGENSOFT'
 version = '6.0.1'
 
 homepage = 'http://www.hsph.harvard.edu/alkes-price/software/'
-description = """The EIGENSOFT package combines functionality from our population genetics methods (Patterson et al. 2006) 
- and our EIGENSTRAT stratification correction method (Price et al. 2006). The EIGENSTRAT method uses principal components 
- analysis to explicitly model ancestry differences between cases and controls along continuous axes of variation; 
- the resulting correction is specific to a candidate marker’s variation in frequency across ancestral populations, 
- minimizing spurious associations while maximizing power to detect true associations. The EIGENSOFT package has a built-in 
- plotting script and supports multiple file formats and quantitative phenotypes."""
+description = """The EIGENSOFT package combines functionality from our population genetics methods (Patterson et al. 
+2006)  and our EIGENSTRAT stratification correction method (Price et al. 2006). The EIGENSTRAT method uses principal 
+components  analysis to explicitly model ancestry differences between cases and controls along continuous axes of 
+variation;  the resulting correction is specific to a candidate marker’s variation in frequency across ancestral 
+populations,  minimizing spurious associations while maximizing power to detect true associations. The EIGENSOFT 
+package has a built-in plotting script and supports multiple file formats and quantitative phenotypes."""
 
 toolchain = {'name': 'foss', 'version': '2016a'}
 

--- a/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.0.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.0.1-foss-2016a.eb
@@ -31,7 +31,7 @@ dependencies = [
 
 # -lm and -pthread are missing in the Makefile
 # also run "make install" after make to copy all binaries to the bin dir
-buildopts = 'LDLIBS="-lgsl -lopenblas -lgfortran -lrt -lm" LDFLAGS="$LDFLAGS -pthread" && make install'
+buildopts = 'LDLIBS="-lgsl $LIBBLAS -lrt -lm" LDFLAGS="$LDFLAGS -pthread" && make install'
 
 start_dir = 'src'
 

--- a/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.0.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.0.1-foss-2016a.eb
@@ -22,7 +22,8 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 
 source_urls = [
     'https://data.broadinstitute.org/alkesgroup/EIGENSOFT/',
-    'https://data.broadinstitute.org/alkesgroup/EIGENSOFT/OLD/']
+    'https://data.broadinstitute.org/alkesgroup/EIGENSOFT/OLD/'
+]
 sources = ['EIG%(version)s.tar.gz']
 
 dependencies = [

--- a/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-foss-2016a.eb
@@ -11,12 +11,12 @@ name = 'EIGENSOFT'
 version = '6.1.1'
 
 homepage = 'http://www.hsph.harvard.edu/alkes-price/software/'
-description = """The EIGENSOFT package combines functionality from our population genetics methods (Patterson et al. 2006) 
- and our EIGENSTRAT stratification correction method (Price et al. 2006). The EIGENSTRAT method uses principal components 
- analysis to explicitly model ancestry differences between cases and controls along continuous axes of variation; 
- the resulting correction is specific to a candidate marker’s variation in frequency across ancestral populations, 
- minimizing spurious associations while maximizing power to detect true associations. The EIGENSOFT package has a built-in 
- plotting script and supports multiple file formats and quantitative phenotypes."""
+description = """The EIGENSOFT package combines functionality from our population genetics methods (Patterson et al. 
+2006)  and our EIGENSTRAT stratification correction method (Price et al. 2006). The EIGENSTRAT method uses principal 
+components  analysis to explicitly model ancestry differences between cases and controls along continuous axes of 
+variation;  the resulting correction is specific to a candidate marker’s variation in frequency across ancestral 
+populations,  minimizing spurious associations while maximizing power to detect true associations. The EIGENSOFT 
+package has a built-in plotting script and supports multiple file formats and quantitative phenotypes."""
 
 toolchain = {'name': 'foss', 'version': '2016a'}
 

--- a/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-foss-2016a.eb
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 # -lm and -pthread are missing in the Makefile
-buildopts = 'LDLIBS="-lgsl -lopenblas -lgfortran -lrt -lm" LDFLAGS="-pthread"'
+buildopts = 'LDLIBS="-lgsl -lopenblas -lgfortran -lrt -lm" LDFLAGS="$LDFLAGS -pthread" && make install'
 
 start_dir = 'src'
 

--- a/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-foss-2016a.eb
@@ -1,0 +1,44 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Pablo Escobar Lopez
+# sciCORE - University of Basel
+# SIB Swiss Institute of Bioinformatics 
+
+# Provided binaries required OpenBLAS and GSL libraries
+
+easyblock = 'MakeCp'
+
+name = 'EIGENSOFT'
+version = '6.1.1'
+
+homepage = 'http://www.hsph.harvard.edu/alkes-price/software/'
+description = """The EIGENSOFT package combines functionality from our population genetics methods (Patterson et al. 2006) 
+ and our EIGENSTRAT stratification correction method (Price et al. 2006). The EIGENSTRAT method uses principal components 
+ analysis to explicitly model ancestry differences between cases and controls along continuous axes of variation; 
+ the resulting correction is specific to a candidate marker’s variation in frequency across ancestral populations, 
+ minimizing spurious associations while maximizing power to detect true associations. The EIGENSOFT package has a built-in 
+ plotting script and supports multiple file formats and quantitative phenotypes."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = [
+    'https://data.broadinstitute.org/alkesgroup/EIGENSOFT/',
+    'https://data.broadinstitute.org/alkesgroup/EIGENSOFT/OLD/']
+sources = ['EIG%(version)s.tar.gz']
+
+dependencies = [
+	('GSL', '2.1'),
+]
+
+# -lm and -pthread are missing in the Makefile
+buildopts = 'LDLIBS="-lgsl -lopenblas -lgfortran -lrt -lm" LDFLAGS="-pthread"'
+
+start_dir = 'src'
+
+files_to_copy = ['bin', 'CONVERTF', 'EIGENSTRAT', 'POPGEN', 'README']
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ["baseprog", "convertf", "eigenstrat", "eigenstratQTL"]],
+    'dirs': []
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-foss-2016a.eb
@@ -30,7 +30,8 @@ dependencies = [
 ]
 
 # -lm and -pthread are missing in the Makefile
-buildopts = 'LDLIBS="-lgsl -lopenblas -lgfortran -lrt -lm" LDFLAGS="$LDFLAGS -pthread" && make install'
+# also run "make install" after make to copy all binaries to the bin dir
+buildopts = 'LDLIBS="-lgsl $LIBBLAS -lrt -lm" LDFLAGS="$LDFLAGS -pthread" && make install'
 
 start_dir = 'src'
 

--- a/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/e/EIGENSOFT/EIGENSOFT-6.1.1-foss-2016a.eb
@@ -22,7 +22,8 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 
 source_urls = [
     'https://data.broadinstitute.org/alkesgroup/EIGENSOFT/',
-    'https://data.broadinstitute.org/alkesgroup/EIGENSOFT/OLD/']
+    'https://data.broadinstitute.org/alkesgroup/EIGENSOFT/OLD/'
+]
 sources = ['EIG%(version)s.tar.gz']
 
 dependencies = [


### PR DESCRIPTION
I took the existing easyconfig EIGENSOFT-6.1.1-goolf-1.7.20.eb, but converted it from Tarball to MakeCp: the source tarball contains both source files and precompiled executables, this easyconfig rebuilds the executables.