### PR TITLE
{lang}[*] flex 2.5.39: Consistency changes

### DIFF
--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-CrayGNU-2015.06.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-CrayGNU-2015.11.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.2-binutils-2.25.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.2-binutils-2.25.eb
@@ -6,10 +6,16 @@ description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners.
  sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.2-binutils-2.25'}
+toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]
 

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.2.eb
@@ -6,8 +6,15 @@ description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners.
  sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.2'}
+toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
+
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.3-binutils-2.25.eb
@@ -6,10 +6,16 @@ description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners.
  sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.3-binutils-2.25'}
+toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]
 

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-4.9.3.eb
@@ -6,8 +6,15 @@ description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners.
  sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
 
 toolchain = {'name': 'GCC', 'version': '4.9.3'}
+toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
+
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-5.1.0-binutils-2.25.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCC-5.1.0-binutils-2.25.eb
@@ -6,10 +6,16 @@ description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners.
  sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
 
 toolchain = {'name': 'GCC', 'version': '5.1.0-binutils-2.25'}
+toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
 # use same binutils version that was used when building GCC toolchain
 builddependencies = [('binutils', '2.25', '', True)]
 

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCCcore-4.9.2.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCCcore-4.9.2.eb
@@ -6,14 +6,17 @@ description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners.
  sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
 
 toolchain = {'name': 'GCCcore', 'version': '4.9.2'}
+toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-# use same binutils version that was used when building GCCcore toolchain
-builddependencies = [
-    ('M4', '1.4.17'),
-    ('binutils', '2.25', '', True)
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
 ]
+
+dependencies = [('M4', '1.4.17')]
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.25', '', True)]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GCCcore-4.9.3.eb
@@ -6,14 +6,17 @@ description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners.
  sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
 
 toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
+toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-# use same binutils version that was used when building GCCcore toolchain
-builddependencies = [
-    ('M4', '1.4.17'),
-    ('binutils', '2.25', '', True)
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
 ]
+
+dependencies = [('M4', '1.4.17')]
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.25', '', True)]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-GNU-4.9.3-2.25.eb
@@ -6,8 +6,15 @@ description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners.
  sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
 
 toolchain = {'name': 'GNU', 'version': '4.9.3-2.25'}
+toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
+
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2014b.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2014b.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015.05.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015.05.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015a.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015a.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015b.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015b.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015b.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2015b.eb
@@ -15,6 +15,6 @@ checksums = [
     'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
 ]
 
-dependencies = [('M4', '1.4.17')]
+dependencies = [('M4', '1.4.17', '', ('GNU', '4.9.3-2.25'))]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-foss-2016a.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-gimkl-2.11.5.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-ictce-7.1.2.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-2014b.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-2014b.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-2015a.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-2015a.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-2015b.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-2015b.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-2015b.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-2015b.eb
@@ -15,6 +15,6 @@ checksums = [
     'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
 ]
 
-dependencies = [('M4', '1.4.17')]
+dependencies = [('M4', '1.4.17', '', ('GNU', '4.9.3-2.25'))]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-2016.02-GCC-4.9.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-2016a.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-2016a.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-para-2014.12.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39-intel-para-2014.12.eb
@@ -11,4 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/f/flex/flex-2.5.39.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.5.39.eb
@@ -11,6 +11,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://prdownloads.sourceforge.net/%(namelower)s']
 
-builddependencies = [('M4', '1.4.17')]
+checksums = [
+    'e133e9ead8ec0a58d81166b461244fde',     # flex-2.5.39.tar.gz
+]
+
+dependencies = [('M4', '1.4.17')]
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015.05.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.17-foss-2015.05.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'M4'
+version = '1.4.17'
+
+homepage = 'http://www.gnu.org/software/m4/m4.html'
+description = """GNU M4 is an implementation of the traditional Unix macro processor. It is mostly SVR4 compatible
+  although it has some extensions (for example, handling more than 9 positional parameters to macros).
+ GNU M4 also has built-in functions for including files, running shell commands, doing arithmetic, etc."""
+
+toolchain = {'name': 'foss', 'version': '2015.05'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/hpcugent/easybuild-easyconfigs/issues/529
+configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+
+sanity_check_paths = {
+    'files': ["bin/m4"],
+    'dirs': [],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Consistently use `pic=True` toolchain option and `M4` as a dependency in flex 2.5.39 easyconfigs.  Also add a checksum for the tarball.

**Note 1**: The 2.5.39 tarball built for me on a machine w/o `Bison` being available, thus it was not added as a build dependency (cfr. https://github.com/hpcugent/easybuild-easyconfigs/pull/3656).

**Note 2**: Running `eb -D flex-2.5.39-GNU-4.9.3-2.25.eb` for me results in `ERROR: Maximum loop cnt 10000 reached, so quitting`.  So something seems to be fishy in this configuration...
