### PR TITLE
{chem}[ictce/7.3.5] QuantumESPRESSO 5.1.2

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.1.2-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.1.2-ictce-7.3.5.eb
@@ -1,0 +1,40 @@
+name = 'QuantumESPRESSO'
+version = '5.1.2'
+
+homepage = 'http://www.pwscf.org/'
+description = """Quantum ESPRESSO  is an integrated suite of computer codes
+for electronic-structure calculations and materials modeling at the nanoscale.
+It is based on density-functional theory, plane waves, and pseudopotentials
+(both norm-conserving and ultrasoft)."""
+
+toolchain = {'name': 'ictce', 'version': '7.3.5'}
+toolchainopts = {'usempi': True}
+
+sources = [
+    'espresso-%(version)s.tar.gz',
+    'atomic-%(version)s.tar.gz',
+    'neb-%(version)s.tar.gz',
+    'PHonon-%(version)s.tar.gz',
+    'pwcond-%(version)s.tar.gz',
+    'tddfpt-%(version)s.tar.gz',
+    'xspectra-%(version)s.tar.gz',
+    'GWW-%(version)s.tar.gz',
+]
+
+source_urls = [
+    'http://www.qe-forge.org/gf/download/frsrelease/185/753/',  # espresso-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/752/',  # atomic-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/754/',  # GWW-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/755/',  # PHonon-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/756/',  # pwcond-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/757/',  # xspectra-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/758/',  # tddfpt-5.1.2.tar.gz
+    'http://www.qe-forge.org/gf/download/frsrelease/185/760/',  # neb-5.1.2.tar.gz
+]
+
+buildopts = 'all plumed w90 want gipaw'
+
+# parallel build tends to fail
+parallel = 1
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.1.2-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.1.2-ictce-7.3.5.eb
@@ -27,7 +27,18 @@ source_urls = [
     'http://www.qe-forge.org/gf/download/frsrelease/185/754/',  # GWW-5.1.2.tar.gz
 ]
 
-buildopts = 'all plumed w90 want gipaw'
+checksums = [
+    '55f766d1c41c8e7994b0d6717a55c3ea',  # espresso-5.1.2.tar.gz
+    '77ec8a5b2106abc080a55463d4fc964b',  # atomic-5.1.2.tar.gz
+    'b6123aa99f7db958dd635e9837abdf00',  # neb-5.1.2.tar.gz
+    '49c65d222449c5fcea539470e8001170',  # PHonon-5.1.2.tar.gz
+    '6a6c8f84d2a3e65d60cf4e5387383b9b',  # pwcond-5.1.2.tar.gz
+    '9790e7d55fc1f08c554a9d0212bc7f9e',  # tddfpt-5.1.2.tar.gz
+    'c27d6c9515c0ce29462a9b1e8203d118',  # xspectra-5.1.2.tar.gz
+    '681c7f83b4adefbf2da721c4b8210670',  # GWW-5.1.2.tar.gz
+]
+
+buildopts = 'all w90 want gipaw'
 
 # parallel build tends to fail
 parallel = 1


### PR DESCRIPTION
wrapper PR for #1644 by @sylmarien, adds checksums for sources and removed `plumed` from `buildopts` due to build issue:

```
touch uncompress-plumed                                                                                                                                                                                                                                                                                                  if test -d ../PLUMED; then \                                                                                                                                                                                                                                                                                                     
    (cd ../PLUMED ; export plumedir="`pwd`" ; \                                                                                                                                                                                                                                                                              
    cp  patches/plumedpatch_qespresso_5.1.sh ../ ; \                                                                                                                                                                                                                                                                         
    cd ../ ; ./plumedpatch_qespresso_5.1.sh -patch) ; fi                                                                                                                                                                                                                                                                 cp: cannot stat `patches/plumedpatch_qespresso_5.1.sh': No such file or directory                                                                                                                                                                                                                                        /bin/sh: line 3: ./plumedpatch_qespresso_5.1.sh: No such file or directory                                                                                                                                                                                                                                               make[1]: *** [patch-plumed] Error 127   
```