### PR TITLE
clean up sources spec for gdc-client bundle easyconfig

### DIFF
--- a/easybuild/easyconfigs/g/gdc-client/gdc-client-1.0.1-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/g/gdc-client/gdc-client-1.0.1-intel-2016b-Python-2.7.12.eb
@@ -10,9 +10,6 @@ description = """The gdc-client provides several convenience functions over the 
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 
-source_urls = ['https://github.com/NCI-GDC/gdc-client/archive/']
-sources = ['v%(version)s.tar.gz']
-
 # this is a bundle of Python packages
 exts_defaultclass = 'PythonPackage'
 


### PR DESCRIPTION
`source_urls` and `sources` for `gdc-client` are already specified via `exts_list`, also defining them top-level doesn't make sense