### PR TITLE
specify correct MPI target in FDS easyconfigs

### DIFF
--- a/easybuild/easyconfigs/f/FDS/FDS-6.3.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-6.3.0-intel-2015b.eb
@@ -23,7 +23,10 @@ start_dir = 'FDS_Compilation'
 skipsteps = ['configure', 'install']
 buildininstalldir = True
 
-prebuildopts = 'env FFLAGS="$FFLAGS -fpp"'
+target = 'mpi_intel_linux_64'
+buildopts = '%s FFLAGS="$FFLAGS -fpp" FCOMPL="$FC"' % target
+
+postinstallcmds = ["ln -s %%(installdir)s/FDS_Compilation/fds_%s %%(installdir)s/FDS_Compilation/fds" % target]
 
 modextrapaths = {'PATH': 'FDS_Compilation'}
 

--- a/easybuild/easyconfigs/f/FDS/FDS-6.3.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-6.3.0-intel-2015b.eb
@@ -34,4 +34,7 @@ sanity_check_paths = {
     'files': ['FDS_Compilation/fds'],
     'dirs': [],
 }
+
+sanity_check_commands = [("fds 2>&1 | grep 'MPI Enabled;'", '')]
+
 moduleclass = 'phys'

--- a/easybuild/easyconfigs/f/FDS/FDS-r17534-intel-2015a.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r17534-intel-2015a.eb
@@ -23,6 +23,11 @@ parallel = 1
 skipsteps = ['configure', 'install']
 buildininstalldir = True
 
