### PR TITLE
Create a goolfc toolchain using CUDA 8.0.44

### DIFF
--- a/easybuild/easyconfigs/c/CUDA/CUDA-8.0.44-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-8.0.44-GCC-5.4.0-2.26.eb
@@ -1,0 +1,19 @@
+name = 'CUDA'
+version = '8.0.44'
+
+homepage = 'https://developer.nvidia.com/cuda-toolkit'
+description = """CUDA (formerly Compute Unified Device Architecture) is a parallel
+ computing platform and programming model created by NVIDIA and implemented by the
+ graphics processing units (GPUs) that they produce. CUDA gives developers access
+ to the virtual instruction set and memory of the parallel computational elements in CUDA GPUs."""
+
+toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
+
+source_urls = [
+    'http://developer.download.nvidia.com/compute/cuda/%(version_major_minor)s/Prod/local_installers/',
+    'https://developer.nvidia.com/compute/cuda/%(version_major_minor)s/prod/local_installers/'
+]
+
+sources = ['%(namelower)s_%(version)s_linux-run']
+
+moduleclass = 'system'

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.5-gompic-2016.10.0.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.5-gompic-2016.10.0.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'FFTW'
+version = '3.3.5'
+
+homepage = 'http://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+ in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'gompic', 'version': '2016.10.0'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [homepage]
+
+common_configopts = "--enable-threads --enable-openmp --with-pic"
+
+configopts = [
+    common_configopts + " --enable-single --enable-sse2 --enable-avx --enable-avx2 --enable-mpi",
+    common_configopts + " --enable-long-double --enable-mpi",
+    common_configopts + " --enable-quad-precision",
+    common_configopts + " --enable-sse2 --enable-avx --enable-avx2 --enable-mpi",  # default as last
+]
+
+sanity_check_paths = {
+    'files': ['bin/fftw%s' % x for x in ['-wisdom', '-wisdom-to-conf', 'f-wisdom', 'l-wisdom', 'q-wisdom']] +
+             ['include/fftw3%s' % x for x in ['-mpi.f03', '-mpi.h', '.f', '.f03',
+                                              '.h', 'l-mpi.f03', 'l.f03', 'q.f03']] +
+             ['lib/libfftw3%s%s.a' % (x, y) for x in ['', 'f', 'l'] for y in ['', '_mpi', '_omp', '_threads']] +
+             ['lib/libfftw3q.a', 'lib/libfftw3q_omp.a'],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.5-gompic-2016.10.0.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.5-gompic-2016.10.0.eb
@@ -16,10 +16,10 @@ source_urls = [homepage]
 common_configopts = "--enable-threads --enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-avx --enable-avx2 --enable-mpi",
+    common_configopts + " --enable-single --enable-sse2 --enable-avx --enable-mpi",
     common_configopts + " --enable-long-double --enable-mpi",
     common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-avx --enable-avx2 --enable-mpi",  # default as last
+    common_configopts + " --enable-sse2 --enable-avx --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/g/gcccuda/gcccuda-2016.10.0.eb
+++ b/easybuild/easyconfigs/g/gcccuda/gcccuda-2016.10.0.eb
@@ -1,0 +1,21 @@
+easyblock = "Toolchain"
+
+name = 'gcccuda'
+version = '2016.10.0'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain, along with CUDA toolkit."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+comp_name = 'GCC'
+comp_ver = '5.4.0-2.26'
+comp = (comp_name, comp_ver)
+
+# compiler toolchain dependencies
+dependencies = [
+    comp,
+    ('CUDA', '8.0.44', '', comp),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompic/gompic-2016.10.0.eb
+++ b/easybuild/easyconfigs/g/gompic/gompic-2016.10.0.eb
@@ -1,0 +1,23 @@
+easyblock = "Toolchain"
+
+name = 'gompic'
+version = '2016.10.0'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain along with CUDA toolkit,
+ including OpenMPI for MPI support with CUDA features enabled."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+comp_name = 'GCC'
+comp_ver = '5.4.0-2.26'
+comp = (comp_name, comp_ver)
+
+# compiler toolchain dependencies
+dependencies = [
+    comp,  # part of gcccuda
+    ('CUDA', '8.0.44', '', comp),  # part of gcccuda
+    ('OpenMPI', '2.0.1', '', ('gcccuda', version)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/goolfc/goolfc-2016.10.0.eb
+++ b/easybuild/easyconfigs/g/goolfc/goolfc-2016.10.0.eb
@@ -1,0 +1,38 @@
+easyblock = "Toolchain"
+
+name = 'goolfc'
+version = '2016.10.0'
+
+homepage = '(none)'
+description = """GCC based compiler toolchain __with CUDA support__, and including
+ OpenMPI for MPI support, OpenBLAS (BLAS and LAPACK support), FFTW and ScaLAPACK."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+comp_name = 'GCC'
+comp_ver = '5.4.0-2.26'
+comp = (comp_name, comp_ver)
+
+# toolchain used to build goolfc dependencies
+comp_mpi_tc_name = 'gompic'
+comp_mpi_tc_ver = version
+comp_mpi_tc = (comp_mpi_tc_name, comp_mpi_tc_ver)
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.19'
+blassuff = '-LAPACK-3.6.1'
+blas = '-%s-%s%s' % (blaslib, blasver, blassuff)
+
+# compiler toolchain dependencies
+# we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
+# because of toolchain preperation functions
+dependencies = [
+    comp,  # part of gompic
+    ('CUDA', '8.0.44', '', comp),  # part of gompic
+    ('OpenMPI', '2.0.1', '', ('gcccuda', version)),  # part of gompic
+    (blaslib, blasver, blassuff, comp_mpi_tc),
+    ('FFTW', '3.3.5', '', comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', blas, comp_mpi_tc),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.4-gcccuda-2016.10.0.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.4-gcccuda-2016.10.0.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake' 
+ 
+name = 'hwloc' 
+version = '1.11.4' 
+ 
+homepage = 'http://www.open-mpi.org/projects/hwloc/' 
+description = """The Portable Hardware Locality (hwloc) software package provides a portable abstraction 
+(across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including 
+NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading. It also gathers various 
+system attributes such as cache and memory information as well as the locality of I/O devices such as 
+network interfaces, InfiniBand HCAs or GPUs. It primarily aims at helping applications with gathering 
+information about modern computing hardware so as to exploit it accordingly and efficiently.""" 
+ 
+toolchain = {'name': 'gcccuda', 'version': '2016.10.0'} 
+ 
+source_urls = ['http://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/'] 
+sources = [SOURCE_TAR_GZ] 
+ 
+dependencies = [('numactl', '2.0.11')] 
+ 
+configopts = "--enable-libnuma=$EBROOTNUMACTL" 
+ 
+moduleclass = 'system'

--- a/easybuild/easyconfigs/n/numactl/numactl-2.0.11-gcccuda-2016.10.0.eb
+++ b/easybuild/easyconfigs/n/numactl/numactl-2.0.11-gcccuda-2016.10.0.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'numactl'
+version = '2.0.11'
+
+homepage = 'http://oss.sgi.com/projects/libnuma/'
+description = """The numactl program allows you to run your application program on specific cpu's and memory nodes.
+ It does this by supplying a NUMA memory policy to the operating system before running your program.
+ The libnuma library provides convenient ways for you to add NUMA memory policies into your own program."""
+
+toolchain = {'name': 'gcccuda', 'version': '2016.10.0'}
+
+source_urls = ['ftp://oss.sgi.com/www/projects/libnuma/download/']
+sources = [SOURCE_TAR_GZ]
+
+checksums = ['d3bc88b7ddb9f06d60898f4816ae9127']
+
+sanity_check_paths = {
+    'files': ['bin/numactl', 'bin/numastat', 'lib/libnuma.%s' % SHLIB_EXT, 'lib/libnuma.a'],
+    'dirs': ['share/man', 'include']
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompic-2016.10.0-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompic-2016.10.0-LAPACK-3.6.1.eb
@@ -1,0 +1,49 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenBLAS'
+version = '0.2.19'
+
+lapackver = '3.6.1'
+versionsuffix = '-LAPACK-%s' % lapackver
+
+homepage = 'http://xianyi.github.com/OpenBLAS/'
+description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
+
+toolchain = {'name': 'gompic', 'version': '2016.10.0'}
+
+lapack_src = 'lapack-%s.tgz' % lapackver
+large_src = 'large.tgz'
+timing_src = 'timing.tgz'
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
+source_urls = [
+    # order matters, trying to download the LAPACK tarball from GitHub causes trouble
+    "http://www.netlib.org/lapack/",
+    "http://www.netlib.org/lapack/timing/",
+    "https://github.com/xianyi/OpenBLAS/archive/",
+]
+
+patches = [
+    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    (large_src, '.'),
+    (timing_src, '.'),
+]
+
+skipsteps = ['configure']
+
+threading = 'USE_THREAD=1'
+buildopts = 'BINARY=64 ' + threading + ' CC="$CC" FC="$F77"'
+installopts = threading + " PREFIX=%(installdir)s"
+
+sanity_check_paths = {
+    'files': ['include/cblas.h', 'include/f77blas.h', 'include/lapacke_config.h', 'include/lapacke.h',
+              'include/lapacke_mangling.h', 'include/lapacke_utils.h', 'include/openblas_config.h',
+              'lib/libopenblas.a', 'lib/libopenblas.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-gcccuda-2016.10.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-gcccuda-2016.10.0.eb
@@ -12,11 +12,6 @@ sources = [SOURCELOWER_TAR_GZ]
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads',]
 
-#patches = [
-#    'OpenMPI-%(version)s_common-cuda-lib.patch',
-#    'OpenMPI-%(version)s-vt_cupti_events.patch',
-#]
-
 dependencies = [('hwloc', '1.11.4')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-gcccuda-2016.10.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-gcccuda-2016.10.0.eb
@@ -1,0 +1,38 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '2.0.1'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'gcccuda', 'version': '2016.10.0'}
+
+sources = [SOURCELOWER_TAR_GZ]
+
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads',]
+
+#patches = [
+#    'OpenMPI-%(version)s_common-cuda-lib.patch',
+#    'OpenMPI-%(version)s-vt_cupti_events.patch',
+#]
+
+dependencies = [('hwloc', '1.11.4')]
+
+configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--with-cuda=$CUDA_HOME '             # CUDA-aware build; N.B. --disable-dlopen is incompatible
+
+# needed for --with-verbs
+osdependencies = [('libibverbs-dev', 'libibverbs-devel'),]
+
+libs = ["mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': [],
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2016.10.0-OpenBLAS-0.2.19-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2016.10.0-OpenBLAS-0.2.19-LAPACK-3.6.1.eb
@@ -1,0 +1,25 @@
+name = 'ScaLAPACK'
+version = '2.0.2'
+
+homepage = 'http://www.netlib.org/scalapack/'
+description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
+ redesigned for distributed memory MIMD parallel computers."""
+
+toolchain = {'name': 'gompic', 'version': '2016.10.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [homepage]
+sources = [SOURCELOWER_TGZ]
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.19'
+blassuff = '-LAPACK-3.6.1'
+
+versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+
+dependencies = [(blaslib, blasver, blassuff)]
+
+# parallel build tends to fail, so disabling it
+parallel = 1
+
+moduleclass = 'numlib'


### PR DESCRIPTION
 Create a goolfc toolchain using CUDA 8.0.44 and the latest versions of the dependencies.

CUDA 8.0.44
GCC 5.4.0-2.26 (Cuda still doesn't support any newer GCC compiler)
FFTW 3.3.5
OpenBLAS 0.2.19/Lapack 3.6.1
OpenMPI 2.0.1
Scalapack 2.0.2