### PR TITLE
foss 2016a versions of scikit-learn for both Python 2.7.11 and 3.5.1

### DIFF
--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.17.1-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.17.1-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,30 @@
+easyblock = 'PythonPackage'
+
+name = 'scikit-learn'
+version = '0.17.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://scikit-learn.org/stable/index.html'
+description = """Scikit-learn integrates machine learning algorithms in the tightly-knit scientific Python world,
+building upon numpy, scipy, and matplotlib. As a machine-learning module,
+it provides versatile tools for data mining and analysis in any field of science and engineering.
+It strives to be simple and efficient, accessible to everybody, and reusable in various contexts."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('Python', '2.7.11'),
+    ('matplotlib', '1.5.1', versionsuffix),
+]
+
+options = {'modulename': 'sklearn'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/sklearn'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.17.1-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.17.1-foss-2016a-Python-3.5.1.eb
@@ -1,0 +1,30 @@
+easyblock = 'PythonPackage'
+
+name = 'scikit-learn'
+version = '0.17.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://scikit-learn.org/stable/index.html'
+description = """Scikit-learn integrates machine learning algorithms in the tightly-knit scientific Python world,
+building upon numpy, scipy, and matplotlib. As a machine-learning module,
+it provides versatile tools for data mining and analysis in any field of science and engineering.
+It strives to be simple and efficient, accessible to everybody, and reusable in various contexts."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('Python', '3.5.1'),
+    ('matplotlib', '1.5.1', versionsuffix),
+]
+
+options = {'modulename': 'sklearn'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/sklearn'],
+}
+
+moduleclass = 'data'


### PR DESCRIPTION
scikit-learn compiled with the foss 2016a toolchain. Both for Python 2.7.11 and 3.5.1.