### PR TITLE
libjpeg-turbo foss 2016a with nasm dependency

### DIFF
--- a/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.4.2-foss-2016a-NASM-2.12.01.eb
+++ b/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.4.2-foss-2016a-NASM-2.12.01.eb
@@ -1,0 +1,33 @@
+easyblock = 'ConfigureMake'
+
+name = 'libjpeg-turbo'
+version = '1.4.2'
+
+homepage = 'http://sourceforge.net/projects/libjpeg-turbo/'
+description = """libjpeg-turbo is a fork of the original IJG libjpeg which uses SIMD to accelerate baseline JPEG
+compression and decompression. libjpeg is a library that implements JPEG image encoding, decoding and transcoding.
+"""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+nasmver = '2.12.01'
+versionsuffix = '-NASM-%s' % nasmver
+
+dependencies = [
+    ('NASM', nasmver),
+]
+
+configopts = "--with-jpeg8"
+runtest = "test"
+
+sanity_check_paths = {
+    'files': ['bin/cjpeg', 'bin/djpeg', 'bin/jpegtran', 'bin/rdjpgcom', 'bin/tjbench', 'bin/wrjpgcom',
+              'lib/libjpeg.a', 'lib/libjpeg.%s' % SHLIB_EXT, 'lib/libturbojpeg.a', 'lib/libturbojpeg.%s' % SHLIB_EXT],
+    'dirs': ['include', 'share'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
This is a foss 2016a version of the existing intel 2016a one. It is required for later pull requests, e.g. Gdk-Pixbuf, which will keep foss 2016a better in line with existing intel 2016a versions.