### PR TITLE
enable running of tests for HPCG

### DIFF
--- a/easybuild/easyconfigs/h/HPCG/HPCG-2.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HPCG/HPCG-2.1-goolf-1.4.10.eb
@@ -11,4 +11,6 @@ toolchainopts = {'usempi': True, 'openmp': True}
 source_urls = ['https://software.sandia.gov/hpcg/downloads/']
 sources = [SOURCELOWER_TAR_GZ]
 
+runtest = True
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/h/HPCG/HPCG-2.1-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/h/HPCG/HPCG-2.1-ictce-5.5.0.eb
@@ -11,4 +11,6 @@ toolchainopts = {'usempi': True, 'openmp': True}
 source_urls = ['https://software.sandia.gov/hpcg/downloads/']
 sources = [SOURCELOWER_TAR_GZ]
 
+runtest = True
+
 moduleclass = 'math'


### PR DESCRIPTION
make sure tests for HPCG are still run after changes made to HPCG easyblock in https://github.com/hpcugent/easybuild-easyblocks/pull/993