### PR TITLE
fix buildopts in tabix easyconfigs

### DIFF
--- a/easybuild/easyconfigs/t/tabix/tabix-0.2.6-foss-2016a.eb
+++ b/easybuild/easyconfigs/t/tabix/tabix-0.2.6-foss-2016a.eb
@@ -13,7 +13,7 @@ sources = [SOURCE_TAR_BZ2]
 
 dependencies = [('zlib', '1.2.8')]
 
-buildopts = 'CFLAGS="-L$EBROOTZLIB/lib"'
+buildopts = 'CC="$CC" CFLAGS="$CFLAGS -L$EBROOTZLIB/lib"'
 
 files_to_copy = [
     (["tabix", "bgzip", "tabix.py"], "bin"),

--- a/easybuild/easyconfigs/t/tabix/tabix-0.2.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/t/tabix/tabix-0.2.6-goolf-1.4.10.eb
@@ -19,7 +19,7 @@ sources = [SOURCE_TAR_BZ2]
 
 dependencies = [('zlib', '1.2.8')]
 
-buildopts = 'CFLAGS="-L$EBROOTZLIB/lib"'
+buildopts = 'CC="$CC" CFLAGS="$CFLAGS -L$EBROOTZLIB/lib"'
 
 files_to_copy = [
     (["tabix", "bgzip", "tabix.py"], "bin"),

--- a/easybuild/easyconfigs/t/tabix/tabix-0.2.6-intel-2014b.eb
+++ b/easybuild/easyconfigs/t/tabix/tabix-0.2.6-intel-2014b.eb
@@ -19,7 +19,7 @@ sources = [SOURCE_TAR_BZ2]
 
 dependencies = [('zlib', '1.2.8')]
 
-buildopts = 'CFLAGS="-L$EBROOTZLIB/lib"'
+buildopts = 'CC="$CC" CFLAGS="$CFLAGS -L$EBROOTZLIB/lib"'
 
 files_to_copy = [
     (["tabix", "bgzip", "tabix.py"], "bin"),


### PR DESCRIPTION
not specifying `CC` results in using hardcoded `gcc`, and we shouldn't be overriding `CFLAGS` without taking `$CFLAGS` into account