### PR TITLE
fix python 3.5.2 compilation with all toolchains

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016.04.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016.04.eb
@@ -56,6 +56,9 @@ exts_list = [
     }),
     ('paycheck', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+        'patches': [
+            'paycheck-1.0.2_setup-open-README-utf8.patch',
+        ],
     }),
     ('pbr', '1.10.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
@@ -76,6 +79,9 @@ exts_list = [
     ('deap', '1.0.2', {
         'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+        'patches': [
+            'deap-1.0.2_setup-open-README-utf8.patch',
+        ],
     }),
     ('decorator', '4.0.10', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016b.eb
@@ -56,6 +56,9 @@ exts_list = [
     }),
     ('paycheck', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+        'patches': [
+            'paycheck-1.0.2_setup-open-README-utf8.patch',
+        ],
     }),
     ('pbr', '1.10.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
@@ -76,6 +79,9 @@ exts_list = [
     ('deap', '1.0.2', {
         'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+        'patches': [
+            'deap-1.0.2_setup-open-README-utf8.patch',
+        ],
     }),
     ('decorator', '4.0.10', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.5.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.2-intel-2016b.eb
@@ -56,6 +56,9 @@ exts_list = [
     }),
     ('paycheck', '1.0.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+        'patches': [
+            'paycheck-1.0.2_setup-open-README-utf8.patch',
+        ],
     }),
     ('pbr', '1.10.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
@@ -76,6 +79,9 @@ exts_list = [
     ('deap', '1.0.2', {
         'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
         'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+        'patches': [
+            'deap-1.0.2_setup-open-README-utf8.patch',
+        ],
     }),
     ('decorator', '4.0.10', {
         'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],


### PR DESCRIPTION
Fix the compilation of Python

Had various issues with README file, and realised the patches were not included in 3.5.2, but were for 3.5.1