### PR TITLE
{vis}[goolf/1.4.10] Blender 2.66a

### DIFF
--- a/easybuild/easyconfigs/b/Blender/Blender-2.66a-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/b/Blender/Blender-2.66a-goolf-1.4.10.eb
@@ -1,0 +1,36 @@
+easyblock = 'CMakeMake'
+
+name = 'Blender'
+version = '2.66a'
+
+homepage = 'https://www.blender.org/'
+description = """Blender is the free and open source 3D creation suite. It supports
+ the entirety of the 3D pipeline-modeling, rigging, animation, simulation, rendering,
+ compositing and motion tracking, even video editing and game creation."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
+sources = ['blender-2.66a.tar.gz']
+source_urls = ['http://download.blender.org/source/']
+
+# Remove and add configopts as desired
+configopts = '-DWITH_INSTALL_PORTABLE=OFF '
+configopts += '-DWITH_BUILDINFO=OFF '
+configopts += '-DWITH_GAMEENGINE=OFF '
+configopts += '-DWITH_CYCLES=OFF '
+configopts += '-DWITH_SYSTEM_GLEW=OFF '
+
+dependencies = [('Python', '3.3.2'),
+                ('Boost', '1.51.0'),
+]
+
+builddependencies = [('CMake', '3.2.3')]
+
+separate_build_dir = 'True'
+
+sanity_check_paths = {
+	'files': ['bin/blender'],
+	'dirs': []
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
An easyconfig for Blender 2.66a which uses the goolf 1.4.10 toolchain.