### PR TITLE
Gdk-Pixbuf using the foss 2016a toolchain.

### DIFF
--- a/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.35.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/Gdk-Pixbuf/Gdk-Pixbuf-2.35.1-foss-2016a.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'Gdk-Pixbuf'
+version = '2.35.1'
+
+homepage = 'https://developer.gnome.org/gdk-pixbuf/stable/'
+description = """
+ The Gdk Pixbuf is a toolkit for image loading and pixel buffer manipulation.
+ It is used by GTK+ 2 and GTK+ 3 to load and manipulate images. In the past it
+ was distributed as part of GTK+ 2 but it was split off into a separate package
+ in preparation for the change to GTK+ 3.
+"""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+
+dependencies = [
+    ('GLib', '2.48.0'),
+    ('libjpeg-turbo', '1.4.2', '-NASM-2.12.01'),
+    ('libpng', '1.6.21'),
+    ('LibTIFF', '4.0.6'),
+    ('GObject-Introspection', '1.48.0')
+]
+
+configopts = "--disable-maintainer-mode --enable-debug=no --enable-introspection=yes "
+configopts += "--disable-Bsymbolic --without-gdiplus --enable-shared --enable-static"
+
+modextrapaths = {
+    'XDG_DATA_DIRS': 'share',
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
Adaptation of Gdk-Pixbuf for the intel 2016a toolchain for foss 2016a.