### PR TITLE
Add IPython 5.0.0 and missing dependencies.

### DIFF
--- a/easybuild/easyconfigs/c/configparser/configparser-3.5.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/c/configparser/configparser-3.5.0-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,40 @@
+easyblock = 'PythonPackage'
+
+name = 'configparser'
+version = '3.5.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://docs.python.org/3/library/configparser.html'
+description = """configparser is a Python library that brings the updated configparser from Python 3.5 to Python 2.6-3.5."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://pypi.python.org/packages/7c/69/c2ce7e91c89dc073eb1aa74c0621c3eefbffe8216b3f9af9d3885265c01c/']
+sources = ['configparser-3.5.0.tar.gz']
+
+dependencies = [
+    ('Python', '2.7.11'),
+]
+builddependencies = [
+    ('pip', '8.1.2', versionsuffix),
+]
+
+use_pip = True
+unpack_sources = False
+
+sanity_check_paths = {
+    'files': ['lib/python%(pyshortver)s/site-packages/configparser.py'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/backports/configparser'],
+}
+
+# XXX: hack! for some reason the sanity check imports fail, even though the
+# PYTHONPATH seems to point to the right directory?!? Creating the __init__.py
+# in backports makes it pass and hopefully does not break anything.
+postinstallcmds = ['touch %(installdir)s/lib/python%(pyshortver)s/site-packages/backports/__init__.py']
+
+sanity_check_commands = [
+    ('python', "-c 'import configparser'"),
+    ('python', "-c 'from backports import configparser'"),
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/c/configparser/configparser-3.5.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/c/configparser/configparser-3.5.0-foss-2016a-Python-2.7.11.eb
@@ -5,12 +5,12 @@ version = '3.5.0'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'http://docs.python.org/3/library/configparser.html'
-description = """configparser is a Python library that brings the updated configparser from Python 3.5 to Python 2.6-3.5."""
+description = "configparser is a Python library that brings the updated configparser from Python 3.5 to Python 2.6-3.5"
 
 toolchain = {'name': 'foss', 'version': '2016a'}
 
 source_urls = ['https://pypi.python.org/packages/7c/69/c2ce7e91c89dc073eb1aa74c0621c3eefbffe8216b3f9af9d3885265c01c/']
-sources = ['configparser-3.5.0.tar.gz']
+sources = ['configparser-%(version)s.tar.gz']
 
 dependencies = [
     ('Python', '2.7.11'),

--- a/easybuild/easyconfigs/e/entrypoints/entrypoints-0.2.2-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/e/entrypoints/entrypoints-0.2.2-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,31 @@
+easyblock = 'PythonPackage'
+
+name = 'entrypoints'
+version = '0.2.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/takluyver/entrypoints'
+description = """Entry points are a way for Python packages to advertise objects with some common interface."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://pypi.python.org/packages/f8/ad/0e77a853c745a15981ab51fa9a0cb4eca7a7a007b4c1970106ee6ba01e0c/']
+sources = ['entrypoints-0.2.2-py2.py3-none-any.whl']
+
+dependencies = [
+    ('Python', '2.7.11'),
+    ('configparser', '3.5.0', versionsuffix),
+]
+builddependencies = [
+    ('pip', '8.1.2', versionsuffix),
+]
+
+use_pip = True
+unpack_sources = False
+
+sanity_check_paths = {
+    'files': ['lib/python%(pyshortver)s/site-packages/entrypoints.py'],
+    'dirs': []
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/e/entrypoints/entrypoints-0.2.2-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/e/entrypoints/entrypoints-0.2.2-foss-2016a-Python-3.5.1.eb
@@ -1,0 +1,27 @@
+easyblock = 'PythonPackage'
+
+name = 'entrypoints'
+version = '0.2.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/takluyver/entrypoints'
+description = """Entry points are a way for Python packages to advertise objects with some common interface."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://pypi.python.org/packages/f8/ad/0e77a853c745a15981ab51fa9a0cb4eca7a7a007b4c1970106ee6ba01e0c/']
+sources = ['entrypoints-0.2.2-py2.py3-none-any.whl']
+
+dependencies = [
+    ('Python', '3.5.1'),
+]
+
+use_pip = True
+unpack_sources = False
+
+sanity_check_paths = {
+    'files': ['lib/python%(pyshortver)s/site-packages/entrypoints.py'],
+    'dirs': []
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/i/IPython/IPython-5.0.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-5.0.0-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,142 @@
+easyblock = 'Bundle'
+
+name = 'IPython'
+version = '5.0.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://ipython.org/index.html'
+description = """IPython provides a rich architecture for interactive computing with:
+ Powerful interactive shells (terminal and Qt-based).
+ A browser-based notebook with support for code, text, mathematical expressions, inline plots and other rich media.
+ Support for interactive data visualization and use of GUI toolkits.
+ Flexible, embeddable interpreters to load into your own projects.
+ Easy to use, high performance tools for parallel computing."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+dependencies = [
+    ('Python', '2.7.11'),
+    ('PyZMQ', '15.3.0', '%s-zmq4' % versionsuffix),
+    ('testpath', '0.3', versionsuffix),
+    ('entrypoints', '0.2.2', versionsuffix),
+    ('path.py', '8.2.1', versionsuffix),
+    ('prompt-toolkit', '1.0.3', versionsuffix),
+]
+
+# this is a bundle of Python packages
+# XXX: the wheel packages (testpath, entrypoints, path.py, prompt-toolkit) have
+# to be included as dependencies because bundling wheels does not work
+exts_defaultclass = 'PythonPackage'
+exts_filter = ("python -c 'import %(ext_name)s'", '')
+
+exts_list = [
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    ('requests', '2.10.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
+    }),
+    ('nbformat', '4.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nbformat/'],
+    }),
+    ('Pygments', '2.1.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/P/Pygments/'],
+    }),
+    ('singledispatch', '3.4.0.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/singledispatch/'],
+    }),
+    ('certifi', '2016.2.28', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
+    }),
+    ('backports_abc', '0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/backports_abc/'],
+    }),
+    ('tornado', '4.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/t/tornado/'],
+    }),
+    ('MarkupSafe', '0.23', {
+        'source_urls': ['https://pypi.python.org/packages/source/M/MarkupSafe/'],
+        'modulename': 'markupsafe',
+    }),
+    ('Jinja2', '2.8', {
+        'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2/'],
+    }),
+    ('jupyter_client', '4.3.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_client/'],
+    }),
+    ('functools32', '3.2.3-2', {
+        'source_urls': ['https://pypi.python.org/packages/source/f/functools32/'],
+    }),
+    ('jsonschema', '2.5.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema/'],
+    }),
+    ('mistune', '0.7.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mistune/'],
+    }),
+    ('ptyprocess', '0.5.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/ptyprocess/'],
+    }),
+    ('terminado', '0.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/t/terminado/'],
+    }),
+    ('setuptools', '24.0.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+    }),
+    ('simplegeneric', '0.8.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/simplegeneric/'],
+        'source_tmpl': 'simplegeneric-%(version)s.zip',
+    }),
+    ('ipython_genutils', '0.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipython_genutils/'],
+    }),
+    ('pathlib2', '2.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pathlib2/'],
+    }),
+    ('pickleshare', '0.7.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pickleshare/'],
+    }),
+    ('traitlets', '4.2.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/t/traitlets/'],
+    }),
+    ('notebook', '4.2.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/notebook/'],
+    }),
+    ('jupyter_core', '4.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_core/'],
+    }),
+    ('ipykernel', '4.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipykernel/'],
+    }),
+    ('pexpect', '4.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pexpect/'],
+    }),
+    ('nbconvert', '4.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
+    }),
+    ('backports.shutil_get_terminal_size', '1.0.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/backports.shutil_get_terminal_size/'],
+    }),
+    ('decorator', '4.0.10', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+    }),
+    ('ipython', version, {
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipython/'],
+        'modulename': 'IPython',
+    }),
+]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+sanity_check_paths = {
+    'files': ['bin/ipython'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/IPython'],
+}
+
+sanity_check_commands = [
+    ('ipython -h', ''),
+    ('ipython notebook --help', ''),
+    ('iptest', ''),
+    ('iptest2', ''),
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/i/IPython/IPython-5.0.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-5.0.0-foss-2016a-Python-2.7.11.eb
@@ -121,6 +121,7 @@ exts_list = [
     }),
     ('ipython', version, {
         'source_urls': ['https://pypi.python.org/packages/source/i/ipython/'],
+        'patches': ['ipython-5.0.0_fix-test-paths-symlink.patch'],
         'modulename': 'IPython',
     }),
 ]

