### PR TITLE
{toolchain} foss 2016.09

### DIFF
--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.5-gompi-2016.09.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.5-gompi-2016.09.eb
@@ -8,7 +8,7 @@ description = """FFTW is a C subroutine library for computing the discrete Fouri
  in one or more dimensions, of arbitrary input size, and of both real and complex data."""
 
 toolchain = {'name': 'gompi', 'version': '2016.09'}
-toolchainopts = {'optarch': True, 'pic': True}
+toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.5-gompi-2016.09.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.5-gompi-2016.09.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'FFTW'
+version = '3.3.5'
+
+homepage = 'http://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+ in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'gompi', 'version': '2016.09'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [homepage]
+
+common_configopts = "--enable-threads --enable-openmp --with-pic"
+
+configopts = [
+    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    common_configopts + " --enable-long-double --enable-mpi",
+    common_configopts + " --enable-quad-precision",
+    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+]
+
+sanity_check_paths = {
+    'files': ['bin/fftw%s' % x for x in ['-wisdom', '-wisdom-to-conf', 'f-wisdom', 'l-wisdom', 'q-wisdom']] +
+             ['include/fftw3%s' % x for x in ['-mpi.f03', '-mpi.h', '.f', '.f03',
+                                              '.h', 'l-mpi.f03', 'l.f03', 'q.f03']] +
+             ['lib/libfftw3%s%s.a' % (x, y) for x in ['', 'f', 'l'] for y in ['', '_mpi', '_omp', '_threads']] +
+             ['lib/libfftw3q.a', 'lib/libfftw3q_omp.a'],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/f/foss/foss-2016.09.eb
+++ b/easybuild/easyconfigs/f/foss/foss-2016.09.eb
@@ -1,0 +1,35 @@
+easyblock = 'Toolchain'
+
+name = 'foss'
+version = '2016.09'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain, including
+ OpenMPI for MPI support, OpenBLAS (BLAS and LAPACK support), FFTW and ScaLAPACK."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+gccver = '6.2.0-2.27'
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.19'
+blas = '%s-%s' % (blaslib, blasver)
+blassuff = '-LAPACK-3.6.1'
+
+# toolchain used to build foss dependencies
+comp_mpi_tc_name = 'gompi'
+comp_mpi_tc = (comp_mpi_tc_name, version)
+
+# compiler toolchain depencies
+# we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
+# because of toolchain preperation functions
+# For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
+dependencies = [
+    ('GCC', gccver),
+    ('OpenMPI', '2.0.1', '', ('GCC', gccver)),
+    (blaslib, blasver, blassuff, comp_mpi_tc),
+    ('FFTW', '3.3.5', '', comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blassuff), comp_mpi_tc)
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompi/gompi-2016.09.eb
+++ b/easybuild/easyconfigs/g/gompi/gompi-2016.09.eb
@@ -1,0 +1,20 @@
+easyblock = "Toolchain" 
+
+name = 'gompi' 
+version = '2016.09' 
+ 
+homepage = '(none)' 
+description = """GNU Compiler Collection (GCC) based compiler toolchain, 
+including OpenMPI for MPI support.""" 
+ 
+toolchain = {'name': 'dummy', 'version': 'dummy'} 
+ 
+gccver = '6.2.0-2.27' 
+ 
+# compiler toolchain dependencies 
+dependencies = [ 
+   ('GCC', gccver),  # includes both GCC and binutils 
+   ('OpenMPI', '2.0.1', '', ('GCC', gccver)), 
+] 
+ 
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/h/HPL/HPL-2.2-foss-2016.09.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.2-foss-2016.09.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.2'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'foss', 'version': '2016.09'}
+toolchainopts = {'optarch': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/HPL/HPL-2.2-foss-2016.09.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.2-foss-2016.09.eb
@@ -7,7 +7,7 @@ description = """HPL is a software package that solves a (random) dense linear s
  High Performance Computing Linpack Benchmark."""
 
 toolchain = {'name': 'foss', 'version': '2016.09'}
-toolchainopts = {'optarch': True, 'usempi': True}
+toolchainopts = {'usempi': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']

--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.4-GCC-6.2.0-2.27.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.4-GCC-6.2.0-2.27.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake' 
+ 
+name = 'hwloc' 
+version = '1.11.4' 
+ 
+homepage = 'http://www.open-mpi.org/projects/hwloc/' 
+description = """The Portable Hardware Locality (hwloc) software package provides a portable abstraction 
+(across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including 
+NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading. It also gathers various 
+system attributes such as cache and memory information as well as the locality of I/O devices such as 
+network interfaces, InfiniBand HCAs or GPUs. It primarily aims at helping applications with gathering 
+information about modern computing hardware so as to exploit it accordingly and efficiently.""" 
+ 
+toolchain = {'name': 'GCC', 'version': '6.2.0-2.27'} 
+ 
+source_urls = ['http://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/'] 
+sources = [SOURCE_TAR_GZ] 
+ 
+dependencies = [('numactl', '2.0.11')] 
+ 
+configopts = "--enable-libnuma=$EBROOTNUMACTL" 
+ 
+moduleclass = 'system'

--- a/easybuild/easyconfigs/n/numactl/numactl-2.0.11-GCC-6.2.0-2.27.eb
+++ b/easybuild/easyconfigs/n/numactl/numactl-2.0.11-GCC-6.2.0-2.27.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake' 
+ 
+name = 'numactl' 
+version = '2.0.11' 
+ 
+homepage = 'http://oss.sgi.com/projects/libnuma/' 
+description = """The numactl program allows you to run your application program on specific cpu's and memory nodes. 
+It does this by supplying a NUMA memory policy to the operating system before running your program. 
+The libnuma library provides convenient ways for you to add NUMA memory policies into your own program.""" 
+ 
+toolchain = {'name': 'GCC', 'version': '6.2.0-2.27'}
+
+source_urls = ['ftp://oss.sgi.com/www/projects/libnuma/download/'] 
+sources = [SOURCE_TAR_GZ] 
+ 
+checksums = ['d3bc88b7ddb9f06d60898f4816ae9127'] 
+ 
+sanity_check_paths = { 
+    'files': ['bin/numactl', 'bin/numastat', 'lib/libnuma.%s' % SHLIB_EXT, 'lib/libnuma.a'], 
+    'dirs': ['share/man', 'include'] 
+} 
+ 
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
@@ -1,0 +1,49 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenBLAS'
+version = '0.2.19'
+
+lapackver = '3.6.1'
+versionsuffix = '-LAPACK-%s' % lapackver
+
+homepage = 'http://xianyi.github.com/OpenBLAS/'
+description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
+
+toolchain = {'name': 'gompi', 'version': '2016.09'}
+
+lapack_src = 'lapack-%s.tgz' % lapackver
+large_src = 'large.tgz'
+timing_src = 'timing.tgz'
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
+source_urls = [
+    # order matters, trying to download the LAPACK tarball from GitHub causes trouble
+    "http://www.netlib.org/lapack/",
+    "http://www.netlib.org/lapack/timing/",
+    "https://github.com/xianyi/OpenBLAS/archive/",
+]
+
+patches = [
+    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    (large_src, '.'),
+    (timing_src, '.'),
+]
+
+skipsteps = ['configure']
+
+threading = 'USE_THREAD=1'
+buildopts = 'BINARY=64 ' + threading + ' CC="$CC" FC="$F77"'
+installopts = threading + " PREFIX=%(installdir)s"
+
+sanity_check_paths = {
+    'files': ['include/cblas.h', 'include/f77blas.h', 'include/lapacke_config.h', 'include/lapacke.h',
+              'include/lapacke_mangling.h', 'include/lapacke_utils.h', 'include/openblas_config.h',
+              'lib/libopenblas.a', 'lib/libopenblas.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
@@ -27,7 +27,7 @@ sanity_check_paths = {
     'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
              ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
              ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
-    'dirs': ["include/openmpi/ompi/mpi/c"],
+    'dirs': [],
 }
 
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
@@ -1,0 +1,42 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '2.0.1'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'GCC', 'version': '6.2.0-2.27'}
+
+sources = [SOURCELOWER_TAR_GZ]
+
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads',]
+
+dependencies = [('hwloc', '1.11.4')]
+
+configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--with-tm=/usr/local/packages/adaptive/torque ' # we want torque support as well
+
+# Add in support for hardware from Mellanox OFED
+configopts += '--with-mxm=/opt/mellanox/mxm '
+configopts += '--with-fca=/opt/mellanox/fca '
+#configopts += '--with-hcoll=/opt/mellanox/hcoll '
+configopts += '--with-knem=/opt/knem-1.1.2.90mlnx1 ' # knem comes from Mellanox OFED
+configopts += '--with-platform=contrib/platform/mellanox/optimized '
+
+# needed for --with-verbs
+osdependencies = [('libibverbs-dev', 'libibverbs-devel'), ('libpciaccess-devel'), ('libudev-devel', 'systemd-devel'),]
+
+libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': ["include/openmpi/ompi/mpi/c"],
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
@@ -18,20 +18,11 @@ configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple 
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
-configopts += '--with-tm=/usr/local/packages/adaptive/torque ' # we want torque support as well
-
-# Add in support for hardware from Mellanox OFED
-configopts += '--with-mxm=/opt/mellanox/mxm '
-configopts += '--with-fca=/opt/mellanox/fca '
-#configopts += '--with-hcoll=/opt/mellanox/hcoll '
-configopts += '--with-knem=/opt/knem-1.1.2.90mlnx1 ' # knem comes from Mellanox OFED
-configopts += '--with-platform=contrib/platform/mellanox/optimized '
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel'), ('libpciaccess-devel'), ('libudev-devel', 'systemd-devel'),]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel'),]
 
 libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
-
 sanity_check_paths = {
     'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
              ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.09-OpenBLAS-0.2.19-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2016.09-OpenBLAS-0.2.19-LAPACK-3.6.1.eb
@@ -1,0 +1,25 @@
+name = 'ScaLAPACK'
+version = '2.0.2'
+
+homepage = 'http://www.netlib.org/scalapack/'
+description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
+ redesigned for distributed memory MIMD parallel computers."""
+
+toolchain = {'name': 'gompi', 'version': '2016.09'}
+toolchainopts = {'pic': True}
+
+source_urls = [homepage]
+sources = [SOURCELOWER_TGZ]
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.19'
+blassuff = '-LAPACK-3.6.1'
+
+versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+
+dependencies = [(blaslib, blasver, blassuff)]
+
+# parallel build tends to fail, so disabling it
+parallel = 1
+
+moduleclass = 'numlib'


### PR DESCRIPTION
An experimental toolchain for foss. This toolchain uses:

- GCC 6.2.0-2.27 (already in the repo)
- Open MPI 2.0.1 (which forms gompi 2016.09 with GCC)
- OpenBLAS 0.2.19
- FFTW 3.3.5 
- ScaLAPACK 2.0.2

There is also an easyconfig for HPL 2.2 with this toolchain, as a test.

Hopefully, this combination works out okay as it has not been thoroughly tested (I'm hoping many people using it can find problems faster).