### PR TITLE
Qhull 2015.2 compiled using the foss 2016a toolchain.

### DIFF
--- a/easybuild/easyconfigs/q/Qhull/Qhull-2015.2-foss-2016a.eb
+++ b/easybuild/easyconfigs/q/Qhull/Qhull-2015.2-foss-2016a.eb
@@ -1,0 +1,37 @@
+easyblock = 'CMakeMake'
+
+name = 'Qhull'
+version = '2015.2'
+
+homepage = 'http://www.qhull.org'
+description = """
+Qhull computes the convex hull, Delaunay triangulation, Voronoi diagram, halfspace intersection about a point,
+furthest-site Delaunay triangulation, and furthest-site Voronoi diagram. The source code runs in 2-d, 3-d, 4-d,
+and higher dimensions. Qhull implements the Quickhull algorithm for computing the convex hull.
+"""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+# Recently changed the Unix version numbering see http://www.qhull.org/src/Changes.txt
+# and https://github.com/Homebrew/homebrew-science/issues/3353
+sources = ['%(namelower)s-%(version_major)s-src-7.%(version_minor)s.0.tgz']
+source_urls = ['http://www.qhull.org/download/']
+
+patches = [
+    'Qhull_pkgconfig.patch',
+]
+
+builddependencies = [('CMake', '3.4.3')]
+
+sanity_check_paths = {
+    'files': ['bin/qhull', 'lib/libqhull.%s' % SHLIB_EXT, 'lib/pkgconfig/qhull.pc'],
+    'dirs': [],
+}
+
+modextrapaths = {
+    'CPATH': ['qhull/include'],
+}
+
+parallel = 1
+
+moduleclass = 'math'


### PR DESCRIPTION
Qhull 2015.2 compiled using the foss 2016a toolchain. The config is based on the intel version.