### PR TITLE
Added bzip2 and libxcb dependencies to FFmpeg 3.x easyconfigs

### DIFF
--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-0.10.16-intel-2016a.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-0.10.16-intel-2016a.eb
@@ -16,7 +16,9 @@ source_urls = ['http://ffmpeg.org/releases/']
 dependencies = [
     ('NASM', '2.11.08'),
     ('zlib', '1.2.8'),
+    ('bzip2', '1.0.6'),
     ('x264', '20160114'),
+    ('libxcb', '1.11.1'),
 ]
 
 configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '
@@ -25,7 +27,7 @@ configopts += '--enable-libx264'
 sanity_check_paths = {
     'files': ['bin/ff%s' % x for x in ['mpeg', 'probe', 'server']] +
              ['lib/lib%s.%s' % (x, y) for x in ['avdevice', 'avfilter', 'avformat', 'avcodec', 'postproc',
-                                                'swresample', 'swscale', 'avutil'] for y in ['so', 'a']],
+                                                'swresample', 'swscale', 'avutil'] for y in [SHLIB_EXT, 'a']],
     'dirs': ['include']
 }
 

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-2.8.6-intel-2016a.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-2.8.6-intel-2016a.eb
@@ -14,7 +14,9 @@ source_urls = ['http://ffmpeg.org/releases/']
 dependencies = [
     ('NASM', '2.11.08'),
     ('zlib', '1.2.8'),
+    ('bzip2', '1.0.6'),
     ('x264', '20160114'),
+    ('libxcb', '1.11.1'),
 ]
 
 configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '
@@ -23,7 +25,7 @@ configopts += '--enable-libx264'
 sanity_check_paths = {
     'files': ['bin/ff%s' % x for x in ['mpeg', 'probe', 'server']] +
              ['lib/lib%s.%s' % (x, y) for x in ['avdevice', 'avfilter', 'avformat', 'avcodec', 'postproc',
-                                                'swresample', 'swscale', 'avutil'] for y in ['so', 'a']],
+                                                'swresample', 'swscale', 'avutil'] for y in [SHLIB_EXT, 'a']],
     'dirs': ['include']
 }
 

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-2.8.7-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-2.8.7-foss-2016a.eb
@@ -14,7 +14,9 @@ source_urls = ['http://ffmpeg.org/releases/']
 dependencies = [
     ('NASM', '2.12.01'),
     ('zlib', '1.2.8'),
+    ('bzip2', '1.0.6'),
     ('x264', '20160430'),
+    ('libxcb', '1.11.1'),
 ]
 
 configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-2.8.7-intel-2016a.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-2.8.7-intel-2016a.eb
@@ -14,7 +14,9 @@ source_urls = ['http://ffmpeg.org/releases/']
 dependencies = [
     ('NASM', '2.12.01'),
     ('zlib', '1.2.8'),
+    ('bzip2', '1.0.6'),
     ('x264', '20160430'),
+    ('libxcb', '1.11.1'),
 ]
 
 configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '
@@ -23,7 +25,7 @@ configopts += '--enable-libx264'
 sanity_check_paths = {
     'files': ['bin/ff%s' % x for x in ['mpeg', 'probe', 'server']] +
              ['lib/lib%s.%s' % (x, y) for x in ['avdevice', 'avfilter', 'avformat', 'avcodec', 'postproc',
-                                                'swresample', 'swscale', 'avutil'] for y in ['so', 'a']],
+                                                'swresample', 'swscale', 'avutil'] for y in [SHLIB_EXT, 'a']],
     'dirs': ['include']
 }
 

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.0.2-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.0.2-foss-2016a.eb
@@ -14,7 +14,9 @@ source_urls = ['http://ffmpeg.org/releases/']
 dependencies = [
     ('NASM', '2.12.01'),
     ('zlib', '1.2.8'),
+    ('bzip2', '1.0.6'),
     ('x264', '20160430'),
+    ('libxcb', '1.11.1'),
 ]
 
 configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.0.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.0.2-intel-2016a.eb
@@ -14,7 +14,9 @@ source_urls = ['http://ffmpeg.org/releases/']
 dependencies = [
     ('NASM', '2.12.01'),
     ('zlib', '1.2.8'),
+    ('bzip2', '1.0.6'),
     ('x264', '20160430'),
+    ('libxcb', '1.11.1'),
 ]
 
 configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.0.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.0.2-intel-2016a.eb
@@ -25,7 +25,7 @@ configopts += '--enable-libx264'
 sanity_check_paths = {
     'files': ['bin/ff%s' % x for x in ['mpeg', 'probe', 'server']] +
              ['lib/lib%s.%s' % (x, y) for x in ['avdevice', 'avfilter', 'avformat', 'avcodec', 'postproc',
-                                                'swresample', 'swscale', 'avutil'] for y in ['so', 'a']],
+                                                'swresample', 'swscale', 'avutil'] for y in [SHLIB_EXT, 'a']],
     'dirs': ['include']
 }
 

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.1.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.1.3-intel-2016b.eb
@@ -25,7 +25,7 @@ configopts += '--enable-libx264'
 sanity_check_paths = {
     'files': ['bin/ff%s' % x for x in ['mpeg', 'probe', 'server']] +
              ['lib/lib%s.%s' % (x, y) for x in ['avdevice', 'avfilter', 'avformat', 'avcodec', 'postproc',
-                                                'swresample', 'swscale', 'avutil'] for y in ['so', 'a']],
+                                                'swresample', 'swscale', 'avutil'] for y in [SHLIB_EXT, 'a']],
     'dirs': ['include']
 }
 

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.1.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.1.3-intel-2016b.eb
@@ -12,7 +12,7 @@ sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://ffmpeg.org/releases/']
 
 dependencies = [
-    ('NASM', '2.12.01'),
+    ('NASM', '2.12.02'),
     ('zlib', '1.2.8'),
     ('bzip2', '1.0.6'),
     ('x264', '20160614'),

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.1.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.1.3-intel-2016b.eb
@@ -16,7 +16,7 @@ dependencies = [
     ('zlib', '1.2.8'),
     ('bzip2', '1.0.6'),
     ('x264', '20160614'),
-    (('X11', '20160819'),
+    ('X11', '20160819'),
 ]
 
 configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.1.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.1.3-intel-2016b.eb
@@ -12,9 +12,11 @@ sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://ffmpeg.org/releases/']
 
 dependencies = [
-    ('NASM', '2.12.02'),
+    ('NASM', '2.12.01'),
     ('zlib', '1.2.8'),
+    ('bzip2', '1.0.6'),
     ('x264', '20160614'),
+    ('libxcb', '1.11.1'),
 ]
 
 configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '

--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.1.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-3.1.3-intel-2016b.eb
@@ -16,7 +16,7 @@ dependencies = [
     ('zlib', '1.2.8'),
     ('bzip2', '1.0.6'),
     ('x264', '20160614'),
-    ('libxcb', '1.11.1'),
+    (('X11', '20160819'),
 ]
 
 configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '


### PR DESCRIPTION
bzip2 and libxcb are pulled in by FFmpeg if available. Since both have easyconfigs, and are pulled in by other software as well, I suggest to include these dependencies.
Also replaced 'so' with SHLIB_EXT for the intel easyconfigs.