### PR TITLE
Add warning about Tk and X

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-GCC-4.9.3-2.25-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-GCC-4.9.3-2.25-bare.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3', '', ('GCCcore', '4.9.3')),
     ('ncurses', '6.0', '', ('GCCcore', '4.9.3')),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-GNU-4.9.3-2.25-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-GNU-4.9.3-2.25-bare.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015a.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.0.0a', '', ('GCC', '4.9.2')),  # required for pycrypto
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015b.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.0.0a', '', ('GNU', '4.9.3-2.25')),  # required for pycrypto
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-gimkl-2.11.5.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.4.10.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.0.0a', '', ('GCC', '4.7.2')),  # required for pycrypto
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.7.20.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.0.0a', '', ('GCC', '4.8.4')),  # required for pycrypto
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015a.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.0.0a', '', ('GCC', '4.9.2')),  # required for pycrypto
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015b.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.10.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1m'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-CrayGNU-2015.11.eb
@@ -26,7 +26,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'), 
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack 
     ('GMP', '6.1.0'),
 ]
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-CrayGNU-2016.03.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-CrayGNU-2016.03.eb
@@ -26,7 +26,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'), 
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack 
     ('GMP', '6.1.0'),
 ]
 

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-GCC-4.9.3-2.25-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-GCC-4.9.3-2.25-bare.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('libreadline', '6.3', '', ('GCCcore', '4.9.3')),
     ('ncurses', '6.0', '', ('GCCcore', '4.9.3')),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2015a.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.10.0'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),  # required for pycrypto
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2016a.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-gimkl-2.11.5.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-goolf-1.7.20.eb
@@ -21,8 +21,8 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.9.2'),
-    #('Tk', '8.6.4', '-no-X11'),
-    ('Tk', '8.6.4'),
+    #('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
+    ('Tk', '8.6.4'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
 #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
 #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2015b.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016.02-GCC-4.9.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016a.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-2.7.12-GCC-5.4.0-2.26-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.12-GCC-5.4.0-2.26-bare.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.13.0'),
-    ('Tk', '8.6.5'),
+    ('Tk', '8.6.5'),  # this requires a full X11 stack
     ('GMP', '6.1.1'),
     ('libffi', '3.2.1'),
     # OS dependency should be preferred if the os version is more recent then this version,

--- a/easybuild/easyconfigs/p/Python/Python-2.7.12-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.12-foss-2016b.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.13.0'),
-    ('Tk', '8.6.5'),
+    ('Tk', '8.6.5'),  # this requires a full X11 stack
     ('GMP', '6.1.1'),
     ('libffi', '3.2.1'),
     # OS dependency should be preferred if the os version is more recent then this version,

--- a/easybuild/easyconfigs/p/Python/Python-2.7.12-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.12-intel-2016b.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.13.0'),
-    ('Tk', '8.6.5'),
+    ('Tk', '8.6.5'),  # this requires a full X11 stack
     ('GMP', '6.1.1'),
     ('libffi', '3.2.1'),
     # OS dependency should be preferred if the os version is more recent then this version,

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-GCC-4.9.2-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-GCC-4.9.2-bare.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015.05.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015.05.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a-bare.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015b.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
 #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
 #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-gompi-1.5.16-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-gompi-1.5.16-bare.eb
@@ -17,7 +17,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.16.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.16.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
 #    ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.7.20.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a-bare.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a-bare.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.8.8.1'),
-    ('Tk', '8.6.3', '-no-X11'),
+    ('Tk', '8.6.3', '-no-X11'),  # this requires a full X11 stack
     #   ('OpenSSL', '1.0.1k'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons
 ]

--- a/easybuild/easyconfigs/p/Python/Python-3.5.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.0-intel-2015b.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     #   ('OpenSSL', '1.0.1p'),  # OS dependency should be preferred if the os version is more recent then this version, it's
     #   nice to have an up to date openssl for security reasons

--- a/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2016a.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     ('XZ', '5.2.2'),
 #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's

--- a/easybuild/easyconfigs/p/Python/Python-3.5.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.1-intel-2016a.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.9.2'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
     ('XZ', '5.2.2'),
 #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's

--- a/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016b.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.13.0'),
-    ('Tk', '8.6.5'),
+    ('Tk', '8.6.5'),  # this requires a full X11 stack
     ('GMP', '6.1.1'),
     ('XZ', '5.2.2'),
     ('libffi', '3.2.1'),

--- a/easybuild/easyconfigs/p/Python/Python-3.5.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.2-intel-2016b.eb
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '6.0'),
     ('SQLite', '3.13.0'),
-    ('Tk', '8.6.5'),
+    ('Tk', '8.6.5'),  # this requires a full X11 stack
     ('GMP', '6.1.1'),
     ('XZ', '5.2.2'),
     ('libffi', '3.2.1'),

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-GCC-4.9.2-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-GCC-4.9.2-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-foss-2015.05-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-foss-2015.05-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-foss-2015a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-foss-2015a-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-foss-2015b-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-foss-2015b-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-gompi-1.5.16-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-gompi-1.5.16-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-goolf-1.5.14-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-goolf-1.5.14-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-goolf-1.5.16-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-goolf-1.5.16-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-goolf-1.7.20-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-goolf-1.7.20-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.3-intel-2015a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.3-intel-2015a-no-X11.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-CrayGNU-2015.11-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-CrayGNU-2015.11-no-X11.eb
@@ -19,6 +19,7 @@ dependencies = [
     ('Tcl', version),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-CrayGNU-2016.03-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-CrayGNU-2016.03-no-X11.eb
@@ -19,6 +19,7 @@ dependencies = [
     ('Tcl', version),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-GCC-4.9.3-2.25-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-GCC-4.9.3-2.25-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-GNU-4.9.3-2.25-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-GNU-4.9.3-2.25-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2015a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2015a-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2015b-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2015b-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2016a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-foss-2016a-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8')
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-gimkl-2.11.5-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-gimkl-2.11.5-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-goolf-1.4.10-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-goolf-1.4.10-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-goolf-1.7.20-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-goolf-1.7.20-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-ictce-7.3.5-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-ictce-7.3.5-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2015a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2015a-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2015b-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2015b-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2016.02-GCC-4.9-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2016.02-GCC-4.9-no-X11.eb
@@ -19,6 +19,7 @@ dependencies = [
     ('Tcl', version),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2016a-no-X11.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.4-intel-2016a-no-X11.eb
@@ -20,6 +20,7 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+# To be clear: this will still require X11 to be present (see issue #2261)
 configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib --without-x CFLAGS="-I$EBROOTTCL/include"'
 
 start_dir = 'unix'


### PR DESCRIPTION
To build Tk, you need an X11 stack. All current python easyconfig need
X11 to build. Follow up in
https://github.com/hpcugent/easybuild-easyconfigs/issues/2261