+target = 'mpi_intel_linux_64'
+buildopts = '%s FFLAGS="$FFLAGS -fpp" FCOMPL="$FC"' % target
+
+postinstallcmds = ["ln -s %%(installdir)s/FDS_Compilation/fds_%s %%(installdir)s/FDS_Compilation/fds" % target]
+
 modextrapaths = {'PATH': 'FDS_Compilation'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FDS/FDS-r17534-intel-2015a.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r17534-intel-2015a.eb
@@ -35,4 +35,6 @@ sanity_check_paths = {
     'dirs': [],
 }
 
+sanity_check_commands = [("fds 2>&1 | grep 'MPI Enabled;'", '')]
+
 moduleclass = 'phys'

--- a/easybuild/easyconfigs/f/FDS/FDS-r18915-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r18915-goolf-1.4.10.eb
@@ -17,6 +17,11 @@ patches = ['FDS-%(version)s_makefile.patch']
 skipsteps = ['configure', 'install']
 buildininstalldir = True
 
+target = 'mpi_intel_linux_64'
+buildopts = '%s FFLAGS="$FFLAGS -fpp" FCOMPL="$FC"' % target
+
+postinstallcmds = ["ln -s %%(installdir)s/FDS_Compilation/fds_%s %%(installdir)s/FDS_Compilation/fds" % target]
+
 modextrapaths = {'PATH': 'FDS_Source'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FDS/FDS-r18915-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r18915-goolf-1.4.10.eb
@@ -17,8 +17,8 @@ patches = ['FDS-%(version)s_makefile.patch']
 skipsteps = ['configure', 'install']
 buildininstalldir = True
 
-target = 'mpi_intel_linux_64'
-buildopts = '%s FFLAGS="$FFLAGS -fpp" FCOMPL="$FC"' % target
+target = 'mpi_gnu_linux'
+buildopts = '%s FFLAGS="$FFLAGS" FCOMPL="$FC"' % target
 
 postinstallcmds = ["ln -s %%(installdir)s/FDS_Source/fds_%s %%(installdir)s/FDS_Source/fds" % target]
 

--- a/easybuild/easyconfigs/f/FDS/FDS-r18915-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r18915-goolf-1.4.10.eb
@@ -29,4 +29,6 @@ sanity_check_paths = {
     'dirs': [],
 }
 
+sanity_check_commands = [("fds 2>&1 | grep 'MPI Enabled;'", '')]
+
 moduleclass = 'phys'

--- a/easybuild/easyconfigs/f/FDS/FDS-r18915-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r18915-goolf-1.4.10.eb
@@ -20,7 +20,7 @@ buildininstalldir = True
 target = 'mpi_intel_linux_64'
 buildopts = '%s FFLAGS="$FFLAGS -fpp" FCOMPL="$FC"' % target
 
-postinstallcmds = ["ln -s %%(installdir)s/FDS_Compilation/fds_%s %%(installdir)s/FDS_Compilation/fds" % target]
+postinstallcmds = ["ln -s %%(installdir)s/FDS_Source/fds_%s %%(installdir)s/FDS_Source/fds" % target]
 
 modextrapaths = {'PATH': 'FDS_Source'}
 

--- a/easybuild/easyconfigs/f/FDS/FDS-r18915-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r18915-ictce-5.5.0.eb
@@ -17,6 +17,11 @@ patches = ['FDS-%(version)s_makefile.patch']
 skipsteps = ['configure', 'install']
 buildininstalldir = True
 
+target = 'mpi_intel_linux_64'
+buildopts = '%s FFLAGS="$FFLAGS -fpp" FCOMPL="$FC"' % target
+
+postinstallcmds = ["ln -s %%(installdir)s/FDS_Compilation/fds_%s %%(installdir)s/FDS_Compilation/fds" % target]
+
 modextrapaths = {'PATH': 'FDS_Source'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FDS/FDS-r18915-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r18915-ictce-5.5.0.eb
@@ -29,4 +29,6 @@ sanity_check_paths = {
     'dirs': [],
 }
 
+sanity_check_commands = [("fds 2>&1 | grep 'MPI Enabled;'", '')]
+
 moduleclass = 'phys'

--- a/easybuild/easyconfigs/f/FDS/FDS-r18915-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r18915-ictce-5.5.0.eb
@@ -20,7 +20,7 @@ buildininstalldir = True
 target = 'mpi_intel_linux_64'
 buildopts = '%s FFLAGS="$FFLAGS -fpp" FCOMPL="$FC"' % target
 
-postinstallcmds = ["ln -s %%(installdir)s/FDS_Compilation/fds_%s %%(installdir)s/FDS_Compilation/fds" % target]
+postinstallcmds = ["ln -s %%(installdir)s/FDS_Source/fds_%s %%(installdir)s/FDS_Source/fds" % target]
 
 modextrapaths = {'PATH': 'FDS_Source'}
 

--- a/easybuild/easyconfigs/f/FDS/FDS-r18915-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r18915-ictce-5.5.0.eb
@@ -18,7 +18,7 @@ skipsteps = ['configure', 'install']
 buildininstalldir = True
 
 target = 'mpi_intel_linux_64'
-buildopts = '%s FFLAGS="$FFLAGS -fpp" FCOMPL="$FC"' % target
+buildopts = '%s FFLAGS="$FFLAGS" FCOMPL="$FC"' % target
 
 postinstallcmds = ["ln -s %%(installdir)s/FDS_Source/fds_%s %%(installdir)s/FDS_Source/fds" % target]
 

--- a/easybuild/easyconfigs/f/FDS/FDS-r18915-intel-2015a.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r18915-intel-2015a.eb
@@ -17,6 +17,11 @@ patches = ['FDS-%(version)s_makefile.patch']
 skipsteps = ['configure', 'install']
 buildininstalldir = True
 
+target = 'mpi_intel_linux_64'
+buildopts = '%s FFLAGS="$FFLAGS -fpp" FCOMPL="$FC"' % target
+
+postinstallcmds = ["ln -s %%(installdir)s/FDS_Compilation/fds_%s %%(installdir)s/FDS_Compilation/fds" % target]
+
 modextrapaths = {'PATH': 'FDS_Source'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FDS/FDS-r18915-intel-2015a.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r18915-intel-2015a.eb
@@ -29,4 +29,6 @@ sanity_check_paths = {
     'dirs': [],
 }
 
+sanity_check_commands = [("fds 2>&1 | grep 'MPI Enabled;'", '')]
+
 moduleclass = 'phys'

--- a/easybuild/easyconfigs/f/FDS/FDS-r18915-intel-2015a.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r18915-intel-2015a.eb
@@ -20,7 +20,7 @@ buildininstalldir = True
 target = 'mpi_intel_linux_64'
 buildopts = '%s FFLAGS="$FFLAGS -fpp" FCOMPL="$FC"' % target
 
-postinstallcmds = ["ln -s %%(installdir)s/FDS_Compilation/fds_%s %%(installdir)s/FDS_Compilation/fds" % target]
+postinstallcmds = ["ln -s %%(installdir)s/FDS_Source/fds_%s %%(installdir)s/FDS_Source/fds" % target]
 
 modextrapaths = {'PATH': 'FDS_Source'}
 

--- a/easybuild/easyconfigs/f/FDS/FDS-r18915-intel-2015a.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r18915-intel-2015a.eb
@@ -18,7 +18,7 @@ skipsteps = ['configure', 'install']
 buildininstalldir = True
 
 target = 'mpi_intel_linux_64'
-buildopts = '%s FFLAGS="$FFLAGS -fpp" FCOMPL="$FC"' % target
+buildopts = '%s FFLAGS="$FFLAGS" FCOMPL="$FC"' % target
 
 postinstallcmds = ["ln -s %%(installdir)s/FDS_Source/fds_%s %%(installdir)s/FDS_Source/fds" % target]
 

--- a/easybuild/easyconfigs/f/FDS/FDS-r22681-intel-2015a.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r22681-intel-2015a.eb
@@ -21,6 +21,11 @@ start_dir = 'FDS_Compilation'
 skipsteps = ['configure', 'install']
 buildininstalldir = True
 
+target = 'mpi_intel_linux_64'
+buildopts = '%s FFLAGS="$FFLAGS -fpp" FCOMPL="$FC"' % target
+
+postinstallcmds = ["ln -s %%(installdir)s/FDS_Compilation/fds_%s %%(installdir)s/FDS_Compilation/fds" % target]
+
 modextrapaths = {'PATH': 'FDS_Compilation'}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/FDS/FDS-r22681-intel-2015a.eb
+++ b/easybuild/easyconfigs/f/FDS/FDS-r22681-intel-2015a.eb
@@ -33,4 +33,6 @@ sanity_check_paths = {
     'dirs': [],
 }
 
+sanity_check_commands = [("fds 2>&1 | grep 'MPI Enabled;'", '')]
+
 moduleclass = 'phys'


### PR DESCRIPTION
fix for #3459

TODO: add sanity check command that verifies that `fds` has MPI support?

```
$ fds<enter><enter>

 Fire Dynamics Simulator

 Current Date     : August 26, 2016  19:43:10
 Version          : FDS 6.3.0
 Revision         : unknown
 Revision Date    : unknown
 Compilation Date : unknown

 MPI Enabled; Number of MPI Processes:     1
 OpenMP Disabled

 Consult FDS Users Guide Chapter, Running FDS, for further instructions.

 Hit Enter to Escape...

$ echo '' | fds 2>&1 | grep 'MPI Enabled'
 MPI Enabled; Number of MPI Processes:     1
$ echo $?
0

```