### PR TITLE
Boost 1.52.0 with foss 2015a

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.52.0-foss-2015a.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.52.0-foss-2015a.eb
@@ -1,0 +1,23 @@
+name = 'Boost'
+version = '1.52.0'
+
+homepage = 'http://www.boost.org/'
+description = """Boost provides free peer-reviewed portable C++ source libraries."""
+
+toolchain = {'name': 'foss', 'version': '2015a'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+]
+
+configopts = '--without-libraries=python'
+
+# also build boost_mpi
+boost_mpi = True
+
+moduleclass = 'devel'


### PR DESCRIPTION
An easyconfig for Boost 1.52.0 built with the toolchain foss 2015a.

I know there are many versions of Boost already, but I noticed this one was missing.