### PR TITLE
stick to matplotlib 1.5.1 in scikit-learn, for compatibility with other Python modules

### DIFF
--- a/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.17.1-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/s/scikit-learn/scikit-learn-0.17.1-intel-2016b-Python-2.7.12.eb
@@ -17,7 +17,7 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [
     ('Python', '2.7.12'),
-    ('matplotlib', '1.5.2', versionsuffix),
+    ('matplotlib', '1.5.1', versionsuffix),
 ]
 
 options = {'modulename': 'sklearn'}


### PR DESCRIPTION
(follow-up for #3554)

@wpoely86 although there's an easyconfig available for matplotlib 1.5.2, it's better to stick to 1.5.1 for now since it's commonly used as a dependency