### PR TITLE
Version of ATK built using the foss 2016a toolchain.

### DIFF
--- a/easybuild/easyconfigs/a/ATK/ATK-2.20.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/a/ATK/ATK-2.20.0-foss-2016a.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'ATK'
+version = '2.20.0'
+
+homepage = 'https://developer.gnome.org/ATK/stable/'
+description = """
+ ATK provides the set of accessibility interfaces that are implemented by other
+ toolkits and applications. Using the ATK interfaces, accessibility tools have
+ full access to view and control running applications.
+"""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+
+dependencies = [
+    ('GLib', '2.48.0'),
+    ('GObject-Introspection', '1.48.0')
+]
+
+configopts = "--enable-introspection=yes"
+
+modextrapaths = {
+    'XDG_DATA_DIRS': 'share',
+}
+
+sanity_check_paths = {
+    'files': ['lib/libatk-1.0.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
Version of ATK built using the foss 2016a toolchain. This one is similar to the intel 2016a version.