### PR TITLE
correct STAMP dependency in i-cisTarget, must be 1.3

### DIFF
--- a/easybuild/easyconfigs/i/i-cisTarget/i-cisTarget-20160602-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/i/i-cisTarget/i-cisTarget-20160602-intel-2016a-Python-2.7.11.eb
@@ -41,7 +41,7 @@ dependencies = [
     ('matplotlib', '1.5.1', versionsuffix + '-freetype-2.6.3'),
     ('MySQL-python', '1.2.5', versionsuffix + '-MariaDB-10.1.14'),
     ('ImageMagick', '6.9.4-8'),
-    ('STAMP', '1.2'),
+    ('STAMP', '1.3'),
     ('Cluster-Buster', '20160106'),
     ('Kent_tools', '20130806', '-linux.x86_64', True),
 ]

--- a/easybuild/easyconfigs/s/STAMP/STAMP-1.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/s/STAMP/STAMP-1.2-intel-2016a.eb
@@ -15,7 +15,7 @@ dependencies = [('GSL', '2.1')]
 
 start_dir = 'src'
 
-cmds_map = [('.*', "$CXX $CXXFLAGS -o stamp *.cpp -lm -lgsl -lgslcblas")]
+cmds_map = [('.*', "$CXX $CXXFLAGS -o stamp *.cpp $LDFLAGS -lm -lgsl -lgslcblas")]
 
 files_to_copy = [(['stamp'], 'bin')]
 

--- a/easybuild/easyconfigs/s/STAMP/STAMP-1.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/s/STAMP/STAMP-1.3-intel-2016a.eb
@@ -1,7 +1,7 @@
 easyblock = 'CmdCp'
 
 name = 'STAMP'
-version = '1.2'
+version = '1.3'
 
 homepage = 'http://www.benoslab.pitt.edu/stamp/'
 description = """STAMP is a tool for characterizing similarities between transcription factor binding motifs"""

--- a/easybuild/easyconfigs/s/STAMP/STAMP-1.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/s/STAMP/STAMP-1.3-intel-2016a.eb
@@ -15,7 +15,7 @@ dependencies = [('GSL', '2.1')]
 
 start_dir = 'src'
 
-cmds_map = [('.*', "$CXX $CXXFLAGS -o stamp *.cpp -lm -lgsl -lgslcblas")]
+cmds_map = [('.*', "$CXX $CXXFLAGS -o stamp *.cpp $LDFLAGS -lm -lgsl -lgslcblas")]
 
 files_to_copy = [(['stamp'], 'bin')]
 


### PR DESCRIPTION
STAMP *must* be version 1.3 to ensure that a bugfix relevant to i-cisTarget is included, cfr. https://github.com/seqcode/stamp/commit/9cdb2327991d53030bebeab1a42c7bb4ad89bf10