### PR TITLE
Add easyconfigs for GROMACS 2016.

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016-foss-2016b-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016-foss-2016b-hybrid.eb
@@ -1,14 +1,15 @@
 ##
 # This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
 #
-# Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
-# Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \
-#             George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Kenneth Hoste
+# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
+# Authors::
+# * Wiktor Jurkowski <wiktor.jurkowski@uni.lu>
+# * Fotis Georgatos <fotis.georgatos@uni.lu>
+# * George Tsouloupas <g.tsouloupas@cyi.ac.cy>
+# * Kenneth Hoste <kenneth.hoste@ugent.be>
+# * Adam Huffman <adam.huffman@crick.ac.uk>
 # License::   MIT/GPL
 # $Id$
-#
-# This work implements a part of the HPCBIOS project and is a component of the policy:
-# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-93.html
 #
 # Version 5.1.4
 # Author: Adam Huffman

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016-foss-2016b-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016-foss-2016b-hybrid.eb
@@ -1,0 +1,38 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
+# Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \
+#             George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Kenneth Hoste
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-93.html
+#
+# Version 5.1.4
+# Author: Adam Huffman
+# The Francis Crick Institute
+##
+
+name = 'GROMACS'
+version = '2016'
+versionsuffix = '-hybrid'
+
+homepage = 'http://www.gromacs.org'
+description = """GROMACS is a versatile package to perform molecular dynamics,
+ i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
+sources = [SOURCELOWER_TAR_GZ]
+
+builddependencies = [
+    ('CMake', '3.5.2'),
+    ('Boost', '1.61.0'),
+]
+
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016-foss-2016b-hybrid.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016-foss-2016b-hybrid.eb
@@ -1,7 +1,7 @@
 ##
 # This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
 #
-# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
+# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University / The Francis Crick Institute
 # Authors::
 # * Wiktor Jurkowski <wiktor.jurkowski@uni.lu>
 # * Fotis Georgatos <fotis.georgatos@uni.lu>
@@ -9,7 +9,6 @@
 # * Kenneth Hoste <kenneth.hoste@ugent.be>
 # * Adam Huffman <adam.huffman@crick.ac.uk>
 # License::   MIT/GPL
-# $Id$
 #
 # Version 5.1.4
 # Author: Adam Huffman

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016-foss-2016b-mt.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016-foss-2016b-mt.eb
@@ -1,0 +1,37 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
+# Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \
+#             George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Kenneth Hoste
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-93.html
+#
+# Version 5.1.4
+# Author: Adam Huffman
+# The Francis Crick Institute
+##
+
+name = 'GROMACS'
+version = '2016'
+versionsuffix = '-mt'
+
+homepage = 'http://www.gromacs.org'
+description = """GROMACS is a versatile package to perform molecular dynamics,
+ i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'openmp': True, 'usempi': False}
+
+source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
+sources = [SOURCELOWER_TAR_GZ]
+
+builddependencies = [
+    ('CMake', '3.5.2'),
+    ('Boost', '1.61.0'),
+]
+
+moduleclass = 'bio'


### PR DESCRIPTION
Boost is only a build dep of Gromacs.
Gromacs now contains tinyxml and thus do not depend on libxml2 any
longer.
