### PR TITLE
{lang}[foss/2016.04] Python 3.5.2

### DIFF
--- a/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-foss-2016.04.eb
+++ b/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-foss-2016.04.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'Autoconf'
+version = '2.69'
+
+homepage = 'http://www.gnu.org/software/autoconf/'
+description = """Autoconf is an extensible package of M4 macros that produce shell scripts
+ to automatically configure software source code packages. These scripts can adapt the
+ packages to many kinds of UNIX-like systems without manual user intervention. Autoconf
+ creates a configuration script for a package from a template file that lists the
+ operating system features that the package can use, in the form of M4 macro calls."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('M4', '1.4.17')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["autoconf", "autoheader", "autom4te", "autoreconf", "autoscan",
+                                     "autoupdate", "ifnames"]],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2016.04.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-foss-2016.04.eb
@@ -1,0 +1,33 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'Automake'
+version = "1.15"
+
+homepage = 'http://www.gnu.org/software/automake/automake.html'
+description = "Automake: GNU Standards-compliant Makefile generator"
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('Autoconf', '2.69')]
+
+sanity_check_paths = {
+    'files': ['bin/automake', 'bin/aclocal'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Autotools/Autotools-20150215-foss-2016.04.eb
+++ b/easybuild/easyconfigs/a/Autotools/Autotools-20150215-foss-2016.04.eb
@@ -1,0 +1,17 @@
+easyblock = 'Bundle'
+
+name = 'Autotools'
+version = '20150215'  # date of the most recent change
+
+homepage = 'http://autotools.io'
+description = """This bundle collect the standard GNU build tools: Autoconf, Automake and libtool"""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+dependencies = [
+    ('Autoconf', '2.69'),  # 20120424
+    ('Automake', '1.15'),  # 20150105
+    ('libtool', '2.4.6'),  # 20150215
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016.04.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-foss-2016.04.eb
@@ -1,0 +1,16 @@
+name = 'bzip2'
+version = '1.0.6'
+
+homepage = 'http://www.bzip.org/'
+description = """bzip2 is a freely available, patent free, high-quality data compressor.
+ It typically compresses files to within 10% to 15% of the best available techniques (the
+ PPM family of statistical compressors), whilst being around twice as fast at compression
+ and six times faster at decompression."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.bzip.org/%(version)s']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/GMP/GMP-6.1.1-foss-2016.04.eb
+++ b/easybuild/easyconfigs/g/GMP/GMP-6.1.1-foss-2016.04.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'GMP'
+version = '6.1.1'
+
+homepage = 'http://gmplib.org/'
+description = """GMP is a free library for arbitrary precision arithmetic, 
+operating on signed integers, rational numbers, and floating point numbers. """
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True, 'precise': True}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = ['http://ftp.gnu.org/gnu/gmp']
+
+builddependencies = [
+    ('Autotools', '20150215'),
+]
+
+# enable C++ interface
+configopts = '--enable-cxx'
+
+runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['lib/libgmp.%s' % SHLIB_EXT, 'include/gmp.h'],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8-foss-2016.04.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8-foss-2016.04.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'gettext'
+version = '0.19.8'
+
+homepage = 'http://www.gnu.org/software/gettext/'
+description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
+and documentation"""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [
+    ('libxml2', '2.9.4'),
+    ('ncurses', '6.0'),
+]
+
+configopts = '--without-emacs --with-libxml2-prefix=$EBROOTLIBXML2'
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libffi/libffi-3.2.1-foss-2016.04.eb
+++ b/easybuild/easyconfigs/l/libffi/libffi-3.2.1-foss-2016.04.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'libffi'
+version = '3.2.1'
+
+homepage = 'http://sourceware.org/libffi/'
+description = """The libffi library provides a portable, high level programming interface to various calling
+conventions. This allows a programmer to call any function specified by a call interface description at run-time."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+source_urls = [
+    'ftp://sourceware.org/pub/libffi/',
+    'http://www.mirrorservice.org/sites/sourceware.org/pub/libffi/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+sanity_check_paths = {
+    'files': [('lib/libffi.%s' % SHLIB_EXT, 'lib64/libffi.%s' % SHLIB_EXT), ('lib/libffi.a', 'lib64/libffi.a')],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2016.04.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-6.3-foss-2016.04.eb
@@ -1,0 +1,32 @@
+easyblock = 'ConfigureMake'
+
+name = 'libreadline'
+version = '6.3'
+
+homepage = 'http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html'
+description = """The GNU Readline library provides a set of functions for use by applications that
+ allow users to edit command lines as they are typed in. Both Emacs and vi editing modes are available.
+ The Readline library includes additional functions to maintain a list of previously-entered command lines,
+ to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True}
+
+sources = ['readline-%(version)s.tar.gz']
+source_urls = ['http://ftp.gnu.org/gnu/readline']
+
+patches = ['libreadline-%(version)s-bugfix.patch']
+
+dependencies = [('ncurses', '6.0')]
+
+# for the termcap symbols, use EB ncurses
+preconfigopts = "env LDFLAGS='-lncurses'"
+
+sanity_check_paths = {
+    'files': ['lib/libreadline.a', 'lib/libhistory.a'] +
+    ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',
+                                         'rlstdc.h', 'rltypedefs.h', 'tilde.h']],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libtool/libtool-2.4.6-foss-2016.04.eb
+++ b/easybuild/easyconfigs/l/libtool/libtool-2.4.6-foss-2016.04.eb
@@ -1,0 +1,17 @@
+easyblock = 'ConfigureMake'
+
+name = 'libtool'
+version = '2.4.6'
+
+homepage = 'http://www.gnu.org/software/libtool'
+description = """GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries
+ behind a consistent, portable interface."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [('M4', '1.4.17')]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.4-foss-2016.04.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.4-foss-2016.04.eb
@@ -1,5 +1,3 @@
-easyblock = 'ConfigureMake'
-
 name = 'libxml2'
 version = '2.9.4'
 
