### PR TITLE
{lang}[GCCcore/*] flex can be built in parallel

### DIFF
--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-4.9.3.eb
@@ -19,6 +19,4 @@ dependencies = [
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]
 
-parallel = 1
-
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-4.9.4.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-4.9.4.eb
@@ -19,6 +19,4 @@ dependencies = [
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]
 
-parallel = 1
-
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-5.3.0.eb
@@ -19,6 +19,4 @@ dependencies = [
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.26', '', True)]
 
-parallel = 1
-
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-5.4.0.eb
@@ -19,6 +19,4 @@ dependencies = [
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.26', '', True)]
 
-parallel = 1
-
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-6.1.0.eb
@@ -19,6 +19,4 @@ dependencies = [
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.27', '', True)]
 
-parallel = 1
-
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-6.2.0.eb
@@ -19,6 +19,4 @@ dependencies = [
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.27', '', True)]
 
-parallel = 1
-
 moduleclass = 'lang'


### PR DESCRIPTION
This seems to be a leftover from some debugging, as the non-GCCcore versions already build in parallel.