### PR TITLE
{vis}[foss/2016.04] Blender 2.66a

### DIFF
--- a/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-foss-2016.04.eb
+++ b/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-foss-2016.04.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'Autoconf'
+version = '2.69'
+
+homepage = 'http://www.gnu.org/software/autoconf/'
+description = """Autoconf is an extensible package of M4 macros that produce shell scripts
+ to automatically configure software source code packages. These scripts can adapt the
+ packages to many kinds of UNIX-like systems without manual user intervention. Autoconf
+ creates a configuration script for a package from a template file that lists the
+ operating system features that the package can use, in the form of M4 macro calls."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('M4', '1.4.17')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["autoconf", "autoheader", "autom4te", "autoreconf", "autoscan",
+                                     "autoupdate", "ifnames"]],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2016.04.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2016.04.eb
@@ -1,0 +1,33 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'Automake'
+version = "1.15"
+
+homepage = 'http://www.gnu.org/software/automake/automake.html'
+description = "Automake: GNU Standards-compliant Makefile generator"
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('Autoconf', '2.69')]
+
+sanity_check_paths = {
+    'files': ['bin/automake', 'bin/aclocal'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Autotools/Autotools-20150215-foss-2016.04.eb
+++ b/easybuild/easyconfigs/a/Autotools/Autotools-20150215-foss-2016.04.eb
@@ -1,0 +1,17 @@
+easyblock = 'Bundle'
+
+name = 'Autotools'
+version = '20150215'  # date of the most recent change
+
+homepage = 'http://autotools.io'
+description = """This bundle collect the standard GNU build tools: Autoconf, Automake and libtool"""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+dependencies = [
+    ('Autoconf', '2.69'),  # 20120424
+    ('Automake', '1.15'),  # 20150105
+    ('libtool', '2.4.6'),  # 20150215
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.4-GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.4-GCCcore-6.1.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'Bison'
+version = '3.0.4'
+
+homepage = 'http://www.gnu.org/software/bison'
+description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
+ into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.1.0'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+builddependencies = [
+    ('M4', '1.4.17'),
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.27', '', True),
+]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["bison", "yacc"]] + ["lib/liby.a"],
+    'dirs': [],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/b/Blender/Blender-2.66a-foss-2016.04-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/b/Blender/Blender-2.66a-foss-2016.04-Python-3.5.2.eb
@@ -1,0 +1,40 @@
+easyblock = 'CMakeMake'
+
+name = 'Blender'
+version = '2.66a'
+
+pyver = 3.5.2
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://www.blender.org/'
+description = """Blender is the free and open source 3D creation suite. It supports
+ the entirety of the 3D pipeline-modeling, rigging, animation, simulation, rendering,
+ compositing and motion tracking, even video editing and game creation."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://download.blender.org/source/']
+
+# These are needed until extra dependencies are added for them to work 
+configopts = '-DWITH_INSTALL_PORTABLE=OFF '
+configopts += '-DWITH_BUILDINFO=OFF '
+configopts += '-DWITH_GAMEENGINE=OFF '
+configopts += '-DWITH_CYCLES=OFF '
+configopts += '-DWITH_SYSTEM_GLEW=OFF '
+
+dependencies = [
+    ('Python', pyver),
+    ('Boost', '1.60.0'),
+]
+
+builddependencies = [('CMake', '3.6.1')]
+
+separate_build_dir = 'True'
+
+sanity_check_paths = {
+	'files': ['bin/blender'],
+	'dirs': []
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.60.0-foss-2016.04.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.60.0-foss-2016.04.eb
@@ -1,0 +1,25 @@
+name = 'Boost'
+version = '1.60.0'
+
+homepage = 'http://www.boost.org/'
+description = """Boost provides free peer-reviewed portable C++ source libraries."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
+source_urls = [SOURCEFORGE_SOURCE]
+
+patches = ['Boost-%(version)s_fix-auto-pointer-reg.patch']
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+]
+
+configopts = '--without-libraries=python'
+
+# also build boost_mpi
+boost_mpi = True
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/binutils/binutils-2.27-GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.27-GCCcore-6.1.0.eb
@@ -1,0 +1,21 @@
+name = 'binutils'
+version = '2.27'
+
+homepage = 'http://directory.fsf.org/project/binutils/'
+description = "binutils: GNU binary utilities"
+
+toolchain = {'name': 'GCCcore', 'version': '6.1.0'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+builddependencies = [
+    ('flex', '2.6.0'),
+    ('Bison', '3.0.4'),
+    # zlib required, but being linked in statically, so not a runtime dep
+    ('zlib', '1.2.8'),
+    # use same binutils version that was used when building GCC toolchain, to 'bootstrap' this binutils
+    ('binutils', version, '', True)
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016.04.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016.04.eb
@@ -1,0 +1,16 @@
+name = 'bzip2'
+version = '1.0.6'
+
+homepage = 'http://www.bzip.org/'
+description = """bzip2 is a freely available, patent free, high-quality data compressor.
+ It typically compresses files to within 10% to 15% of the best available techniques (the
+ PPM family of statistical compressors), whilst being around twice as fast at compression
+ and six times faster at decompression."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.bzip.org/%(version)s']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/c/CMake/CMake-3.6.1-foss-2016.04.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.6.1-foss-2016.04.eb
@@ -1,0 +1,31 @@
+easyblock = 'ConfigureMake'
+
+name = 'CMake'
+version = '3.6.1'
+
+homepage = 'http://www.cmake.org'
+description = """CMake, the cross-platform, open-source build system.
+ CMake is a family of tools designed to build, test and package software."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = '-- -DCMAKE_USE_OPENSSL=1'
+
+dependencies = [
+    ('ncurses', '6.0'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    #('OpenSSL', '1.0.2h'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/c/cppcheck/cppcheck-1.75-intel-2015b.eb
+++ b/easybuild/easyconfigs/c/cppcheck/cppcheck-1.75-intel-2015b.eb
@@ -1,0 +1,23 @@
+name = 'cppcheck'
+version = '1.75'
+
+homepage = 'http://cppcheck.sourceforge.net/'
+description = """Cppcheck is a static analysis tool for C/C++ code"""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%(name)s-%(version)s.tar.bz2']
+
+dependencies = [
+    ('Qt5', '5.5.1'),
+    ('PCRE', '8.37'),
+]
+
+have_rules = True
+build_gui = True
+
+buildopts = 'CXXFLAGS="$CXXFLAGS -std=c++11"'
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/d/DBD-mysql/DBD-mysql-4.033-intel-2016b-Perl-5.24.0.eb
+++ b/easybuild/easyconfigs/d/DBD-mysql/DBD-mysql-4.033-intel-2016b-Perl-5.24.0.eb
@@ -1,0 +1,36 @@
+easyblock = 'PerlModule'
+
+name = 'DBD-mysql'
+version = '4.033'
+versionsuffix = '-Perl-%(perlver)s'
+
+homepage = 'http://search.cpan.org/~capttofu/DBD-mysql-%(version)s/'
+description = """Perl binding for MySQL"""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+
+source_urls = ['http://cpan.metacpan.org/authors/id/C/CA/CAPTTOFU/']
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('Perl', '5.24.0'),
+    ('MariaDB', '10.1.17'),
+    ('zlib', '1.2.8'),
+    # OS dependency should be preferred if the os version is more recent then this version
+    # it's nice to have an up to date openssl for security reasons
+    #('OpenSSL', '1.0.1q'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# force static linking of libmysqlclient to dance around problem with unresolved symbols
+configopts = '--libs="-L$EBROOTMARIADB/lib -Wl,-Bstatic -lmysqlclient -Wl,-Bdynamic -lpthread -lz -lrt -lssl -lcrypto"'
+
+options = {'modulename': 'DBD::mysql'}
+
+sanity_check_paths = {
+    'files': ['lib/perl5/site_perl/%(perlver)s/x86_64-linux-thread-multi/DBD/mysql.pm'],
+    'dirs': ['lib/perl5/site_perl/%(perlver)s/x86_64-linux-thread-multi/DBD/mysql'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016.07.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.4-gompi-2016.07.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'FFTW'
+version = '3.3.4'
+
+homepage = 'http://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+ in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'gompi', 'version': '2016.07'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [homepage]
+
+common_configopts = "--enable-threads --enable-openmp --with-pic"
+
+configopts = [
+    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    common_configopts + " --enable-long-double --enable-mpi",
+    common_configopts + " --enable-quad-precision",
+    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+]
+
+sanity_check_paths = {
+    'files': ['bin/fftw%s' % x for x in ['-wisdom', '-wisdom-to-conf', 'f-wisdom', 'l-wisdom', 'q-wisdom']] +
+             ['include/fftw3%s' % x for x in ['-mpi.f03', '-mpi.h', '.f', '.f03',
+                                              '.h', 'l-mpi.f03', 'l.f03', 'q.f03']] +
+             ['lib/libfftw3%s%s.a' % (x, y) for x in ['', 'f', 'l'] for y in ['', '_mpi', '_omp', '_threads']] +
+             ['lib/libfftw3q.a', 'lib/libfftw3q_omp.a'],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.5-gompi-2016.07.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.5-gompi-2016.07.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'FFTW'
+version = '3.3.5'
+
+homepage = 'http://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+ in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'gompi', 'version': '2016.07'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [homepage]
+
+common_configopts = "--enable-threads --enable-openmp --with-pic"
+
+configopts = [
+    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    common_configopts + " --enable-long-double --enable-mpi",
+    common_configopts + " --enable-quad-precision",
+    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+]
+
+sanity_check_paths = {
+    'files': ['bin/fftw%s' % x for x in ['-wisdom', '-wisdom-to-conf', 'f-wisdom', 'l-wisdom', 'q-wisdom']] +
+             ['include/fftw3%s' % x for x in ['-mpi.f03', '-mpi.h', '.f', '.f03',
+                                              '.h', 'l-mpi.f03', 'l.f03', 'q.f03']] +
+             ['lib/libfftw3%s%s.a' % (x, y) for x in ['', 'f', 'l'] for y in ['', '_mpi', '_omp', '_threads']] +
+             ['lib/libfftw3q.a', 'lib/libfftw3q_omp.a'],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-6.1.0.eb
@@ -1,0 +1,21 @@
+name = 'flex'
+version = '2.6.0'
+
+homepage = 'http://flex.sourceforge.net/'
+description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners. A scanner,
+ sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.1.0'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
+
+dependencies = [('Bison', '3.0.4')]
+
+# use same binutils version that was used when building GCC toolchain
+builddependencies = [('binutils', '2.27', '', True)]
+
+parallel = 1
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/foss/foss-2016.07.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2016.07.eb
@@ -1,0 +1,37 @@
+easyblock = 'Toolchain'
+
+name = 'foss'
+version = '2016.07'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain, including
+ OpenMPI for MPI support, OpenBLAS (BLAS and LAPACK support), FFTW and ScaLAPACK."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+gccver = '6.1.0'
+binutilsver = '2.27'
+gccbinver = '%s-%s' % (gccver, binutilsver)
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.18'
+blas = '%s-%s' % (blaslib, blasver)
+blassuff = '-LAPACK-3.6.1'
+
+# toolchain used to build foss dependencies
+comp_mpi_tc_name = 'gompi'
+comp_mpi_tc = (comp_mpi_tc_name, version)
+
+# compiler toolchain depencies
+# we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
+# because of toolchain preperation functions
+# For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
+dependencies = [
+    ('GCC', gccbinver),
+    ('OpenMPI', '1.10.3', '', ('GCC', gccbinver)),
+    (blaslib, blasver, blassuff, comp_mpi_tc),
+    ('FFTW', '3.3.4', '', comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc)
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/GCC/GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-6.1.0-2.27.eb
@@ -1,0 +1,25 @@
+easyblock = 'Bundle'
+
+name = 'GCC'
+version = '6.1.0'
+
+binutilsver = '2.27'
+versionsuffix = '-%s' % binutilsver
+
+homepage = 'http://gcc.gnu.org/'
+description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
+ as well as libraries for these languages (libstdc++, libgcj,...)."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+dependencies = [
+    ('GCCcore', version),
+    # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
+    ('binutils', binutilsver, '', ('GCCcore', version)),
+]
+
+altroot = 'GCCcore'
+altversion = 'GCCcore'
+
+# this bundle serves as a compiler-only toolchain, so it should be marked as compiler (important for HMNS)
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.1.0.eb
@@ -1,0 +1,57 @@
+easyblock = 'EB_GCC'
+
+name = 'GCCcore'
+version = '6.1.0'
+
+homepage = 'http://gcc.gnu.org/'
+description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
+ as well as libraries for these languages (libstdc++, libgcj,...)."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+mpfr_version = '3.1.4'
+
+source_urls = [
+    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://www.multiprecision.org/mpc/download',  # MPC official
+    'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
+    'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies
+    'http://ftpmirror.gnu.org/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
+    'https://ftp.gnu.org/gnu/gcc/gcc-%(version)s/',  # Alternative GCC
+]
+
+sources = [
+    'gcc-%(version)s.tar.bz2',
+    'gmp-6.1.1.tar.bz2',
+    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpc-1.0.3.tar.gz',
+    'isl-0.16.1.tar.bz2',
+]
+
+builddependencies = [
+    ('M4', '1.4.17'),
+    ('binutils', '2.27'),
+]
+
+patches = [
+    ('mpfr-%s-allpatches-20160804.patch' % mpfr_version, '../mpfr-%s' % mpfr_version),
+    ('%s-%s_fix-find-isl.patch' % (name, version)),
+]
+
+checksums = [
+    '8fb6cb98b8459f5863328380fbf06bd1',     # gcc-6.1.0.tar.bz2
+    '4c175f86e11eb32d8bf9872ca3a8e11d',     # gmp-6.1.1.tar.bz2
+    'b8a2f6b0e68bef46e53da2ac439e1cf4',     # mpfr-3.1.4.tar.gz
+    'd6a1d5f8ddea3abd2cc3e98f58352d26',     # mpc-1.0.3.tar.gz
+    'ac1f25a0677912952718a51f5bc20f32',     # isl-0.16.1.tar.bz2
+]
+
+languages = ['c', 'c++', 'fortran']
+
+withisl = True
+
+# building GCC sometimes fails if make parallelism is too high, so let's limit it
+maxparallel = 4
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.1.0_fix-find-isl.patch
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.1.0_fix-find-isl.patch
@@ -1,0 +1,14 @@
+# Don't use libmpc and libmpfr to find libisl
+# by wpoely86@gmail.com
+diff -ur gcc-6.1.0.orig/configure gcc-6.1.0/configure
+--- gcc-6.1.0.orig/configure	2016-08-26 17:51:48.470524515 +0200
++++ gcc-6.1.0/configure	2016-03-17 23:54:19.000000000 +0100
+@@ -6018,7 +6018,7 @@
+     _isl_saved_LIBS=$LIBS
+
+     CFLAGS="${_isl_saved_CFLAGS} ${islinc} ${gmpinc}"
+-    LDFLAGS="${_isl_saved_LDFLAGS} ${isllibs} ${gmplibs}"
++    LDFLAGS="${_isl_saved_LDFLAGS} ${isllibs}"
+     LIBS="${_isl_saved_LIBS} -lisl -lgmp"
+
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for isl 0.16, 0.15, or deprecated 0.14" >&5

--- a/easybuild/easyconfigs/g/GMP/GMP-6.1.1-foss-2016.04.eb
+++ b/easybuild/easyconfigs/g/GMP/GMP-6.1.1-foss-2016.04.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'GMP'
+version = '6.1.1'
+
+homepage = 'http://gmplib.org/'
+description = """GMP is a free library for arbitrary precision arithmetic, 
+operating on signed integers, rational numbers, and floating point numbers. """
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True, 'precise': True}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = ['http://ftp.gnu.org/gnu/gmp']
+
+builddependencies = [
+    ('Autotools', '20150215'),
+]
+
+# enable C++ interface
+configopts = '--enable-cxx'
+
+runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['lib/libgmp.%s' % SHLIB_EXT, 'include/gmp.h'],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8-foss-2016.04.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8-foss-2016.04.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'gettext'
+version = '0.19.8'
+
+homepage = 'http://www.gnu.org/software/gettext/'
+description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
+and documentation"""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [
+    ('libxml2', '2.9.4'),
+    ('ncurses', '6.0'),
+]
+
+configopts = '--without-emacs --with-libxml2-prefix=$EBROOTLIBXML2'
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/gompi/gompi-2016.07.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2016.07.eb
@@ -1,0 +1,22 @@
+easyblock = "Toolchain"
+
+name = 'gompi'
+version = '2016.07'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain,
+including OpenMPI for MPI support."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+gccver = '6.1.0'
+binutilsver = '2.27'
+gccbinver = '%s-%s' % (gccver, binutilsver)
+
+# compiler toolchain dependencies
+dependencies = [
+   ('GCC', gccbinver),  # includes both GCC and binutils
+   ('OpenMPI', '1.10.3', '', ('GCC', gccbinver)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gperftools/gperftools-2.5-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/gperftools/gperftools-2.5-foss-2016a.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = "gperftools"
+version = "2.5"
+
+homepage = 'http://github.com/gperftools/gperftools'
+description = """gperftools are for use by developers so that they can create more robust applications.
+ Especially of use to those developing multi-threaded applications in C++ with templates.
+ Includes TCMalloc, heap-checker, heap-profiler and cpu-profiler."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['https://github.com/gperftools/gperftools/releases/download/%(namelower)s-%(version)s']
+
+builddependencies = [('Autotools', '20150215')]
+dependencies = [('libunwind', '1.1')]
+
+sanity_check_paths = {
+    'files': ["bin/pprof"],
+    'dirs': []
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/HPL/HPL-2.1-pomkl-2016.09.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.1-pomkl-2016.09.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.1'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'pomkl', 'version': '2016.09'}
+toolchainopts = {'optarch': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/HPL/HPL-2.2-foss-2016.07.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.2-foss-2016.07.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.2'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'foss', 'version': '2016.07'}
+toolchainopts = {'optarch': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/HPL/HPL-2.2-pomkl-2016.09.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.2-pomkl-2016.09.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.2'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'pomkl', 'version': '2016.09'}
+toolchainopts = {'optarch': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.3-GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.3-GCC-6.1.0-2.27.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'hwloc'
+version = '1.11.3'
+
+homepage = 'http://www.open-mpi.org/projects/hwloc/'
+description = """The Portable Hardware Locality (hwloc) software package provides a portable abstraction
+ (across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including
+ NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading. It also gathers various
+ system attributes such as cache and memory information as well as the locality of I/O devices such as
+ network interfaces, InfiniBand HCAs or GPUs. It primarily aims at helping applications with gathering
+ information about modern computing hardware so as to exploit it accordingly and efficiently."""
+
+toolchain = {'name': 'GCC', 'version': '6.1.0-2.27'}
+
+source_urls = ['http://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/']
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [('numactl', '2.0.11')]
+
+configopts = "--enable-libnuma=$EBROOTNUMACTL"
+
+moduleclass = 'system'

--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.4-PGI-16.7-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.4-PGI-16.7-GCC-5.4.0-2.26.eb
@@ -1,0 +1,27 @@
+easyblock = 'ConfigureMake'
+
+name = 'hwloc'
+version = '1.11.4'
+
+homepage = 'http://www.open-mpi.org/projects/hwloc/'
+description = """The Portable Hardware Locality (hwloc) software package provides a portable abstraction
+ (across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including
+ NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading. It also gathers various
+ system attributes such as cache and memory information as well as the locality of I/O devices such as
+ network interfaces, InfiniBand HCAs or GPUs. It primarily aims at helping applications with gathering
+ information about modern computing hardware so as to exploit it accordingly and efficiently."""
+
+toolchain = {'name': 'PGI', 'version': '16.7-GCC-5.4.0-2.26'}
+
+source_urls = ['http://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/']
+sources = [SOURCE_TAR_GZ]
+
+checksums = ['b6f23eb59074fd09fdd84905d50b103d']
+
+dependencies = [
+    ('numactl', '2.0.11', '', ('GCCcore', '5.4.0')),
+]
+
+configopts = "--enable-libnuma=$EBROOTNUMACTL"
+
+moduleclass = 'system'

--- a/easybuild/easyconfigs/i/IMOD/IMOD-4.7.15_RHEL6-64_CUDA6.0.eb
+++ b/easybuild/easyconfigs/i/IMOD/IMOD-4.7.15_RHEL6-64_CUDA6.0.eb
@@ -1,40 +1,29 @@
 # This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
-# Author: Pablo Escobar Lopez
-# sciCORE - University of Basel
-# SIB Swiss Institute of Bioinformatics 
-
-easyblock = 'Binary'
+# authors:
+# * Pablo Escobar Lopez (sciCORE - University of Basel - SIB Swiss Institute of Bioinformatics)
+# * Benjamin Roberts (Landcare Research NZ Ltd)
 
 name = 'IMOD'
 version = '4.7.15'
 versionsuffix = '_RHEL6-64_CUDA6.0'
 
 homepage = 'http://bio3d.colorado.edu/imod/'
-description = """IMOD is a set of image processing, modeling and display programs 
- used for tomographic reconstruction and for 3D reconstruction of EM serial sections 
- and optical sections."""
+description = """IMOD is a set of image processing, modeling and display
+programs used for tomographic reconstruction and for 3D reconstruction of EM
+serial sections and optical sections. The package contains tools for assembling
+and aligning data within multiple types and sizes of image stacks, viewing 3-D
+data from any orientation, and modeling and display of the image files. IMOD
+was developed primarily by David Mastronarde, Rick Gaudette, Sue Held, Jim
+Kremer, Quanren Xiong, and John Heumann at the University of Colorado."""
 
 toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://bio3d.colorado.edu/imod/AMD64-RHEL5/']
 sources = ['%(namelower)s_%(version)s%(versionsuffix)s.csh']
 
-dependencies = [('Java', '1.7.0_80')]
+dependencies = [
+    ('CUDA', '6.0.37'),
+    ('Java', '1.7.0_80'),
+]
 
-install_cmd = "csh %(namelower)s_%(version)s%(versionsuffix)s.csh -dir %(installdir)s -script %(installdir)s/ -yes"
-
-# the provied init script located in %(installdir)s also defines a bash/csh function named 'subm'.
-# It's not possible to define a function in the module file 
-modloadmsg = """Bash users run: 'source $EBROOTIMOD/IMOD-linux.sh'
-csh users run: 'source $EBROOTIMOD/IMOD-linux.csh'"""
-
-modextravars = {
-    'IMOD_JAVADIR': '\$EBROOTJAVA',
-}
-
-sanity_check_paths = {
-    'files': ['IMOD/bin/imod'],
-    'dirs': [],
-}
-
-moduleclass = 'bio'
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-pompi-2016.09.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-pompi-2016.09.eb
@@ -1,0 +1,38 @@
+# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+
+name = 'imkl'
+version = '11.3.3.210'
+
+homepage = 'http://software.intel.com/en-us/intel-mkl/'
+description = """Intel Math Kernel Library is a library of highly optimized,
+ extensively threaded math routines for science, engineering, and financial
+ applications that require maximum performance. Core math functions include
+ BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
+
+toolchain = {'name': 'pompi', 'version': '2016.09'}
+
+sources = ['l_mkl_%(version)s.tgz']
+checksums = ['f72546df27f5ebb0941b5d21fd804e34']
+
+dontcreateinstalldir = 'True'
+
+license_file = HOME + '/licenses/intel/license.lic'
+
+components = ['intel-mkl']
+
+interfaces = True
+
+postinstallcmds = [
+    # extract the examples
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_f95.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_mic.tgz -C %(installdir)s/mkl/examples/'
+]
+
+modextravars = {
+    'MKL_EXAMPLES': '%(installdir)s/mkl/examples/',
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/j/jemalloc/jemalloc-4.2.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/j/jemalloc/jemalloc-4.2.1-intel-2016b.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'jemalloc'
+version = '4.2.1'
+
+homepage = 'http://www.canonware.com/jemalloc'
+description = """jemalloc is a general purpose malloc(3) implementation that emphasizes fragmentation avoidance and
+ scalable concurrency support."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+
+source_urls = ['https://github.com/jemalloc/jemalloc/archive']
+sources = ['%(version)s.tar.gz']
+
+builddependencies = [('Autotools', '20150215')]
+
+preconfigopts = "./autogen.sh && "
+prebuildopts = "make dist && "
+
+sanity_check_paths = {
+    'files': ['bin/jeprof', 'lib/libjemalloc.a', 'lib/libjemalloc_pic.a', 'lib/libjemalloc.%s' % SHLIB_EXT,
+              'include/jemalloc/jemalloc.h'],
+    'dirs': ['share'],
+}
+
+modextrapaths = {'LD_PRELOAD': ['lib/libjemalloc.%s' % SHLIB_EXT]}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-3.9.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-3.9.0-foss-2016b.eb
@@ -1,0 +1,43 @@
+easyblock = 'CMakeMake'
+
+name = 'LLVM'
+version = '3.9.0'
+
+homepage = "http://llvm.org/"
+description = """The LLVM Core libraries provide a modern source- and target-independent
+ optimizer, along with code generation support for many popular CPUs
+ (as well as some less common ones!) These libraries are built around a well
+ specified code representation known as the LLVM intermediate representation
+ ("LLVM IR"). The LLVM Core libraries are well documented, and it is
+ particularly easy to invent your own language (or port an existing compiler)
+ to use LLVM as an optimizer and code generator."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'cstd': 'gnu++11'}
+
+source_urls = ["http://llvm.org/releases/%(version)s"]
+sources = ["llvm-%(version)s.src.tar.xz"]
+
+builddependencies = [
+    ('CMake', '3.6.1'),
+    ('Python', '2.7.12'),
+]
+
+dependencies = [
+    ('ncurses', '6.0'),
+    ('zlib', '1.2.8'),
+]
+
+configopts = '-DBUILD_SHARED_LIBS=ON '
+# required to install extra tools in bin/
+configopts += '-DLLVM_INSTALL_UTILS=ON -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_ZLIB=ON '
+configopts += '-DCMAKE_BUILD_TYPE=Release '
+
+sanity_check_paths = {
+    'files': ['bin/llvm-ar', 'bin/FileCheck'],
+    'dirs': ['include/llvm', 'include/llvm-c'],
+}
+
+separate_build_dir = True
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-3.9.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-3.9.0-intel-2016b.eb
@@ -1,0 +1,45 @@
+easyblock = 'CMakeMake'
+
+name = 'LLVM'
+version = '3.9.0'
+
+homepage = "http://llvm.org/"
+description = """The LLVM Core libraries provide a modern source- and target-independent
+ optimizer, along with code generation support for many popular CPUs
+ (as well as some less common ones!) These libraries are built around a well
+ specified code representation known as the LLVM intermediate representation
+ ("LLVM IR"). The LLVM Core libraries are well documented, and it is
+ particularly easy to invent your own language (or port an existing compiler)
+ to use LLVM as an optimizer and code generator."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+toolchainopts = {'cstd': 'gnu++11'}
+
+source_urls = ["http://llvm.org/releases/%(version)s"]
+sources = ["llvm-%(version)s.src.tar.xz"]
+
+patches = ['LLVM-3.9.0-intel-fix-loop.patch']
+
+builddependencies = [
+    ('CMake', '3.6.1'),
+    ('Python', '2.7.12'),
+]
+
+dependencies = [
+    ('ncurses', '6.0'),
+    ('zlib', '1.2.8'),
+]
+
+configopts = '-DBUILD_SHARED_LIBS=ON -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS -shared-intel" '
+# required to install extra tools in bin/
+configopts += '-DLLVM_INSTALL_UTILS=ON -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_ZLIB=ON '
+configopts += '-DCMAKE_BUILD_TYPE=Release '
+
+sanity_check_paths = {
+    'files': ['bin/llvm-ar', 'bin/FileCheck'],
+    'dirs': ['include/llvm', 'include/llvm-c'],
+}
+
+separate_build_dir = True
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/l/LLVM/LLVM-3.9.0-intel-fix-loop.patch
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-3.9.0-intel-fix-loop.patch
@@ -1,0 +1,26 @@
+# Bug in intel compiler
+# Source: From https://sft.its.cern.ch/jira/browse/ROOT-8233
+diff -ur llvm-3.9.0rc3.src.orig/lib/Transforms/Utils/LoopUtils.cpp llvm-3.9.0rc3.src/lib/Transforms/Utils/LoopUtils.cpp
+--- llvm-3.9.0rc3.src.orig/lib/Transforms/Utils/LoopUtils.cpp	2016-06-11 23:48:25.000000000 +0200
++++ llvm-3.9.0rc3.src/lib/Transforms/Utils/LoopUtils.cpp	2016-09-01 11:40:34.394205219 +0200
+@@ -834,6 +834,11 @@
+   return UsedOutside;
+ }
+
++namespace llvm {
++  extern char &LoopSimplifyID;
++  extern char &LCSSAID;
++}
++
+ void llvm::getLoopAnalysisUsage(AnalysisUsage &AU) {
+   // By definition, all loop passes need the LoopInfo analysis and the
+   // Dominator tree it depends on. Because they all participate in the loop
+@@ -845,8 +850,6 @@
+
+   // We must also preserve LoopSimplify and LCSSA. We locally access their IDs
+   // here because users shouldn't directly get them from this header.
+-  extern char &LoopSimplifyID;
+-  extern char &LCSSAID;
+   AU.addRequiredID(LoopSimplifyID);
+   AU.addPreservedID(LoopSimplifyID);
+   AU.addRequiredID(LCSSAID);

--- a/easybuild/easyconfigs/l/Libint/Libint-2.1.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/Libint/Libint-2.1.0-intel-2016b.eb
@@ -1,0 +1,21 @@
+name = 'Libint'
+version = '2.1.0'
+
+homepage = 'https://github.com/evaleev/libint'
+description = """Libint library is used to evaluate the traditional (electron repulsion) and certain novel two-body
+ matrix elements (integrals) over Cartesian Gaussian functions used in modern atomic and molecular theory."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+toolchainopts = {'pic': True}
+
+sources = ['libint-%(version)s-stable.tgz']
+source_urls = ['https://github.com/evaleev/libint/releases/download/v%(version)s']
+
+builddependencies = [
+    ('GMP', '6.1.1'),
+    ('Boost', '1.61.0', '-Python-2.7.12'),
+    ('Eigen', '3.2.9'),
+    ('Python', '2.7.12'),
+]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/libGLU/libGLU-9.0.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libGLU/libGLU-9.0.0-intel-2016b.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = 'libGLU'
+version = '9.0.0'
+
+homepage = 'ftp://ftp.freedesktop.org/pub/mesa/glu/'
+description = """The OpenGL Utility Library (GLU) is a computer graphics library for OpenGL. """
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['ftp://ftp.freedesktop.org/pub/mesa/glu/']
+sources = ['glu-%(version)s.tar.bz2']
+
+dependencies = [
+    ('Mesa', '12.0.1'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libGLU.so.1'],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libGLU/libGLU-9.0.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libGLU/libGLU-9.0.0-intel-2016b.eb
@@ -13,7 +13,7 @@ source_urls = ['ftp://ftp.freedesktop.org/pub/mesa/glu/']
 sources = ['glu-%(version)s.tar.bz2']
 
 dependencies = [
-    ('Mesa', '12.0.1'),
+    ('Mesa', '12.0.2'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libdrm/libdrm-2.4.70-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libdrm/libdrm-2.4.70-intel-2016b.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = 'libdrm'
+version = '2.4.70'
+
+homepage = 'http://dri.freedesktop.org'
+description = """Direct Rendering Manager runtime library."""
+
+source_urls = ['http://dri.freedesktop.org/libdrm/']
+sources = [SOURCELOWER_TAR_GZ]
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+
+dependencies = [
+    ('X11', '20160819'),
+]
+
+sanity_check_paths = {
+    'files': ['include/xf86drm.h', 'include/xf86drmMode.h', 'lib/libdrm_intel.%s' % SHLIB_EXT,
+              'lib/libdrm_radeon.%s' % SHLIB_EXT, 'lib/libdrm.%s' % SHLIB_EXT, 'lib/libkms.%s' % SHLIB_EXT],
+    'dirs': ['include/libdrm', 'include/libkms', 'lib/pkgconfig'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libffi/libffi-3.2.1-foss-2016.04.eb
+++ b/easybuild/easyconfigs/l/libffi/libffi-3.2.1-foss-2016.04.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'libffi'
+version = '3.2.1'
+
+homepage = 'http://sourceware.org/libffi/'
+description = """The libffi library provides a portable, high level programming interface to various calling
+conventions. This allows a programmer to call any function specified by a call interface description at run-time."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+source_urls = [
+    'ftp://sourceware.org/pub/libffi/',
+    'http://www.mirrorservice.org/sites/sourceware.org/pub/libffi/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+sanity_check_paths = {
+    'files': [('lib/libffi.%s' % SHLIB_EXT, 'lib64/libffi.%s' % SHLIB_EXT), ('lib/libffi.a', 'lib64/libffi.a')],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2016.04.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2016.04.eb
@@ -1,0 +1,32 @@
+easyblock = 'ConfigureMake'
+
+name = 'libreadline'
+version = '6.3'
+
+homepage = 'http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html'
+description = """The GNU Readline library provides a set of functions for use by applications that
+ allow users to edit command lines as they are typed in. Both Emacs and vi editing modes are available.
+ The Readline library includes additional functions to maintain a list of previously-entered command lines,
+ to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True}
+
+sources = ['readline-%(version)s.tar.gz']
+source_urls = ['http://ftp.gnu.org/gnu/readline']
+
+patches = ['libreadline-%(version)s-bugfix.patch']
+
+dependencies = [('ncurses', '6.0')]
+
+# for the termcap symbols, use EB ncurses
+preconfigopts = "env LDFLAGS='-lncurses'"
+
+sanity_check_paths = {
+    'files': ['lib/libreadline.a', 'lib/libhistory.a'] +
+    ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',
+                                         'rlstdc.h', 'rltypedefs.h', 'tilde.h']],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libtool/libtool-2.4.6-foss-2016.04.eb
+++ b/easybuild/easyconfigs/l/libtool/libtool-2.4.6-foss-2016.04.eb
@@ -1,0 +1,17 @@
+easyblock = 'ConfigureMake'
+
+name = 'libtool'
+version = '2.4.6'
+
+homepage = 'http://www.gnu.org/software/libtool'
+description = """GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries
+ behind a consistent, portable interface."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [('M4', '1.4.17')]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.4-foss-2016.04.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.4-foss-2016.04.eb
@@ -1,0 +1,20 @@
+name = 'libxml2'
+version = '2.9.4'
+
+homepage = 'http://xmlsoft.org/'
+description = """Libxml2 is the XML C parser and 
+toolchain developed for the Gnome project
+ (but usable outside of the Gnome platform)."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True}
+
+source_urls = [
+    'http://xmlsoft.org/sources/',
+    'http://xmlsoft.org/sources/old/'
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('zlib', '1.2.8')]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.4-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.4-intel-2016b-Python-2.7.12.eb
@@ -1,0 +1,23 @@
+name = 'libxml2'
+version = '2.9.4'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://xmlsoft.org/'
+description = """Libxml2 is the XML C parser and toolchain developed for the Gnome project (but usable
+ outside of the Gnome platform)."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+toolchainopts = {'pic': True}
+
+source_urls = [
+    'http://xmlsoft.org/sources/',
+    'http://xmlsoft.org/sources/old/'
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('zlib', '1.2.8'),
+    ('Python', '2.7.12'),
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.1.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'M4'
+version = '1.4.17'
+
+homepage = 'http://www.gnu.org/software/m4/m4.html'
+description = """GNU M4 is an implementation of the traditional Unix macro processor. It is mostly SVR4 compatible
+  although it has some extensions (for example, handling more than 9 positional parameters to macros).
+ GNU M4 also has built-in functions for including files, running shell commands, doing arithmetic, etc."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.1.0'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+# use same binutils version that was used when building GCCcore
+builddependencies = [('binutils', '2.27', '', True)]
+
+configopts = "--enable-cxx"
+
+sanity_check_paths = {
+    'files': ["bin/m4"],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016.04.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016.04.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'M4'
+version = '1.4.17'
+
+homepage = 'http://www.gnu.org/software/m4/m4.html'
+description = """GNU M4 is an implementation of the traditional Unix macro processor. It is mostly SVR4 compatible
+  although it has some extensions (for example, handling more than 9 positional parameters to macros).
+ GNU M4 also has built-in functions for including files, running shell commands, doing arithmetic, etc."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+
+sanity_check_paths = {
+    'files': ["bin/m4"],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/m/MIRA/MIRA-4.0.2-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/MIRA/MIRA-4.0.2-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,36 @@
+easyblock = 'ConfigureMake'
+
+name = 'MIRA'
+version = '4.0.2'
+versionsuffix = '-Python-2.7.11'
+
+homepage = 'http://sourceforge.net/p/mira-assembler/wiki/Home/'
+description = """MIRA is a whole genome shotgun and EST sequence assembler for Sanger, 454, Solexa (Illumina),
+    IonTorrent data and PacBio (the later at the moment only CCS and error-corrected CLR reads)."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+sources = ['%(namelower)s-%(version)s.tar.bz2']
+source_urls = [('http://sourceforge.net/projects/mira-assembler/files/MIRA/stable/', 'download')]
+
+# don't use PAX, it might break.
+tar_config_opts = True
+
+configopts = '--with-boost-libdir=$EBROOTBOOST/lib --with-expat=$EBROOTEXPAT'
+
+patches = ['MIRA-%(version)s-quirks.patch']
+
+builddependencies = [('flex', '2.5.39')]
+dependencies = [
+    ('Boost', '1.61.0', versionsuffix),
+    ('expat', '2.1.1'),
+    ('zlib', '1.2.8'),
+    ('gperftools', '2.5'),
+]
+
+sanity_check_paths = {
+    'files': ["bin/mira"],
+    'dirs': ["bin", "share"],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/Mako/Mako-1.0.4-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/Mako/Mako-1.0.4-intel-2016b-Python-2.7.12.eb
@@ -1,0 +1,22 @@
+easyblock = 'PythonPackage'
+
+name = 'Mako'
+version = '1.0.4'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://www.makotemplates.org'
+description = """A super-fast templating language that borrows the best ideas from the existing templating languages"""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [('Python', '2.7.12')]
+
+sanity_check_paths = {
+    'files': ['bin/mako-render'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s-%(version)s-py%(pyshortver)s.egg'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/m/MariaDB/MariaDB-10.1.17-intel-2016b.eb
+++ b/easybuild/easyconfigs/m/MariaDB/MariaDB-10.1.17-intel-2016b.eb
@@ -1,0 +1,43 @@
+easyblock = 'CMakeMake'
+
+name = 'MariaDB'
+version = '10.1.17'
+
+homepage = 'https://mariadb.org/'
+description = """MariaDB An enhanced, drop-in replacement for MySQL."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+
+source_urls = ['https://downloads.mariadb.org/f/mariadb-%(version)s/source']
+sources = [SOURCELOWER_TAR_GZ]
+
+patches = [
+    'MariaDB-10.1.13-remove-Werror.patch',
+    'MariaDB-10.1.13-link-rt-for-jemalloc.patch',
+]
+
+dependencies = [
+    ('zlib', '1.2.8'),
+    ('ncurses', '6.0'),
+    ('jemalloc', '4.2.1'),
+    ('PCRE', '8.39'),
+    ('XZ', '5.2.2'),
+    ('Boost', '1.61.0', '-Python-2.7.12'),
+    ('libxml2', '2.9.4'),
+]
+
+builddependencies = [('CMake', '3.6.1')]
+
+separate_build_dir = True
+
+configopts = "-DWITH_PCRE=system -DWITH_JEMALLOC=yes -DWITH_ZLIB=system -DMYSQL_MAINTAINER_MODE=ON "
+configopts += "-DWITH_EMBEDDED_SERVER=ON "  # for libmysqld.so & co
+configopts += "-DWITHOUT_TOKUDB=ON "  # not supported with Intel compilers
+
+sanity_check_paths = {
+    'files': ['bin/mysql', 'bin/mysqld_safe', 'lib/libmysqlclient.%s' % SHLIB_EXT, 'lib/libmysqld.%s' % SHLIB_EXT,
+              'scripts/mysql_install_db'],
+    'dirs': ['include', 'share'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/m/Mesa/Mesa-12.0.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-12.0.1-intel-2016b.eb
@@ -1,0 +1,56 @@
+# the purpose of the easyconfig is to build a Mesa for software rendering,
+# not hardware rendering. This means you want at least SSE4.2. We build:
+# - llvmpipe: the high-performance Gallium LLVM driver
+# - swr: Intel's OpenSWR
+# it will try to use the llvmpipe by default. It you want swr, do:
+# GALLIUM_DRIVER=swr
+
+easyblock = 'ConfigureMake'
+
+name = 'Mesa'
+version = '12.0.1'
+
+homepage = 'http://www.mesa3d.org/'
+description = """Mesa is an open-source implementation of the OpenGL specification -
+ a system for rendering interactive 3D graphics."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+
+sources = [SOURCELOWER_TAR_XZ]
+source_urls = [
+    'https://mesa.freedesktop.org/archive/%(version)s',
+    'ftp://ftp.freedesktop.org/pub/mesa/%(version)s',
+    'ftp://ftp.freedesktop.org/pub/mesa/older-versions/%(version_major)s.x/%(version)s',
+]
+
+builddependencies = [
+    ('flex', '2.6.0'),
+    ('Bison', '3.0.4'),
+    ('Autotools', '20150215'),
+    ('pkg-config', '0.29.1'),
+    ('Mako', '1.0.4', '-Python-2.7.12'),
+    ('libxml2', '2.9.4', '-Python-2.7.12'),
+]
+
+dependencies = [
+    ('zlib', '1.2.8'),
+    ('nettle', '3.2'),
+    ('libdrm', '2.4.70'),
+    ('LLVM', '3.8.1'),
+    ('X11', '20160819'),
+]
+
+# GLU is not part anymore of Mesa package!
+configopts = " --disable-osmesa --enable-gallium-osmesa --enable-gallium-llvm --enable-glx --disable-dri"
+configopts += " --disable-driglx-direct --with-gallium-drivers='swrast,swr' --disable-egl"
+configopts += " --with-osmesa-bits=32 --enable-texture-float --enable-llvm-shared-libs "
+
+sanity_check_paths = {
+    'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libOSMesa.%s' % SHLIB_EXT, 'lib/libGLESv1_CM.%s' % SHLIB_EXT,
+              'lib/libGLESv2.%s' %SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h', 'include/GL/glx.h',
+              'include/GL/osmesa.h', 'include/GL/wglext.h', 'include/GL/gl.h', 'include/GL/glxext.h',
+              'include/GL/glx_mangle.h', 'include/GLES/gl.h', 'include/GLES2/gl2.h', 'include/GLES3/gl3.h'],
+    'dirs': []
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/Mesa/Mesa-12.0.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-12.0.2-intel-2016b.eb
@@ -8,13 +8,16 @@
 easyblock = 'ConfigureMake'
 
 name = 'Mesa'
-version = '12.0.1'
+version = '12.0.2'
 
 homepage = 'http://www.mesa3d.org/'
 description = """Mesa is an open-source implementation of the OpenGL specification -
  a system for rendering interactive 3D graphics."""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
+# swr detects and builds parts specific for AVX and AVX2. If we use
+# -xHost, this always gets overwritten and will fail.
+toolchainopts = {'optarch': False}
 
 sources = [SOURCELOWER_TAR_XZ]
 source_urls = [

--- a/easybuild/easyconfigs/n/nettle/nettle-3.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/n/nettle/nettle-3.2-intel-2016b.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'nettle'
+version = '3.2'
+
+homepage = 'http://www.lysator.liu.se/~nisse/nettle/'
+description = """Nettle is a cryptographic library that is designed to fit easily
+ in more or less any context: In crypto toolkits for object-oriented
+ languages (C++, Python, Pike, ...), in applications like LSH or GNUPG,
+ or even in kernel space."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('GMP', '6.1.1'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['nettle-hash', 'nettle-lfib-stream', 'pkcs1-conv', 'sexp-conv']] +
+             ['lib64/libhogweed.a', 'lib64/libhogweed.%s' % SHLIB_EXT,
+              'lib64/libnettle.a', 'lib64/libnettle.%s' % SHLIB_EXT],
+    'dirs': ['include/nettle'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/numactl/numactl-2.0.11-GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/n/numactl/numactl-2.0.11-GCC-6.1.0-2.27.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'numactl'
+version = '2.0.11'
+
+homepage = 'http://oss.sgi.com/projects/libnuma/'
+description = """The numactl program allows you to run your application program on specific cpu's and memory nodes.
+It does this by supplying a NUMA memory policy to the operating system before running your program.
+The libnuma library provides convenient ways for you to add NUMA memory policies into your own program."""
+
+toolchain = {'name': 'GCC', 'version': '6.1.0-2.27'}
+
+source_urls = ['ftp://oss.sgi.com/www/projects/libnuma/download/']
+sources = [SOURCE_TAR_GZ]
+
+checksums = ['d3bc88b7ddb9f06d60898f4816ae9127']
+
+sanity_check_paths = {
+    'files': ['bin/numactl', 'bin/numastat', 'lib/libnuma.%s' % SHLIB_EXT, 'lib/libnuma.a'],
+    'dirs': ['share/man', 'include']
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
@@ -1,0 +1,49 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenBLAS'
+version = '0.2.18'
+
+lapackver = '3.6.1'
+versionsuffix = '-LAPACK-%s' % lapackver
+
+homepage = 'http://xianyi.github.com/OpenBLAS/'
+description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
+
+toolchain = {'name': 'gompi', 'version': '2016.07'}
+
+lapack_src = 'lapack-%s.tgz' % lapackver
+large_src = 'large.tgz'
+timing_src = 'timing.tgz'
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
+source_urls = [
+    # order matters, trying to download the LAPACK tarball from GitHub causes trouble
+    "http://www.netlib.org/lapack/",
+    "http://www.netlib.org/lapack/timing/",
+    "https://github.com/xianyi/OpenBLAS/archive/",
+]
+
+patches = [
+    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    (large_src, '.'),
+    (timing_src, '.'),
+]
+
+skipsteps = ['configure']
+
+threading = 'USE_THREAD=1'
+buildopts = 'BINARY=64 ' + threading + ' CC="$CC" FC="$F77"'
+installopts = threading + " PREFIX=%(installdir)s"
+
+sanity_check_paths = {
+    'files': ['include/cblas.h', 'include/f77blas.h', 'include/lapacke_config.h', 'include/lapacke.h',
+              'include/lapacke_mangling.h', 'include/lapacke_utils.h', 'include/openblas_config.h',
+              'lib/libopenblas.a', 'lib/libopenblas.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/o/OpenBabel/OpenBabel-2.3.2-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/o/OpenBabel/OpenBabel-2.3.2-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,36 @@
+name = 'OpenBabel'
+version = '2.3.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://openbabel.org'
+description = """Open Babel is a chemical toolbox designed to speak the many
+ languages of chemical data. It's an open, collaborative project allowing anyone
+ to search, convert, analyze, or store data from molecular modeling, chemistry,
+ solid-state materials, biochemistry, or related areas."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+toolchainopts = {'strict': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+patches = [
+    'OpenBabel-%(version)s-fix-link-path-tests.patch',
+    'OpenBabel-%(version)s-ignore-failed-test.patch',
+    'OpenBabel-%(version)s-ignore-rotor-test.patch',
+]
+
+builddependencies = [
+    ('CMake', '3.5.2'),
+]
+
+dependencies = [
+    ('Python', '2.7.11'),
+    ('zlib', '1.2.8'),
+    ('libxml2', '2.9.3'),
+    ('Eigen', '3.2.8'),
+]
+
+runtest = 'test'
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/o/OpenBabel/OpenBabel-2.3.2-ignore-rotor-test.patch
+++ b/easybuild/easyconfigs/o/OpenBabel/OpenBabel-2.3.2-ignore-rotor-test.patch
@@ -1,0 +1,12 @@
+# The rotor tests fails, it is removed from the test set.
+# Author: Ruben van Dijk (University of Groningen)
+--- test/CMakeLists.txt.orig	2016-09-05 15:17:23.000000000 +0200
++++ test/CMakeLists.txt	2016-09-05 15:17:38.000000000 +0200
+@@ -18,7 +18,6 @@
+     implicitH
+     lssr
+     isomorphism
+-    rotor
+     shuffle
+     smiles
+     spectrophore

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-GCC-6.1.0-2.27.eb
@@ -1,0 +1,33 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '1.10.2'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'GCC', 'version': '6.1.0-2.27'}
+
+sources = [SOURCELOWER_TAR_GZ]
+
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads',]
+
+dependencies = [('hwloc', '1.11.3')]
+
+configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+
+# needed for --with-verbs
+osdependencies = [('libibverbs-dev', 'libibverbs-devel'),]
+
+libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-6.1.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.3-GCC-6.1.0-2.27.eb
@@ -1,0 +1,33 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '1.10.3'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'GCC', 'version': '6.1.0-2.27'}
+
+sources = [SOURCELOWER_TAR_GZ]
+
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads',]
+
+dependencies = [('hwloc', '1.11.3')]
+
+configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+
+# needed for --with-verbs
+osdependencies = [('libibverbs-dev', 'libibverbs-devel'),]
+
+libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-PGI-16.7-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-PGI-16.7-GCC-5.4.0-2.26.eb
@@ -1,0 +1,41 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '1.10.4'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'PGI', 'version': '16.7-GCC-5.4.0-2.26'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+
+checksums = ['fb2fdb6a5b65c80d7dfa4bc9a0caf665']
+
+configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--with-cxxrtlib="-lgcc_s -lstdc++"' # for vt-mpi-unify
+
+dependencies = [('hwloc', '1.11.4')]
+
+# needed for --with-verbs
+osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+
+libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
+
+sanity_check_commands = [
+    ('mpicc --version | grep pgcc', ''),
+    ('mpicxx --version | grep pgc++', ''),
+    ('mpifort --version | grep pgfortran', ''),
+]
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenSSL/OpenSSL-1.0.2h-foss-2016.04.eb
+++ b/easybuild/easyconfigs/o/OpenSSL/OpenSSL-1.0.2h-foss-2016.04.eb
@@ -1,0 +1,19 @@
+name = 'OpenSSL'
+version = '1.0.2h'
+
+homepage = 'http://www.openssl.org/'
+description = """The OpenSSL Project is a collaborative effort to develop a robust, commercial-grade, full-featured,
+ and Open Source toolchain implementing the Secure Sockets Layer (SSL v2/v3) and Transport Layer Security (TLS v1) 
+ protocols as well as a full-strength general purpose cryptography library. """
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.openssl.org/source/']
+
+dependencies = [('zlib', '1.2.8')]
+
+runtest = 'test'
+
+moduleclass = 'system'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-GCC-4.9.3-2.25-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-GCC-4.9.3-2.25-bare.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3', '', ('GCCcore', '4.9.3')),
     ('ncurses', '6.0', '', ('GCCcore', '4.9.3')),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-GNU-4.9.3-2.25-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-GNU-4.9.3-2.25-bare.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015a.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.0.0a', '', ('GCC', '4.9.2')),  # required for pycrypto
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015b.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.0.0a', '', ('GNU', '4.9.3-2.25')),  # required for pycrypto
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-gimkl-2.11.5.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.4.10.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.0.0a', '', ('GCC', '4.7.2')),  # required for pycrypto
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.7.20.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.0.0a', '', ('GCC', '4.8.4')),  # required for pycrypto
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015a.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.0.0a', '', ('GCC', '4.9.2')),  # required for pycrypto
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015b.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-CrayGNU-2015.11.eb
@@ -26,7 +26,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'), 
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack 
     ('GMP', '6.1.0'),
 ]
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-CrayGNU-2016.03.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-CrayGNU-2016.03.eb
@@ -26,7 +26,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'), 
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack 
     ('GMP', '6.1.0'),
 ]
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-GCC-4.9.3-2.25-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-GCC-4.9.3-2.25-bare.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('libreadline', '6.3', '', ('GCCcore', '4.9.3')),
     ('ncurses', '6.0', '', ('GCCcore', '4.9.3')),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2015a.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.10.0'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),  # required for pycrypto
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2016a.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-gimkl-2.11.5.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-goolf-1.7.20.eb
@@ -21,8 +21,8 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.9.2'),
-    #('Tk', '8.6.4', '-no-X11'),
-    ('Tk', '8.6.4'),
+    #('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
+    ('Tk', '8.6.4'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
 #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
 #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2015b.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016.02-GCC-4.9.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016a.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.12-GCC-5.4.0-2.26-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.12-GCC-5.4.0-2.26-bare.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.13.0'),
-    ('Tk', '8.6.5'),
+    ('Tk', '8.6.5'),  # this requires a full X11 stack
     ('GMP', '6.1.1'),
     ('libffi', '3.2.1'),
     # OS dependency should be preferred if the os version is more recent then this version,

--- a/easybuild/easyconfigs/p/Python/Python-2.7.12-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.12-foss-2016b.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.13.0'),
-    ('Tk', '8.6.5'),
+    ('Tk', '8.6.5'),  # this requires a full X11 stack
     ('GMP', '6.1.1'),
     ('libffi', '3.2.1'),
     # OS dependency should be preferred if the os version is more recent then this version,

--- a/easybuild/easyconfigs/p/Python/Python-2.7.12-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.12-intel-2016b.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.13.0'),
-    ('Tk', '8.6.5'),
+    ('Tk', '8.6.5'),  # this requires a full X11 stack
     ('GMP', '6.1.1'),
     ('libffi', '3.2.1'),
     # OS dependency should be preferred if the os version is more recent then this version,

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-GCC-4.9.2-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-GCC-4.9.2-bare.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015.05.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015.05.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a-bare.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015b.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
 #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
 #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-gompi-1.5.16-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-gompi-1.5.16-bare.eb
@@ -17,7 +17,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.16.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.16.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
 #    ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.7.20.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a-bare.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-3.5.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.0-intel-2015b.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     #   ('OpenSSL', '1.0.1p'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2016a.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     ('XZ', '5.2.2'),
 #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's

--- a/easybuild/easyconfigs/p/Python/Python-3.5.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.1-intel-2016a.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     ('XZ', '5.2.2'),
 #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's

--- a/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016.04.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016.04.eb
@@ -1,0 +1,117 @@
+name = 'Python'
+version = '3.5.2'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly
+ and integrate your systems more effectively."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libreadline', '6.3'),
+    ('ncurses', '6.0'),
+    ('SQLite', '3.13.0'),
+    ('Tk', '8.6.5'),  # this requires a full X11 stack
+    ('GMP', '6.1.1'),
+    ('XZ', '5.2.2'),
+    ('libffi', '3.2.1'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    #('OpenSSL', '1.0.2h'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# order is important!
+# package versions updated May 28th 2015
+exts_list = [
+    ('setuptools', '23.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+    }),
+    ('pip', '8.1.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    ('numpy', '1.11.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy'],
+        'patches': ['numpy-1.8.0-mkl.patch'],
+    }),
+    ('scipy', '0.17.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+    }),
+    ('mpi4py', '1.3.1', {
+        'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+    }),
+    ('paycheck', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+    }),
+    ('pbr', '1.10.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
+    ('lockfile', '0.12.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+    }),
+    ('Cython', '0.24', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+    }),
+    ('six', '1.10.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+    }),
+    ('dateutil', '2.5.3', {
+        'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+    }),
+    ('deap', '1.0.2', {
+        'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+    }),
+    ('decorator', '4.0.10', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+    }),
+    ('arff', '2.1.0', {
+        'source_tmpl': 'liac-%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+    }),
+    ('cryptography', '1.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
+    }),
+    ('paramiko', '2.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+    }),
+    ('pyparsing', '2.1.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+    }),
+    ('netifaces', '0.10.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+    }),
+    ('netaddr', '0.7.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('pandas', '0.18.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+    }),
+    ('virtualenv', '15.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016b.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.13.0'),
-    ('Tk', '8.6.5'),
+    ('Tk', '8.6.5'),  # this requires a full X11 stack
     ('GMP', '6.1.1'),
     ('XZ', '5.2.2'),
     ('libffi', '3.2.1'),

--- a/easybuild/easyconfigs/p/Python/Python-3.5.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.2-intel-2016b.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.13.0'),
-    ('Tk', '8.6.5'),
+    ('Tk', '8.6.5'),  # this requires a full X11 stack
     ('GMP', '6.1.1'),
     ('XZ', '5.2.2'),
     ('libffi', '3.2.1'),

--- a/easybuild/easyconfigs/p/pomkl/pomkl-2016.09.eb
+++ b/easybuild/easyconfigs/p/pomkl/pomkl-2016.09.eb
@@ -1,0 +1,20 @@
+easyblock = "Toolchain"
+
+name = 'pomkl'
+version = '2016.09'
+
+homepage = 'http://www.pgroup.com/index.htm'
+description = """Toolchain with PGI C, C++ and Fortran compilers, alongside Intel MKL & OpenMPI."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+compver = '16.7'
+gccsuff = '-GCC-5.4.0-2.26'
+
+dependencies = [
+    ('PGI', compver, gccsuff),
+    ('OpenMPI', '1.10.4', '', ('PGI', '%s%s' % (compver, gccsuff))),
+    ('imkl', '11.3.3.210', '', ('pompi', '%s' % (version))),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/p/pompi/pompi-2016.09.eb
+++ b/easybuild/easyconfigs/p/pompi/pompi-2016.09.eb
@@ -1,0 +1,19 @@
+easyblock = "Toolchain"
+
+name = 'pompi'
+version = '2016.09'
+pgisuffix = '-GCC-5.4.0-2.26'
+
+homepage = 'http://www.pgroup.com/index.htm'
+description = """Toolchain with PGI C, C++ and Fortran compilers, alongside OpenMPI."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+compver = '16.7'
+
+dependencies = [
+    ('PGI', compver, pgisuffix),
+    ('OpenMPI', '1.10.4', '', ('PGI', '%s%s' % (compver, pgisuffix))),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-foss-2016.04.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-foss-2016.04.eb
@@ -1,0 +1,40 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'SQLite'
+version = '3.13.0'
+
+homepage = 'http://www.sqlite.org/'
+description = 'SQLite: SQL Database Engine in a C Library'
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+source_urls = ['http://www.sqlite.org/2016/']
+version_minor_etc = version.split('.')[1:]
+version_minor_etc += '0' * (3 - len(version_minor_etc))
+version_str = '%(version_major)s' + ''.join('%02d' % int(x) for x in version_minor_etc)
+sources = ['sqlite-autoconf-%s.tar.gz' % version_str]
+
+dependencies = [
+    ('libreadline', '6.3'),
+    ('Tcl', '8.6.5'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/sqlite3', 'include/sqlite3ext.h', 'include/sqlite3.h', 'lib/libsqlite3.a',
+              'lib/libsqlite3.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.07-OpenBLAS-0.2.18-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.07-OpenBLAS-0.2.18-LAPACK-3.6.1.eb
@@ -1,0 +1,25 @@
+name = 'ScaLAPACK'
+version = '2.0.2'
+
+homepage = 'http://www.netlib.org/scalapack/'
+description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
+ redesigned for distributed memory MIMD parallel computers."""
+
+toolchain = {'name': 'gompi', 'version': '2016.07'}
+toolchainopts = {'pic': True}
+
+source_urls = [homepage]
+sources = [SOURCELOWER_TGZ]
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.18'
+blassuff = '-LAPACK-3.6.1'
+
+versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+
+dependencies = [(blaslib, blasver, blassuff)]
+
+# parallel build tends to fail, so disabling it
+parallel = 1
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-foss-2016.04.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-foss-2016.04.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'Tcl'
+version = '8.6.5'
+
+homepage = 'http://www.tcl.tk/'
+description = """Tcl (Tool Command Language) is a very powerful but easy to learn dynamic programming language,
+suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+source_urls = ["http://prdownloads.sourceforge.net/tcl"]
+sources = ['%(namelower)s%(version)s-src.tar.gz']
+
+dependencies = [
+    ('zlib', '1.2.8'),
+]
+
+configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
+
+runtest = 'test'
+
+start_dir = 'unix'
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-GCC-4.9.2-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-GCC-4.9.2-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-foss-2015.05-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-foss-2015.05-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-foss-2015a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-foss-2015a-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-foss-2015b-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-foss-2015b-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-gompi-1.5.16-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-gompi-1.5.16-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-goolf-1.5.14-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-goolf-1.5.14-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-goolf-1.5.16-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-goolf-1.5.16-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-goolf-1.7.20-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-goolf-1.7.20-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-intel-2015a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-intel-2015a-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-CrayGNU-2015.11-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-CrayGNU-2015.11-no-X11.eb
@@ -19,6 +19,7 @@ dependencies = [
     ('Tcl', version),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-CrayGNU-2016.03-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-CrayGNU-2016.03-no-X11.eb
@@ -19,6 +19,7 @@ dependencies = [
     ('Tcl', version),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-GCC-4.9.3-2.25-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-GCC-4.9.3-2.25-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-GNU-4.9.3-2.25-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-GNU-4.9.3-2.25-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2015a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2015a-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2015b-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2015b-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2016a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2016a-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8')
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-gimkl-2.11.5-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-gimkl-2.11.5-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-goolf-1.4.10-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-goolf-1.4.10-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-goolf-1.7.20-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-goolf-1.7.20-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-ictce-7.3.5-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-ictce-7.3.5-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2015a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2015a-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2015b-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2015b-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2016.02-GCC-4.9-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2016.02-GCC-4.9-no-X11.eb
@@ -19,6 +19,7 @@ dependencies = [
     ('Tcl', version),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2016a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2016a-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.5-foss-2016.04.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.5-foss-2016.04.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'Tk'
+version = '8.6.5'
+
+homepage = 'http://www.tcl.tk/'
+description = """Tk is an open source, cross-platform widget toolchain that provides a library of basic elements for
+ building a graphical user interface (GUI) in many different programming languages."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+source_urls = ["http://prdownloads.sourceforge.net/tcl"]
+sources = ['%(namelower)s%(version)s-src.tar.gz']
+
+patches = ['Tk-8.6.4_different-prefix-with-tcl.patch']
+
+dependencies = [
+    ('Tcl', version),
+    ('zlib', '1.2.8'),
+]
+
+configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib CFLAGS="-I$EBROOTTCL/include"'
+
+start_dir = 'unix'
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2016.04.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2016.04.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'XZ'
+version = '5.2.2'
+
+homepage = 'http://tukaani.org/xz/'
+description = "xz: XZ utilities"
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = ['http://tukaani.org/xz/']
+
+builddependencies = [
+    ('Autotools', '20150215'),
+]
+
+dependencies = [
+    ('gettext', '0.19.8'),
+]
+
+# may become useful in non-x86 archs
+#configopts = ' --disable-assembler '
+
+sanity_check_paths = {
+    'files': ["bin/xz", "bin/lzmainfo"],
+    'dirs': []
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-goolf-1.4.10-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-goolf-1.4.10-Perl-5.16.3.eb
@@ -11,6 +11,7 @@ easyblock = 'PerlModule'
 
 name = 'YAML-Syck'
 version = '1.27'
+versionsuffix = '-Perl-%(perlver)s'
 
 homepage = 'http://search.cpan.org/perldoc?YAML%3A%3ASyck'
 description = """Fast, lightweight YAML loader and dumper.
@@ -21,21 +22,15 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 source_urls = ['http://www.cpan.org/modules/by-module/YAML']
 sources = [SOURCE_TAR_GZ]
 
-perl = 'Perl'
-perlver = '5.16.3'
-perlverextra = ''
-versionsuffix = '-%s-%s%s' % (perl, perlver, perlverextra)
-
 dependencies = [
-    (perl, perlver, perlverextra),
+    ('Perl', '5.16.3'),
 ]
 
 options = {'modulename': 'YAML::Syck'}
 
-perlmajver = perlver.split('.')[0]
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/YAML' % (perlmajver, perlver)],
+    'dirs': ['lib/perl5/site_perl/%(perlver)s/x86_64-linux-thread-multi/YAML'],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-4.1.13-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-4.1.13-Perl-5.16.3.eb
@@ -11,6 +11,7 @@ easyblock = 'PerlModule'
 
 name = 'YAML-Syck'
 version = '1.27'
+versionsuffix = '-Perl-%(perlver)s'
 
 homepage = 'http://search.cpan.org/perldoc?YAML%3A%3ASyck'
 description = """Fast, lightweight YAML loader and dumper.
@@ -21,21 +22,15 @@ toolchain = {'name': 'ictce', 'version': '4.1.13'}
 source_urls = ['http://www.cpan.org/modules/by-module/YAML']
 sources = [SOURCE_TAR_GZ]
 
-perl = 'Perl'
-perlver = '5.16.3'
-perlverextra = ''
-versionsuffix = '-%s-%s%s' % (perl, perlver, perlverextra)
-
 dependencies = [
-    (perl, perlver, perlverextra),
+    ('Perl', '5.16.3'),
 ]
 
 options = {'modulename': 'YAML::Syck'}
 
-perlmajver = perlver.split('.')[0]
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/YAML' % (perlmajver, perlver)],
+    'dirs': ['lib/perl5/site_perl/%(perlver)s/x86_64-linux-thread-multi/YAML'],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-5.3.0-Perl-5.16.3.eb
+++ b/easybuild/easyconfigs/y/YAML-Syck/YAML-Syck-1.27-ictce-5.3.0-Perl-5.16.3.eb
@@ -11,6 +11,7 @@ easyblock = 'PerlModule'
 
 name = 'YAML-Syck'
 version = '1.27'
+versionsuffix = '-Perl-%(perlver)s'
 
 homepage = 'http://search.cpan.org/perldoc?YAML%3A%3ASyck'
 description = """Fast, lightweight YAML loader and dumper.
@@ -21,21 +22,15 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 source_urls = ['http://www.cpan.org/modules/by-module/YAML']
 sources = [SOURCE_TAR_GZ]
 
-perl = 'Perl'
-perlver = '5.16.3'
-perlverextra = ''
-versionsuffix = '-%s-%s%s' % (perl, perlver, perlverextra)
-
 dependencies = [
-    (perl, perlver, perlverextra),
+    ('Perl', '5.16.3'),
 ]
 
 options = {'modulename': 'YAML::Syck'}
 
-perlmajver = perlver.split('.')[0]
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/perl%s/site_perl/%s/x86_64-linux-thread-multi/YAML' % (perlmajver, perlver)],
+    'dirs': ['lib/perl5/site_perl/%(perlver)s/x86_64-linux-thread-multi/YAML'],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.8-GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.8-GCCcore-6.1.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'zlib'
+version = '1.2.8'
+
+homepage = 'http://www.zlib.net/'
+description = """zlib is designed to be a free, general-purpose, legally unencumbered -- that is,
+ not covered by any patents -- lossless data-compression library for use on virtually any
+ computer hardware and operating system."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.1.0'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [('http://sourceforge.net/projects/libpng/files/zlib/%(version)s', 'download')]
+
+# use same binutils version that was used when building GCC toolchain
+builddependencies = [('binutils', '2.27', '', True)]
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.8-foss-2016.04.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.8-foss-2016.04.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = 'zlib'
+version = '1.2.8'
+
+homepage = 'http://www.zlib.net/'
+description = """zlib is designed to be a free, general-purpose, legally unencumbered
+ -- that is, not covered by any patents -- lossless data-compression library for use
+ on virtually any computer hardware and operating system."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [('http://sourceforge.net/projects/libpng/files/zlib/%(version)s', 'download')]
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -44,9 +44,10 @@ import easybuild.main as main
 import easybuild.tools.options as eboptions
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.framework.easyconfig.default import DEFAULT_CONFIG
 from easybuild.framework.easyconfig.easyconfig import EasyConfig
-from easybuild.framework.easyconfig.easyconfig import get_easyblock_class
-from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconfig
+from easybuild.framework.easyconfig.easyconfig import get_easyblock_class, resolve_template
+from easybuild.framework.easyconfig.parser import EasyConfigParser, fetch_parameters_from_easyconfig
 from easybuild.framework.easyconfig.tools import dep_graph, get_paths_for, process_easyconfig
 from easybuild.tools import config
 from easybuild.tools.config import build_option
@@ -258,7 +259,8 @@ def template_easyconfig_test(self, spec):
                     self.assertTrue(os.path.isfile(ext_patch_full), msg)
 
     # check whether all extra_options defined for used easyblock are defined
-    for key in app.extra_options():
+    extra_opts = app.extra_options()
+    for key in extra_opts:
         self.assertTrue(key in app.cfg)
 
     app.close_log()
@@ -269,7 +271,7 @@ def template_easyconfig_test(self, spec):
     os.close(handle)
 
     ec.dump(test_ecfile)
-    dumped_ec = EasyConfig(test_ecfile)
+    dumped_ec = EasyConfigParser(test_ecfile).get_config_dict()
     os.remove(test_ecfile)
 
     # inject dummy values for templates that are only known at a later stage
@@ -278,16 +280,31 @@ def template_easyconfig_test(self, spec):
         'installdir': '/dummy/installdir',
     }
     ec.template_values.update(dummy_template_values)
-    dumped_ec.template_values.update(dummy_template_values)
 
-    for key in sorted(ec._config):
-        self.assertEqual(ec[key], dumped_ec[key])
+    ec_dict = ec.parser.get_config_dict()
+    keys = []
+    for key in ec_dict:
+        # skip parameters for which value is equal to default value
+        orig_val = ec_dict[key]
+        if key in DEFAULT_CONFIG and orig_val == DEFAULT_CONFIG[key][0]:
+            continue
+        if key in extra_opts and orig_val == extra_opts[key][0]:
+            continue
+        if key not in DEFAULT_CONFIG and key not in extra_opts:
+            continue
+
+        keys.append(key)
+        orig_val = resolve_template(ec_dict[key], ec.template_values)
+        dumped_val = resolve_template(dumped_ec[key], ec.template_values)
+
+        self.assertEqual(orig_val, dumped_val)
 
     # cache the parsed easyconfig, to avoid that it is parsed again
     self.parsed_easyconfigs.append(ecs[0])
 
     # test passed, so set back to True
     single_tests_ok = True and prev_single_tests_ok
+
 
 def suite():
     """Return all easyblock initialisation tests."""


### PR DESCRIPTION
Correction to #3510.

An easyconfig for Blender 2.66a using the foss 2016.04 toolchain.

@boegel  After some tinkering I found that I had some troubles using GCC 6 to build Blender, but it built okay using a toolchain that uses GCC 5 so this should be better. ~~I have named this 'Trimmed' to reflect the lesser dependencies that were needed to get it to build at a cost of reduced functionality - but those can be added in future easyconfigs when the other dependencies have easyconfigs of their own.~~