@@ -17,13 +15,6 @@ source_urls = [
 ]
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = 'CC="$CC" CXX="$CXX" --with-pic --without-python --with-zlib=$EBROOTZLIB'
-
 dependencies = [('zlib', '1.2.8')]
-
-sanity_check_paths = {
-    'files': [('lib/libxml2.a', 'lib64/libxml2.a'), ('lib/libxml2.%s' % SHLIB_EXT, 'lib64/libxml2.%s' % SHLIB_EXT)],
-    'dirs': ['bin', 'include/libxml2/libxml'],
-}
 
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.4-foss-2016.04.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.4-foss-2016.04.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'libxml2'
+version = '2.9.4'
+
+homepage = 'http://xmlsoft.org/'
+description = """Libxml2 is the XML C parser and 
+toolchain developed for the Gnome project
+ (but usable outside of the Gnome platform)."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True}
+
+source_urls = [
+    'http://xmlsoft.org/sources/',
+    'http://xmlsoft.org/sources/old/'
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = 'CC="$CC" CXX="$CXX" --with-pic --without-python --with-zlib=$EBROOTZLIB'
+
+dependencies = [('zlib', '1.2.8')]
+
+sanity_check_paths = {
+    'files': [('lib/libxml2.a', 'lib64/libxml2.a'), ('lib/libxml2.%s' % SHLIB_EXT, 'lib64/libxml2.%s' % SHLIB_EXT)],
+    'dirs': ['bin', 'include/libxml2/libxml'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016.04.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016.04.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'M4'
+version = '1.4.17'
+
+homepage = 'http://www.gnu.org/software/m4/m4.html'
+description = """GNU M4 is an implementation of the traditional Unix macro processor. It is mostly SVR4 compatible
+  although it has some extensions (for example, handling more than 9 positional parameters to macros).
+ GNU M4 also has built-in functions for including files, running shell commands, doing arithmetic, etc."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+
+sanity_check_paths = {
+    'files': ["bin/m4"],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/o/OpenSSL/OpenSSL-1.0.2h-foss-2016.04.eb
+++ b/easybuild/easyconfigs/o/OpenSSL/OpenSSL-1.0.2h-foss-2016.04.eb
@@ -1,0 +1,19 @@
+name = 'OpenSSL'
+version = '1.0.2h'
+
+homepage = 'http://www.openssl.org/'
+description = """The OpenSSL Project is a collaborative effort to develop a robust, commercial-grade, full-featured,
+ and Open Source toolchain implementing the Secure Sockets Layer (SSL v2/v3) and Transport Layer Security (TLS v1) 
+ protocols as well as a full-strength general purpose cryptography library. """
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.openssl.org/source/']
+
+dependencies = [('zlib', '1.2.8')]
+
+runtest = 'test'
+
+moduleclass = 'system'

--- a/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016.04.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016.04.eb
@@ -1,0 +1,117 @@
+name = 'Python'
+version = '3.5.2'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly
+ and integrate your systems more effectively."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libreadline', '6.3'),
+    ('ncurses', '6.0'),
+    ('SQLite', '3.13.0'),
+    ('Tk', '8.6.5'),  # this requires a full X11 stack
+    ('GMP', '6.1.1'),
+    ('XZ', '5.2.2'),
+    ('libffi', '3.2.1'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    ('OpenSSL', '1.0.2h'),
+]
+
+#osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# order is important!
+# package versions updated May 28th 2015
+exts_list = [
+    ('setuptools', '23.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+    }),
+    ('pip', '8.1.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    ('numpy', '1.11.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy'],
+        'patches': ['numpy-1.8.0-mkl.patch'],
+    }),
+    ('scipy', '0.17.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+    }),
+    ('mpi4py', '1.3.1', {
+        'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+    }),
+    ('paycheck', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+    }),
+    ('pbr', '1.10.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
+    ('lockfile', '0.12.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+    }),
+    ('Cython', '0.24', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+    }),
+    ('six', '1.10.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+    }),
+    ('dateutil', '2.5.3', {
+        'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+    }),
+    ('deap', '1.0.2', {
+        'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+    }),
+    ('decorator', '4.0.10', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+    }),
+    ('arff', '2.1.0', {
+        'source_tmpl': 'liac-%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+    }),
+    ('cryptography', '1.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
+    }),
+    ('paramiko', '2.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+    }),
+    ('pyparsing', '2.1.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+    }),
+    ('netifaces', '0.10.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+    }),
+    ('netaddr', '0.7.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('pandas', '0.18.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+    }),
+    ('virtualenv', '15.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016.04.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016.04.eb
@@ -24,10 +24,10 @@ dependencies = [
     ('libffi', '3.2.1'),
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
-    ('OpenSSL', '1.0.2h'),
+    #('OpenSSL', '1.0.2h'),
 ]
 
-#osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
 # package versions updated May 28th 2015

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-foss-2016.04.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.13.0-foss-2016.04.eb
@@ -1,0 +1,40 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'SQLite'
+version = '3.13.0'
+
+homepage = 'http://www.sqlite.org/'
+description = 'SQLite: SQL Database Engine in a C Library'
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+source_urls = ['http://www.sqlite.org/2016/']
+version_minor_etc = version.split('.')[1:]
+version_minor_etc += '0' * (3 - len(version_minor_etc))
+version_str = '%(version_major)s' + ''.join('%02d' % int(x) for x in version_minor_etc)
+sources = ['sqlite-autoconf-%s.tar.gz' % version_str]
+
+dependencies = [
+    ('libreadline', '6.3'),
+    ('Tcl', '8.6.5'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/sqlite3', 'include/sqlite3ext.h', 'include/sqlite3.h', 'lib/libsqlite3.a',
+              'lib/libsqlite3.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-foss-2016.04.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.5-foss-2016.04.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'Tcl'
+version = '8.6.5'
+
+homepage = 'http://www.tcl.tk/'
+description = """Tcl (Tool Command Language) is a very powerful but easy to learn dynamic programming language,
+suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+source_urls = ["http://prdownloads.sourceforge.net/tcl"]
+sources = ['%(namelower)s%(version)s-src.tar.gz']
+
+dependencies = [
+    ('zlib', '1.2.8'),
+]
+
+configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
+
+runtest = 'test'
+
+start_dir = 'unix'
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.5-foss-2016.04.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.5-foss-2016.04.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'Tk'
+version = '8.6.5'
+
+homepage = 'http://www.tcl.tk/'
+description = """Tk is an open source, cross-platform widget toolchain that provides a library of basic elements for
+ building a graphical user interface (GUI) in many different programming languages."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+source_urls = ["http://prdownloads.sourceforge.net/tcl"]
+sources = ['%(namelower)s%(version)s-src.tar.gz']
+
+patches = ['Tk-8.6.4_different-prefix-with-tcl.patch']
+
+dependencies = [
+    ('Tcl', version),
+    ('zlib', '1.2.8'),
+]
+
+configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib CFLAGS="-I$EBROOTTCL/include"'
+
+start_dir = 'unix'
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2016.04.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2016.04.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'XZ'
+version = '5.2.2'
+
+homepage = 'http://tukaani.org/xz/'
+description = "xz: XZ utilities"
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = ['http://tukaani.org/xz/']
+
+builddependencies = [
+    ('Autotools', '20150215'),
+]
+
+dependencies = [
+    ('gettext', '0.19.8'),
+]
+
+# may become useful in non-x86 archs
+#configopts = ' --disable-assembler '
+
+sanity_check_paths = {
+    'files': ["bin/xz", "bin/lzmainfo"],
+    'dirs': []
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.8-foss-2016.04.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.8-foss-2016.04.eb
@@ -15,7 +15,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [('http://sourceforge.net/projects/libpng/files/zlib/%(version)s', 'download')]
 
 sanity_check_paths = {
-    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.so'],
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.%s' % SHLIB_EXT],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.8-foss-2016.04.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.8-foss-2016.04.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = 'zlib'
+version = '1.2.8'
+
+homepage = 'http://www.zlib.net/'
+description = """zlib is designed to be a free, general-purpose, legally unencumbered
+ -- that is, not covered by any patents -- lossless data-compression library for use
+ on virtually any computer hardware and operating system."""
+
+toolchain = {'name': 'foss', 'version': '2016.04'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [('http://sourceforge.net/projects/libpng/files/zlib/%(version)s', 'download')]
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.so'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
An easyconfig for Python 3.5.2 as well as its (many) dependencies. The reason for foss 2016.04 is because this Python is needed for Blender 2.66a (#3518) and I used a foss toolchain that is similar to 2016.04 in order to build Blender.