### PR TITLE
Consistently specify to use -fgnu89-inline flag in M4 1.4.17 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.06.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'CrayGNU', 'version': '2015.06'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-CrayGNU-2015.11.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'CrayGNU', 'version': '2015.11'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.7.2.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'GCC', 'version': '4.7.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.2.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'GCC', 'version': '4.8.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.8.4.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'GCC', 'version': '4.8.4'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2-binutils-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2-binutils-2.25.eb
@@ -16,6 +16,8 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'GCC', 'version': '4.9.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-2.25.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3-binutils-2.25.eb
@@ -16,6 +16,8 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.3.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'GCC', 'version': '4.9.3'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.1.0-binutils-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.1.0-binutils-2.25.eb
@@ -16,6 +16,8 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.4.0-2.26.eb
@@ -13,7 +13,7 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
-configopts = "--enable-cxx"
+configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-5.4.0-2.26.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.2.eb
@@ -16,6 +16,8 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS='-fgnu89-inline'"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.3.eb
@@ -16,6 +16,8 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS='-fgnu89-inline'"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.4.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-4.9.4.eb
@@ -16,6 +16,8 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS='-fgnu89-inline'"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.3.0.eb
@@ -16,7 +16,7 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.26', '', True)]
 
-configopts = "--enable-cxx"
+configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.3.0.eb
@@ -16,6 +16,8 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.26', '', True)]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.4.0.eb
@@ -16,7 +16,7 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.26', '', True)]
 
-configopts = "--enable-cxx"
+configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-5.4.0.eb
@@ -16,6 +16,8 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.26', '', True)]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.1.0.eb
@@ -16,7 +16,7 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCCcore
 builddependencies = [('binutils', '2.27', '', True)]
 
-configopts = "--enable-cxx"
+configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.1.0.eb
@@ -16,6 +16,8 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCCcore
 builddependencies = [('binutils', '2.27', '', True)]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.2.0.eb
@@ -16,7 +16,7 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.27', '', True)]
 
-configopts = "--enable-cxx"
+configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GCCcore-6.2.0.eb
@@ -16,6 +16,8 @@ source_urls = [GNU_SOURCE]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.27', '', True)]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.2-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.2-2.25.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'GNU', 'version': '4.9.2-2.25'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-4.9.3-2.25.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'GNU', 'version': '4.9.3-2.25'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-5.1.0-2.25.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-GNU-5.1.0-2.25.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'GNU', 'version': '5.1.0-2.25'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2014b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2014b.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'foss', 'version': '2014b'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015a.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015b.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'foss', 'version': '2015b'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016.04.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016.04.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'foss', 'version': '2016.04'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016a.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS='-fgnu89-inline'"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2016b.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-gimkl-2.11.5.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'gimkl', 'version': '2.11.5'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-5.4.0.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'ictce', 'version': '5.4.0'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-5.5.0.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'ictce', 'version': '5.5.0'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-ictce-7.1.2.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'ictce', 'version': '7.1.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2014b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2014b.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'intel', 'version': '2014b'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2015a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2015a.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'intel', 'version': '2015a'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2015b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2015b.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'intel', 'version': '2015b'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016.02-GCC-4.9.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016a.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016a.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016b.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-2016b.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-para-2014.12.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-intel-para-2014.12.eb
@@ -13,6 +13,8 @@ toolchain = {'name': 'intel-para', 'version': '2014.12'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17.eb
@@ -15,6 +15,8 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
 configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
 
 sanity_check_paths = {


### PR DESCRIPTION
Consistent fix for #529, see also ~~#2774~~, ~~#2779~~ and ~~#2816~~.  Though I'm not entirely sure whether this is still relevant...