### PR TITLE
{tools}[GCC/5.2.0] AutoDock 4.2.5.1

### DIFF
--- a/easybuild/easyconfigs/a/AutoDock/AutoDock-4.2.5.1-GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/a/AutoDock/AutoDock-4.2.5.1-GCC-5.2.0.eb
@@ -5,8 +5,8 @@ name = 'AutoDock'
 version = '4.2.5.1'
 
 homepage = 'http://autodock.scripps.edu/'
-description = """AutoDock is a suite of automated docking tools. It is designed to
- predict how small molecules, such as substrates or drug candidates, bind to
+description = """AutoDock is a suite of automated docking tools. It is designed to 
+ predict how small molecules, such as substrates or drug candidates, bind to 
  a receptor of known 3D structure."""
 
 toolchain = {'name': 'GCC', 'version': '5.2.0'}
@@ -17,8 +17,8 @@ source_urls = ['http://autodock.scripps.edu/downloads/previous-releases/autodock
 start_dir = 'autodock'
 
 sanity_check_paths = {
-	'files': ["bin/autodock4"],
-	'dirs': []
+    'files': ["bin/autodock4"],
+    'dirs': []
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/a/AutoDock/AutoDock-4.2.5.1-GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/a/AutoDock/AutoDock-4.2.5.1-GCC-5.2.0.eb
@@ -1,0 +1,24 @@
+# Currently there is not an EasyBlock to unify AutoDock and AutoGrid so this is a happy medium until then
+easyblock = 'ConfigureMake'
+
+name = 'AutoDock'
+version = '4.2.5.1'
+
+homepage = 'http://autodock.scripps.edu/'
+description = """AutoDock is a suite of automated docking tools. It is designed to
+ predict how small molecules, such as substrates or drug candidates, bind to
+ a receptor of known 3D structure."""
+
+toolchain = {'name': 'GCC', 'version': '5.2.0'}
+
+sources = ['%(namelower)ssuite-%(version)s-src.tar.gz']
+source_urls = ['http://autodock.scripps.edu/downloads/previous-releases/autodock-4-2-5/tars/dist4251/']
+
+start_dir = 'autodock'
+
+sanity_check_paths = {
+	'files': ["bin/autodock4"],
+	'dirs': []
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
An easyconfig for AutoDock 4.2.5.1 with toolchain GCC 5.2.0.

Note that AutoGrid will be provided as a separate easyconfig, due to there not currently being an easyblock for the AutoDock suite.