### PR TITLE
Update GCCcore-5.4.0.eb

### DIFF
--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-5.4.0.eb
@@ -18,6 +18,7 @@ source_urls = [
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies
+    'http://isl.gforge.inria.fr/', # original HTTP source for ISL (isl-0.15.tar.bz2) dependency
 ]
 
 sources = [


### PR DESCRIPTION
- added original source url for Integer Set Library (isl-0.15.tar.bz2)
