### PR TITLE
{lang}[*] flex: Make Bison a build dependency

### DIFF
--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCC-4.9.2.eb
@@ -11,9 +11,11 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
+
+dependencies = [('M4', '1.4.17')]
+builddependencies = [('Bison', '3.0.4')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-4.9.3.eb
@@ -11,12 +11,15 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
 
-# use same binutils version that was used when building GCC toolchain
-builddependencies = [('binutils', '2.25', '', True)]
+dependencies = [('M4', '1.4.17')]
+builddependencies = [
+    ('Bison', '3.0.4'),
+    # use same binutils version that was used when building GCC toolchain
+    ('binutils', '2.25', '', True),
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-4.9.4.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-4.9.4.eb
@@ -11,12 +11,15 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
 
-# use same binutils version that was used when building GCC toolchain
-builddependencies = [('binutils', '2.25', '', True)]
+dependencies = [('M4', '1.4.17')]
+builddependencies = [
+    ('Bison', '3.0.4'),
+    # use same binutils version that was used when building GCC toolchain
+    ('binutils', '2.25', '', True),
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-5.3.0.eb
@@ -11,12 +11,15 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
 
-# use same binutils version that was used when building GCC toolchain
-builddependencies = [('binutils', '2.26', '', True)]
+dependencies = [('M4', '1.4.17')]
+builddependencies = [
+    ('Bison', '3.0.4'),
+    # use same binutils version that was used when building GCC toolchain
+    ('binutils', '2.26', '', True),
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-5.4.0.eb
@@ -11,12 +11,15 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
 
-# use same binutils version that was used when building GCC toolchain
-builddependencies = [('binutils', '2.26', '', True)]
+dependencies = [('M4', '1.4.17')]
+builddependencies = [
+    ('Bison', '3.0.4'),
+    # use same binutils version that was used when building GCC toolchain
+    ('binutils', '2.26', '', True),
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-6.1.0.eb
@@ -11,12 +11,15 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
 
-# use same binutils version that was used when building GCC toolchain
-builddependencies = [('binutils', '2.27', '', True)]
+dependencies = [('M4', '1.4.17')]
+builddependencies = [
+    ('Bison', '3.0.4'),
+    # use same binutils version that was used when building GCC toolchain
+    ('binutils', '2.27', '', True),
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCCcore-6.2.0.eb
@@ -11,12 +11,15 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
 
-# use same binutils version that was used when building GCC toolchain
-builddependencies = [('binutils', '2.27', '', True)]
+dependencies = [('M4', '1.4.17')]
+builddependencies = [
+    ('Bison', '3.0.4'),
+    # use same binutils version that was used when building GCC toolchain
+    ('binutils', '2.27', '', True),
+]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-foss-2015a.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-foss-2015a.eb
@@ -11,9 +11,11 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
+
+dependencies = [('M4', '1.4.17')]
+builddependencies = [('Bison', '3.0.4')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-foss-2016a.eb
@@ -11,9 +11,11 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
+
+dependencies = [('M4', '1.4.17')]
+builddependencies = [('Bison', '3.0.4')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-foss-2016b.eb
@@ -11,9 +11,11 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
+
+dependencies = [('M4', '1.4.17')]
+builddependencies = [('Bison', '3.0.4')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-gimkl-2.11.5.eb
@@ -11,9 +11,11 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
+
+dependencies = [('M4', '1.4.17')]
+builddependencies = [('Bison', '3.0.4')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-intel-2015b.eb
@@ -11,9 +11,11 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
+
+dependencies = [('M4', '1.4.17')]
+builddependencies = [('Bison', '3.0.4')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-intel-2016a.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-intel-2016a.eb
@@ -11,9 +11,11 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
+
+dependencies = [('M4', '1.4.17')]
+builddependencies = [('Bison', '3.0.4')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-intel-2016b.eb
@@ -11,9 +11,11 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
+
+dependencies = [('M4', '1.4.17')]
+builddependencies = [('Bison', '3.0.4')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0.eb
@@ -11,9 +11,11 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-dependencies = [
-    ('Bison', '3.0.4'),
-    ('M4', '1.4.17')
+checksums = [
+    '5724bcffed4ebe39e9b55a9be80859ec',     # flex-2.6.0.tar.gz
 ]
+
+dependencies = [('M4', '1.4.17')]
+builddependencies = [('Bison', '3.0.4')]
 
 moduleclass = 'lang'


### PR DESCRIPTION
As discussed on the mailing list a couple of weeks ago, `Bison` is not really necessary for using `flex` and can thus be specified as a build dependency.  This PR implements this change for flex 2.6.0, and also adds a checksum for the source tarball.  If this change is considered OK, I can prepare corresponding PRs for older versions of flex available in the repo.

**Note:** This change may potentially break packages that only (build-)depend on `flex` rather than depending on both `flex` and `Bison`.  However, how many packages are affected is hard to predict.

edit: ref to thread on ML: https://lists.ugent.be/wws/arc/easybuild/2016-08/msg00017.html