### PR TITLE
Easyconfig for QuantumESPRESSO-5.4.0 with FOSS of 2016, hybrid version. 

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.4.0-foss-2016-hybrid.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.4.0-foss-2016-hybrid.eb
@@ -1,0 +1,60 @@
+name = 'QuantumESPRESSO'
+version = '5.4.0'
+
+homepage = 'http://www.pwscf.org/'
+description = """Quantum ESPRESSO  is an integrated suite of computer codes
+ for electronic-structure calculations and materials modeling at the nanoscale.
+ It is based on density-functional theory, plane waves, and pseudopotentials
+  (both norm-conserving and ultrasoft)."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+
+toolchainopts = {'usempi': True, 'openmp': True}
+
+dependencies = [
+#    ('netCDF-Fortran','4.4.3'), # For Yambo, check if it is picked up
+#    ('Libxc','2.2.2'), # For Yambo, check if it is picked up
+]
+
+# Part of this list was determined from install/plugins_list
+sources = [
+    'espresso-%(version)s.tar.gz',
+    'tddfpt-%(version)s.tar.gz',
+    # Other sources
+    # Common source
+    'atomic-%(version)s.tar.gz',
+    'neb-%(version)s.tar.gz',
+    'PHonon-%(version)s.tar.gz',
+    'pwcond-%(version)s.tar.gz',
+    'xspectra-%(version)s.tar.gz' ,
+    'EPW-%(version)s.tar.gz' ,
+    'test-suite-%(version)s.tar.gz' ,
+    'GWW-%(version)s.tar.gz' ,
+]
+source_urls = [
+    'http://files.qe-forge.org/index.php?file=',  # Almost all
+    'http://www.qe-forge.org/gf/download/frsrelease/211/968/', # espresso-5.4.0.tar.gz
+    # These will not be used because of the 404 signal not found from the previous link.
+    'http://www.qe-forge.org/gf/download/frsrelease/211/961/', # PWgui-5.4.0.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/211/956/', # tddfpt-5.4.0.tar.gz        
+    'http://www.qe-forge.org/gf/download/frsrelease/211/954/', # atomic-5.4.0.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/211/959/', # neb-5.4.0.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/211/962/', # PHonon-5.4.0.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/211/960/', # pwcond-5.4.0.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/211/958/', # xspectra-5.4.0.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/211/969/', # EPW-5.4.0.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/211/963/', # test-suite-5.4.0.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/211/957/', # GWW-5.4.0.tar.gz
+]
+
+# Hybrid option exist only for backward compatibility, use toolchain option openmp instead.
+#hybrid = True
+  
+#Build QE with packages of Pwscf, tddfpt, NEB, xspectra, Phonon of  QE 5.4.0. While yambo and someother packages can not be successfully built with this easyconfig with QE 5.4.0 version!
+buildopts = 'all tddfpt neb xspectra ph '
+
+# parallel build tends to fail
+parallel = 1
+
+moduleclass = 'chem'
+


### PR DESCRIPTION
OpenMP-MPIhybrid easyconfig should be used with the corresponding easyblock in the link [Easyblock pull request 954](https://github.com/hpcugent/easybuild-easyblocks/pull/954) @aocais