### PR TITLE
Mira 402 foss 2016a

### DIFF
--- a/easybuild/easyconfigs/g/gperftools/gperftools-2.5-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/gperftools/gperftools-2.5-foss-2016a.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = "gperftools"
+version = "2.5"
+
+homepage = 'http://github.com/gperftools/gperftools'
+description = """gperftools are for use by developers so that they can create more robust applications.
+ Especially of use to those developing multi-threaded applications in C++ with templates.
+ Includes TCMalloc, heap-checker, heap-profiler and cpu-profiler."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['https://github.com/gperftools/gperftools/releases/download/%(namelower)s-%(version)s']
+
+builddependencies = [('Autotools', '20150215', '', ('GCCcore', '4.9.3'))]
+dependencies = [('libunwind', '1.1')]
+
+sanity_check_paths = {
+    'files': ["bin/pprof"],
+    'dirs': []
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/gperftools/gperftools-2.5-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/gperftools/gperftools-2.5-foss-2016a.eb
@@ -13,7 +13,7 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['https://github.com/gperftools/gperftools/releases/download/%(namelower)s-%(version)s']
 
-builddependencies = [('Autotools', '20150215', '', ('GCCcore', '4.9.3'))]
+builddependencies = [('Autotools', '20150215')]
 dependencies = [('libunwind', '1.1')]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/MIRA/MIRA-4.0.2-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/MIRA/MIRA-4.0.2-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,36 @@
+easyblock = 'ConfigureMake'
+
+name = 'MIRA'
+version = '4.0.2'
+versionsuffix = '-Python-2.7.11'
+
+homepage = 'http://sourceforge.net/p/mira-assembler/wiki/Home/'
+description = """MIRA is a whole genome shotgun and EST sequence assembler for Sanger, 454, Solexa (Illumina),
+    IonTorrent data and PacBio (the later at the moment only CCS and error-corrected CLR reads)."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+sources = ['%(namelower)s-%(version)s.tar.bz2']
+source_urls = [('http://sourceforge.net/projects/mira-assembler/files/MIRA/stable/', 'download')]
+
+# don't use PAX, it might break.
+tar_config_opts = True
+
+configopts = '--with-boost-libdir=$EBROOTBOOST/lib --with-expat=$EBROOTEXPAT'
+
+patches = ['MIRA-%(version)s-quirks.patch']
+
+builddependencies = [('flex', '2.5.39')]
+dependencies = [
+    ('Boost', '1.61.0', versionsuffix),
+    ('expat', '2.1.1'),
+    ('zlib', '1.2.8'),
+    ('gperftools', '2.5'),
+]
+
+sanity_check_paths = {
+    'files': ["bin/mira"],
+    'dirs': ["bin", "share"],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
Version of MIRA using the foss 2016a toolchain including an updated version of the dependency gperftools.