--- a/easybuild/easyconfigs/i/IPython/IPython-5.0.0-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-5.0.0-foss-2016a-Python-3.5.1.eb
@@ -1,0 +1,124 @@
+easyblock = 'Bundle'
+
+name = 'IPython'
+version = '5.0.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://ipython.org/index.html'
+description = """IPython provides a rich architecture for interactive computing with:
+ Powerful interactive shells (terminal and Qt-based).
+ A browser-based notebook with support for code, text, mathematical expressions, inline plots and other rich media.
+ Support for interactive data visualization and use of GUI toolkits.
+ Flexible, embeddable interpreters to load into your own projects.
+ Easy to use, high performance tools for parallel computing."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+dependencies = [
+    ('Python', '3.5.1'),
+    ('PyZMQ', '15.3.0', '%s-zmq4' % versionsuffix),
+    ('testpath', '0.3', versionsuffix),
+    ('entrypoints', '0.2.2', versionsuffix),
+    ('path.py', '8.2.1', versionsuffix),
+    ('prompt-toolkit', '1.0.3', versionsuffix),
+]
+
+# this is a bundle of Python packages
+# XXX: the wheel packages (testpath, entrypoints, path.py, prompt-toolkit) have
+# to be included as dependencies because bundling wheels does not work
+exts_defaultclass = 'PythonPackage'
+exts_filter = ("python -c 'import %(ext_name)s'", '')
+
+exts_list = [
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    ('requests', '2.10.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
+    }),
+    ('nbformat', '4.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nbformat/'],
+    }),
+    ('Pygments', '2.1.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/P/Pygments/'],
+    }),
+    ('tornado', '4.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/t/tornado/'],
+    }),
+    ('MarkupSafe', '0.23', {
+        'source_urls': ['https://pypi.python.org/packages/source/M/MarkupSafe/'],
+        'modulename': 'markupsafe',
+    }),
+    ('Jinja2', '2.8', {
+        'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2/'],
+    }),
+    ('jupyter_client', '4.3.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_client/'],
+    }),
+    ('jsonschema', '2.5.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema/'],
+    }),
+    ('mistune', '0.7.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mistune/'],
+    }),
+    ('ptyprocess', '0.5.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/ptyprocess/'],
+    }),
+    ('terminado', '0.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/t/terminado/'],
+    }),
+    ('setuptools', '24.0.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+    }),
+    ('simplegeneric', '0.8.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/simplegeneric/'],
+        'source_tmpl': 'simplegeneric-%(version)s.zip',
+    }),
+    ('ipython_genutils', '0.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipython_genutils/'],
+    }),
+    ('pickleshare', '0.7.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pickleshare/'],
+    }),
+    ('traitlets', '4.2.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/t/traitlets/'],
+    }),
+    ('notebook', '4.2.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/notebook/'],
+    }),
+    ('jupyter_core', '4.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_core/'],
+    }),
+    ('ipykernel', '4.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipykernel/'],
+    }),
+    ('pexpect', '4.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pexpect/'],
+    }),
+    ('nbconvert', '4.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
+    }),
+    ('decorator', '4.0.10', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+    }),
+    ('ipython', version, {
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipython/'],
+        'modulename': 'IPython',
+    }),
+]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+sanity_check_paths = {
+    'files': ['bin/ipython'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/IPython'],
+}
+
+sanity_check_commands = [
+    ('ipython -h', ''),
+    ('ipython notebook --help', ''),
+    ('iptest', ''),
+    ('iptest3', ''),
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/i/IPython/IPython-5.0.0-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-5.0.0-foss-2016a-Python-3.5.1.eb
@@ -103,6 +103,7 @@ exts_list = [
     }),
     ('ipython', version, {
         'source_urls': ['https://pypi.python.org/packages/source/i/ipython/'],
+        'patches': ['ipython-5.0.0_fix-test-paths-symlink.patch'],
         'modulename': 'IPython',
     }),
 ]

--- a/easybuild/easyconfigs/i/IPython/ipython-5.0.0_fix-test-paths-symlink.patch
+++ b/easybuild/easyconfigs/i/IPython/ipython-5.0.0_fix-test-paths-symlink.patch
@@ -1,0 +1,14 @@
+take into account that $TMPDIR may be a symlinked directory, this is required because path equality is checked
+in some tests
+author: Kenneth Hoste (HPC-UGent)
+--- ipython-5.0.0/IPython/core/tests/test_paths.py.orig	2016-08-17 11:11:24.104380000 +0200
++++ ipython-5.0.0/IPython/core/tests/test_paths.py	2016-08-17 11:11:24.153308000 +0200
+@@ -17,7 +17,7 @@
+ from IPython.testing.decorators import skip_win32
+ from IPython.utils.tempdir import TemporaryDirectory
+ 
+-TMP_TEST_DIR = tempfile.mkdtemp()
++TMP_TEST_DIR = os.path.realpath(tempfile.mkdtemp())
+ HOME_TEST_DIR = os.path.join(TMP_TEST_DIR, "home_test_dir")
+ XDG_TEST_DIR = os.path.join(HOME_TEST_DIR, "xdg_test_dir")
+ XDG_CACHE_DIR = os.path.join(HOME_TEST_DIR, "xdg_cache_dir")

--- a/easybuild/easyconfigs/p/PyZMQ/PyZMQ-15.3.0-foss-2016a-Python-2.7.11-zmq4.eb
+++ b/easybuild/easyconfigs/p/PyZMQ/PyZMQ-15.3.0-foss-2016a-Python-2.7.11-zmq4.eb
@@ -1,0 +1,28 @@
+easyblock = 'PythonPackage'
+
+name = 'PyZMQ'
+version = '15.3.0'
+zmqversion = '4.1.4'
+versionsuffix = '-Python-%%(pyver)s-zmq%s' % zmqversion.split('.')[0]
+
+homepage = 'http://www.zeromq.org/bindings:python'
+description = """Python bindings for ZeroMQ"""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = [PYPI_LOWER_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('Python', '2.7.11'),
+    ('ZeroMQ', zmqversion),
+]
+
+options = {'modulename': 'zmq'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/zmq'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/PyZMQ/PyZMQ-15.3.0-foss-2016a-Python-3.5.1-zmq4.eb
+++ b/easybuild/easyconfigs/p/PyZMQ/PyZMQ-15.3.0-foss-2016a-Python-3.5.1-zmq4.eb
@@ -1,0 +1,28 @@
+easyblock = 'PythonPackage'
+
+name = 'PyZMQ'
+version = '15.3.0'
+zmqversion = '4.1.4'
+versionsuffix = '-Python-%%(pyver)s-zmq%s' % zmqversion.split('.')[0]
+
+homepage = 'http://www.zeromq.org/bindings:python'
+description = """Python bindings for ZeroMQ"""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = [PYPI_LOWER_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('Python', '3.5.1'),
+    ('ZeroMQ', zmqversion),
+]
+
+options = {'modulename': 'zmq'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/zmq'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/path.py/path.py-8.2.1-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/path.py/path.py-8.2.1-foss-2016a-Python-2.7.11.eb
@@ -5,7 +5,8 @@ version = '8.2.1'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://github.com/jaraco/path.py'
-description = """path.py is a Python library implementing path objects as first-class entities, allowing common operations on files to be invoked on those path objects directly."""
+description = """path.py is a Python library implementing path objects as first-class entities,
+ allowing common operations on files to be invoked on those path objects directly."""
 
 toolchain = {'name': 'foss', 'version': '2016a'}
 

--- a/easybuild/easyconfigs/p/path.py/path.py-8.2.1-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/path.py/path.py-8.2.1-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,32 @@
+easyblock = 'PythonPackage'
+
+name = 'path.py'
+version = '8.2.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/jaraco/path.py'
+description = """path.py is a Python library implementing path objects as first-class entities, allowing common operations on files to be invoked on those path objects directly."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://pypi.python.org/packages/fc/fc/dcae2146aed6becbea77158eddb4e437718170efeade0f7fdf0aebe46b94/']
+sources = ['path.py-%(version)s-py2.py3-none-any.whl']
+
+dependencies = [
+    ('Python', '2.7.11'),
+]
+builddependencies = [
+    ('pip', '8.1.2', versionsuffix),
+]
+
+use_pip = True
+unpack_sources = False
+
+sanity_check_paths = {
+    'files': ['lib/python%(pyshortver)s/site-packages/path.py'],
+    'dirs': [],
+}
+
+options = {'modulename': 'path'}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/path.py/path.py-8.2.1-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/p/path.py/path.py-8.2.1-foss-2016a-Python-3.5.1.eb
@@ -1,0 +1,29 @@
+easyblock = 'PythonPackage'
+
+name = 'path.py'
+version = '8.2.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/jaraco/path.py'
+description = """path.py is a Python library implementing path objects as first-class entities, allowing common operations on files to be invoked on those path objects directly."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://pypi.python.org/packages/fc/fc/dcae2146aed6becbea77158eddb4e437718170efeade0f7fdf0aebe46b94/']
+sources = ['path.py-%(version)s-py2.py3-none-any.whl']
+
+dependencies = [
+    ('Python', '3.5.1'),
+]
+
+use_pip = True
+unpack_sources = False
+
+sanity_check_paths = {
+    'files': ['lib/python%(pyshortver)s/site-packages/path.py'],
+    'dirs': [],
+}
+
+options = {'modulename': 'path'}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/path.py/path.py-8.2.1-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/p/path.py/path.py-8.2.1-foss-2016a-Python-3.5.1.eb
@@ -5,7 +5,8 @@ version = '8.2.1'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://github.com/jaraco/path.py'
-description = """path.py is a Python library implementing path objects as first-class entities, allowing common operations on files to be invoked on those path objects directly."""
+description = """path.py is a Python library implementing path objects as first-class entities,
+ allowing common operations on files to be invoked on those path objects directly."""
 
 toolchain = {'name': 'foss', 'version': '2016a'}
 

--- a/easybuild/easyconfigs/p/prompt-toolkit/prompt-toolkit-1.0.3-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/prompt-toolkit/prompt-toolkit-1.0.3-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,33 @@
+easyblock = 'PythonPackage'
+
+name = 'prompt-toolkit'
+version = '1.0.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/jonathanslenders/python-prompt-toolkit'
+description = """prompt_toolkit is a Python library for building powerful interactive command lines and terminal applications."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://pypi.python.org/packages/4d/1f/5f5a3831006a1e9799d418e32d02c01529d6fa292851e381bd7df4908079/']
+sources = ['prompt_toolkit-%(version)s-py2-none-any.whl']
+
+dependencies = [
+    ('Python', '2.7.11'),
+    ('wcwidth', '0.1.7', versionsuffix),
+]
+builddependencies = [
+    ('pip', '8.1.2', versionsuffix),
+]
+
+use_pip = True
+unpack_sources = False
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/prompt_toolkit'],
+}
+
+options = {'modulename': 'prompt_toolkit'}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/prompt-toolkit/prompt-toolkit-1.0.3-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/p/prompt-toolkit/prompt-toolkit-1.0.3-foss-2016a-Python-3.5.1.eb
@@ -1,0 +1,30 @@
+easyblock = 'PythonPackage'
+
+name = 'prompt-toolkit'
+version = '1.0.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/jonathanslenders/python-prompt-toolkit'
+description = """prompt_toolkit is a Python library for building powerful interactive command lines and terminal applications."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://pypi.python.org/packages/1b/5b/6a1c5e6b9ad024a32b93abaeb49f517079f0fd9539aba2c2f36d8a76a1cf/']
+sources = ['prompt_toolkit-%(version)s-py3-none-any.whl']
+
+dependencies = [
+    ('Python', '3.5.1'),
+    ('wcwidth', '0.1.7', versionsuffix),
+]
+
+use_pip = True
+unpack_sources = False
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/prompt_toolkit'],
+}
+
+options = {'modulename': 'prompt_toolkit'}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/testpath/testpath-0.3-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/t/testpath/testpath-0.3-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,30 @@
+easyblock = 'PythonPackage'
+
+name = 'testpath'
+version = '0.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/jupyter/testpath'
+description = """Test utilities for code working with files and commands"""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://pypi.python.org/packages/py2.py3/t/testpath/']
+sources = ['testpath-%(version)s-py2.py3-none-any.whl']
+
+dependencies = [
+    ('Python', '2.7.11'),
+]
+builddependencies = [
+    ('pip', '8.1.2', versionsuffix),
+]
+
+use_pip = True
+unpack_sources = False
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/testpath'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/testpath/testpath-0.3-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/t/testpath/testpath-0.3-foss-2016a-Python-3.5.1.eb
@@ -1,0 +1,27 @@
+easyblock = 'PythonPackage'
+
+name = 'testpath'
+version = '0.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/jupyter/testpath'
+description = """Test utilities for code working with files and commands"""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://pypi.python.org/packages/py2.py3/t/testpath/']
+sources = ['testpath-%(version)s-py2.py3-none-any.whl']
+
+dependencies = [
+    ('Python', '3.5.1'),
+]
+
+use_pip = True
+unpack_sources = False
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/testpath'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/w/wcwidth/wcwidth-0.1.7-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/w/wcwidth/wcwidth-0.1.7-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,30 @@
+easyblock = 'PythonPackage'
+
+name = 'wcwidth'
+version = '0.1.7'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/jquast/wcwidth'
+description = """wcwidth is a low-level Python library to simplify Terminal emulation."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://pypi.python.org/packages/7e/9f/526a6947247599b084ee5232e4f9190a38f398d7300d866af3ab571a5bfe/']
+sources = ['%(name)s-%(version)s-py2.py3-none-any.whl']
+
+dependencies = [
+    ('Python', '2.7.11'),
+]
+builddependencies = [
+    ('pip', '8.1.2', versionsuffix),
+]
+
+use_pip = True
+unpack_sources = False
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/wcwidth'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/w/wcwidth/wcwidth-0.1.7-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/w/wcwidth/wcwidth-0.1.7-foss-2016a-Python-3.5.1.eb
@@ -1,0 +1,27 @@
+easyblock = 'PythonPackage'
+
+name = 'wcwidth'
+version = '0.1.7'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/jquast/wcwidth'
+description = """wcwidth is a low-level Python library to simplify Terminal emulation."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://pypi.python.org/packages/7e/9f/526a6947247599b084ee5232e4f9190a38f398d7300d866af3ab571a5bfe/']
+sources = ['%(name)s-%(version)s-py2.py3-none-any.whl']
+
+dependencies = [
+    ('Python', '3.5.1'),
+]
+
+use_pip = True
+unpack_sources = False
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/wcwidth'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
Hi all,

here are two versions of the new IPython 5.0.0 for Python 2.7 and 3.5.

I followed the same approach as others used in previous IPython versions, that is to create a bundle out of all the python package dependencies. However I did not succeed to bundle the whl-based python packages (entrypoints, prompt-toolkit, ...). Does anybody know how to do this?

I would be happy for comments from any easybuild guru on whether everything is handled correctly.

Best,
Tomas