### PR TITLE
Matplotlib for Python 3.5.1 using the foss 2016a toolchain.

### DIFF
--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.5.1-foss-2016a-Python-3.5.1.eb
@@ -1,0 +1,45 @@
+easyblock = 'Bundle'
+
+name = 'matplotlib'
+version = '1.5.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://matplotlib.org'
+description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
+ hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
+ and ipython shell, web application servers, and six graphical user interface toolkits."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+# this is a bundle of Python packages
+exts_defaultclass = 'PythonPackage'
+
+dependencies = [
+    ('Python', '3.5.1'),
+    ('freetype', '2.6.2'),
+    ('libpng', '1.6.21'),
+]
+
+exts_list = [
+    ('Cycler', '0.9.0', {
+        'modulename': 'cycler',
+        'source_urls': ['https://pypi.python.org/packages/source/C/Cycler'],
+        'source_tmpl': 'cycler-%(version)s.tar.gz',
+    }),
+    (name, version, {
+        'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
+        'patches': ['matplotlib-1.5.1_fix-Tcl-Tk-libdir.patch'],
+    }),
+]
+
+# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
+full_sanity_check = True
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+moduleclass = 'vis'


### PR DESCRIPTION
Matplotlib for Python 3.5.1 using the foss 2016a toolchain.