### PR TITLE
Protobuf 3.0.2

### DIFF
--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-3.0.2-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-3.0.2-foss-2016a-Python-2.7.11.eb
@@ -1,0 +1,31 @@
+easyblock = 'PythonPackage'
+
+name = 'protobuf-python'
+version = '3.0.2'
+versionsuffix= '-Python-%(version)s'
+
+homepage = 'https://github.com/google/protobuf/'
+description = """Python Protocol Buffers runtime library."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://github.com/google/protobuf/archive/v%(version)s']
+sources = [SOURCE_TAR_GZ]
+
+versionsuffix = '-Python-%(pyver)s'
+
+dependencies = [
+    ('Python', '2.7.11'),
+    ('protobuf', version)
+]
+
+start_dir = 'python'
+
+sanity_check_paths = {
+    'files': ['lib/python%(pyshortver)s/site-packages/protobuf-%(version)s-py%(pyshortver)s.egg/google/__init__.py'],
+    'dirs': ['bin'],
+}
+
+options = {'modulename': 'google.protobuf' }
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-3.0.2-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-3.0.2-foss-2016a-Python-2.7.11.eb
@@ -2,7 +2,7 @@ easyblock = 'PythonPackage'
 
 name = 'protobuf-python'
 version = '3.0.2'
-versionsuffix= '-Python-%(version)s'
+versionsuffix= '-Python-%(pyver)s'
 
 homepage = 'https://github.com/google/protobuf/'
 description = """Python Protocol Buffers runtime library."""
@@ -12,8 +12,6 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 source_urls = ['https://github.com/google/protobuf/archive/v%(version)s']
 sources = [SOURCE_TAR_GZ]
 
-versionsuffix = '-Python-%(pyver)s'
-
 dependencies = [
     ('Python', '2.7.11'),
     ('protobuf', version)
@@ -22,8 +20,8 @@ dependencies = [
 start_dir = 'python'
 
 sanity_check_paths = {
-    'files': ['lib/python%(pyshortver)s/site-packages/protobuf-%(version)s-py%(pyshortver)s.egg/google/__init__.py'],
-    'dirs': ['bin'],
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
 options = {'modulename': 'google.protobuf' }

--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-3.0.2-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-3.0.2-foss-2016a-Python-3.5.1.eb
@@ -1,0 +1,31 @@
+easyblock = 'PythonPackage'
+
+name = 'protobuf-python'
+version = '3.0.2'
+versionsuffix= '-Python-%(version)s'
+
+homepage = 'https://github.com/google/protobuf/'
+description = """Python Protocol Buffers runtime library."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://github.com/google/protobuf/archive/v%(version)s']
+sources = [SOURCE_TAR_GZ]
+
+versionsuffix = '-Python-%(pyver)s'
+
+dependencies = [
+    ('Python', '3.5.1'),
+    ('protobuf', version)
+]
+
+start_dir = 'python'
+
+sanity_check_paths = {
+    'files': ['lib/python%(pyshortver)s/site-packages/protobuf-%(version)s-py%(pyshortver)s.egg/google/__init__.py'],
+    'dirs': ['bin'],
+}
+
+options = {'modulename': 'google.protobuf' }
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/protobuf-python/protobuf-python-3.0.2-foss-2016a-Python-3.5.1.eb
+++ b/easybuild/easyconfigs/p/protobuf-python/protobuf-python-3.0.2-foss-2016a-Python-3.5.1.eb
@@ -2,7 +2,7 @@ easyblock = 'PythonPackage'
 
 name = 'protobuf-python'
 version = '3.0.2'
-versionsuffix= '-Python-%(version)s'
+versionsuffix= '-Python-%(pyver)s'
 
 homepage = 'https://github.com/google/protobuf/'
 description = """Python Protocol Buffers runtime library."""
@@ -12,8 +12,6 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 source_urls = ['https://github.com/google/protobuf/archive/v%(version)s']
 sources = [SOURCE_TAR_GZ]
 
-versionsuffix = '-Python-%(pyver)s'
-
 dependencies = [
     ('Python', '3.5.1'),
     ('protobuf', version)
@@ -22,8 +20,8 @@ dependencies = [
 start_dir = 'python'
 
 sanity_check_paths = {
-    'files': ['lib/python%(pyshortver)s/site-packages/protobuf-%(version)s-py%(pyshortver)s.egg/google/__init__.py'],
-    'dirs': ['bin'],
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
 options = {'modulename': 'google.protobuf' }

--- a/easybuild/easyconfigs/p/protobuf/protobuf-3.0.2-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/protobuf/protobuf-3.0.2-foss-2016a.eb
@@ -1,0 +1,21 @@
+easyblock = 'ConfigureMake'
+
+name = 'protobuf'
+version = '3.0.2'
+
+homepage = 'https://github.com/google/protobuf/'
+description = """Google Protocol Buffers"""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://github.com/google/protobuf/archive/v%(version)s/']
+sources = [SOURCE_TAR_GZ]
+
+preconfigopts = "./autogen.sh &&"
+
+sanity_check_paths = {
+    'files': ['bin/protoc','lib/libprotobuf.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Google protobuf 3.0.2 including the Python library. Since protobuf includes libraries that can be used by other programs using a dummy toolchain (as done for older protobuf versions) does not seem to be the right approach.
For now I've choosen the foss 2016a toolchain. Since protobuf itself is a low level compiler and library using a GCC toolchain could also be an option for the main protobuf. Please let me know if this approach is better.