### PR TITLE
added M4 as builddependency of flex 2.6.0

### DIFF
--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCC-4.9.2.eb
@@ -11,6 +11,9 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [('Bison', '3.0.4')]
+dependencies = [
+	('Bison', '3.0.4'),
+	('M4','1.4.17')
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-4.9.3.eb
@@ -11,7 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [('Bison', '3.0.4')]
+dependencies = [
+	('Bison', '3.0.4'),
+	('M4','1.4.17')
+]
 
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-5.3.0.eb
@@ -11,7 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [('Bison', '3.0.4')]
+dependencies = [
+	('Bison', '3.0.4'),
+	('M4','1.4.17')
+]
 
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.26', '', True)]

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-5.4.0.eb
@@ -11,7 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [('Bison', '3.0.4')]
+dependencies = [
+	('Bison', '3.0.4'),
+	('M4','1.4.17')
+]
 
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.26', '', True)]

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-foss-2015a.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-foss-2015a.eb
@@ -11,6 +11,9 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [('Bison', '3.0.4')]
+dependencies = [
+	('Bison', '3.0.4'),
+	('M4','1.4.17')
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-foss-2016a.eb
@@ -11,6 +11,9 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [('Bison', '3.0.4')]
+dependencies = [
+	('Bison', '3.0.4'),
+	('M4','1.4.17')
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-foss-2016b.eb
@@ -11,6 +11,9 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [('Bison', '3.0.4')]
+dependencies = [
+	('Bison', '3.0.4'),
+	('M4','1.4.17')
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-gimkl-2.11.5.eb
@@ -11,6 +11,9 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [('Bison', '3.0.4')]
+dependencies = [
+	('Bison', '3.0.4'),
+	('M4','1.4.17')
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-intel-2015b.eb
@@ -11,6 +11,9 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [('Bison', '3.0.4')]
+dependencies = [
+	('Bison', '3.0.4'),
+	('M4','1.4.17')
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-intel-2016a.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-intel-2016a.eb
@@ -11,6 +11,9 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [('Bison', '3.0.4')]
+dependencies = [
+	('Bison', '3.0.4'),
+	('M4','1.4.17')
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-intel-2016b.eb
@@ -11,6 +11,9 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [('Bison', '3.0.4')]
+dependencies = [
+	('Bison', '3.0.4'),
+	('M4','1.4.17')
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0.eb
@@ -11,6 +11,9 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [('Bison', '3.0.4')]
+dependencies = [
+	('Bison', '3.0.4'),
+	('M4','1.4.17')
+]
 
 moduleclass = 'lang'


### PR DESCRIPTION
Configure of flex/2.6.0 (dummy) failed with following error:
```
[...]
checking if g++ supports -c -o file.o... (cached) yes
checking whether the g++ linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... (cached) GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking dependency style of g++... gcc3
checking whether ln -s works... yes
checking for gawk... (cached) gawk
checking for bison... /opt/easybuild/modules/software/Bison/3.0.4/bin/bison
checking for help2man... help2man
checking for m4 that supports -P... configure: error: could not find m4 that supports -P
 (at easybuild/modules/software/EasyBuild/2.8.1/lib/python2.7/site-packages/easybuild_framework-2.8.1-py2.7.egg/easybuild/tools/run.py:397 in parse_cmd_output)
== 2016-09-20 14:22:18,954 easyblock.py:2362 WARNING build failed (first 300 chars): cmd " ./configure --prefix=/opt/easybuild/modules/software/flex/2.6.0 " exited with exitcode 1 and output:
ls: ignoring invalid width in environment variable COLUMNS: 0
ls: ignoring invalid width in environment variable COLUMNS: 0
checking build system type... x86_64-unknown-linux-gnu
checking host 
== 2016-09-20 14:22:18,954 easyblock.py:270 INFO Closing log for application name flex version 2.6.0
[...]
```
Adding m4 as dependency solved this issue.

This is identical with the following issue: https://github.com/hpcugent/easybuild-easyconfigs/issues/2384


