### PR TITLE
{data}[foss/2015a] CDO 1.7.1

### DIFF
--- a/easybuild/easyconfigs/c/CDO/CDO-1.7.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-1.7.1-foss-2015a.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'CDO'
+version = '1.7.1'
+
+homepage = 'https://code.zmaw.de/projects/cdo'
+description = """CDO is a collection of command line Operators to manipulate and analyse Climate and NWP model Data."""
+
+toolchain = {'name': 'foss', 'version': '2015a'}
+toolchainopts = {'opt': True, 'pic': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://code.zmaw.de/attachments/download/12070/']
+
+dependencies = [
+    ('HDF5', '1.8.13'),
+    ('netCDF', '4.3.2'),
+    ('YAXT', '0.4.4'),
+]
+
+configopts = "--with-hdf5=$EBROOTHDF5 --with-netcdf=$EBROOTNETCDF"
+
+sanity_check_paths = {
+    'files': ["bin/cdo"],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/y/YAXT/YAXT-0.4.4-foss-2015a.eb
+++ b/easybuild/easyconfigs/y/YAXT/YAXT-0.4.4-foss-2015a.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = 'YAXT'
+version = '0.4.4'
+
+homepage = 'https://www.dkrz.de/redmine/projects/yaxt'
+description = "Yet Another eXchange Tool"
+
+toolchain = {'name': 'foss', 'version': '2015a'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://www.dkrz.de/redmine/attachments/download/464/']
+sources = [SOURCELOWER_TAR_GZ]
+
+sanity_check_paths = {
+    'files': ["include/yaxt.h", "include/yaxt.mod", "lib/libyaxt.a", "lib/libyaxt.%s" % SHLIB_EXT],
+    'dirs': ["include/xt"],
+}
+
+configopts = 'FC="$F90" FCFLAGS="$F90FLAGS -cpp"'
+
+moduleclass = 'tools'


### PR DESCRIPTION
Two easyconfigs, one for CDO 1.7.1 and one for one of its dependencies, YAXT 0.4.4 (netCDF 4.3.2 and HDF5 1.8.13 are already present in the repo). These are built with the toolchain foss 2015a.