### PR TITLE
Adding new toolchains for iomkl and iompi version 2016.09-GCC-4.9.3-2.25

### DIFF
--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.3-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.3-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,5 +1,3 @@
-# Automatically converted from hwloc-1.11.3-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
-# by /gpfs/sysapps/bham/scripts/easybuild/copy_to_toolchain.py
 easyblock = 'ConfigureMake'
 
 name = 'hwloc'

--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.3-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.3-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,0 +1,25 @@
+# Automatically converted from hwloc-1.11.3-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+# by /gpfs/sysapps/bham/scripts/easybuild/copy_to_toolchain.py
+easyblock = 'ConfigureMake'
+
+name = 'hwloc'
+version = '1.11.3'
+
+homepage = 'http://www.open-mpi.org/projects/hwloc/'
+description = """The Portable Hardware Locality (hwloc) software package provides a portable abstraction
+  (across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including
+ NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading. It also gathers various
+ system attributes such as cache and memory information as well as the locality of I/O devices such as
+ network interfaces, InfiniBand HCAs or GPUs. It primarily aims at helping applications with gathering
+ information about modern computing hardware so as to exploit it accordingly and efficiently."""
+
+toolchain = {'name': 'iccifort', 'version': '2016.3.210-GCC-4.9.3-2.25'}
+
+dependencies = [('numactl', '2.0.11')]
+
+configopts = "--enable-libnuma=$EBROOTNUMACTL"
+
+source_urls = ['http://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/']
+sources = [SOURCE_TAR_GZ]
+
+moduleclass = 'system'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iompi-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iompi-2016.09-GCC-4.9.3-2.25.eb
@@ -14,25 +14,11 @@ checksums = ['f72546df27f5ebb0941b5d21fd804e34']
 
 dontcreateinstalldir = 'True'
 
-
-# We want this in the module file. We send its output to /dev/null
-# as otherwise it conflicts with the easybuild checking.
-# It executes compilervars.sh which in turn executes several more scripts 
-# setting up the environment for icc etc.
-modtclfooter = '''
-if [module-info mode load] {
-    set chan [open /dev/null a]
-    puts $chan "echo intel64"
-    puts $chan "source $root/bin/compilervars.sh"
-}
-'''
-
-
-license_file = '/gpfs/apps/intel/LicenseManager/current/INTEL.lic'
+components = ['intel-mkl']
 
 interfaces = True
 
-moduleclass = 'numlib'
+license_file = HOME + '/licenses/intel/license.lic'
 
 postinstallcmds = [
     # extract the examples
@@ -44,5 +30,7 @@ postinstallcmds = [
 ]
 
 modextravars = {
-     'MKL_EXAMPLES' : '%(installdir)s/mkl/examples/',
+    'MKL_EXAMPLES': '%(installdir)s/mkl/examples/',
 }
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iompi-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iompi-2016.09-GCC-4.9.3-2.25.eb
@@ -1,0 +1,48 @@
+name = 'imkl'
+version = '11.3.3.210'
+
+homepage = 'http://software.intel.com/en-us/intel-mkl/'
+description = """Intel Math Kernel Library is a library of highly optimized,
+ extensively threaded math routines for science, engineering, and financial
+ applications that require maximum performance. Core math functions include
+ BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
+
+toolchain = {'name': 'iompi', 'version': '2016.09-GCC-4.9.3-2.25'}
+
+sources = ['l_mkl_%(version)s.tgz']
+checksums = ['f72546df27f5ebb0941b5d21fd804e34']
+
+dontcreateinstalldir = 'True'
+
+
+# We want this in the module file. We send its output to /dev/null
+# as otherwise it conflicts with the easybuild checking.
+# It executes compilervars.sh which in turn executes several more scripts 
+# setting up the environment for icc etc.
+modtclfooter = '''
+if [module-info mode load] {
+    set chan [open /dev/null a]
+    puts $chan "echo intel64"
+    puts $chan "source $root/bin/compilervars.sh"
+}
+'''
+
+
+license_file = '/gpfs/apps/intel/LicenseManager/current/INTEL.lic'
+
+interfaces = True
+
+moduleclass = 'numlib'
+
+postinstallcmds = [
+    # extract the examples
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_f95.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_mic.tgz -C %(installdir)s/mkl/examples/'
+]
+
+modextravars = {
+     'MKL_EXAMPLES' : '%(installdir)s/mkl/examples/',
+}

--- a/easybuild/easyconfigs/i/iomkl/iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iomkl/iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -1,0 +1,20 @@
+easyblock = "Toolchain"
+
+name = 'iomkl'
+version = '2016.09-GCC-4.9.3-2.25'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Intel Cluster Toolchain Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MKL & OpenMPI."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+compver = '2016.3.210-GCC-4.9.3-2.25'
+
+dependencies = [
+    ('icc', compver),
+    ('ifort', compver),
+    ('OpenMPI', '1.10.2', '', ('iccifort', compver)),
+    ('imkl', '11.3.3.210', '', ('iompi', version)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iomkl/iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iomkl/iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -13,7 +13,7 @@ compver = '2016.3.210-GCC-4.9.3-2.25'
 dependencies = [
     ('icc', compver),
     ('ifort', compver),
-    ('OpenMPI', '1.10.2', '', ('iccifort', compver)),
+    ('OpenMPI', '1.10.4', '', ('iccifort', compver)),
     ('imkl', '11.3.3.210', '', ('iompi', version)),
 ]
 

--- a/easybuild/easyconfigs/i/iompi/iompi-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iompi/iompi-2016.09-GCC-4.9.3-2.25.eb
@@ -11,7 +11,7 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 compver = '2016.3.210-GCC-4.9.3-2.25'
 
 dependencies = [
-    ('OpenMPI', '1.10.2', '', ('iccifort', compver)),
+    ('OpenMPI', '1.10.4', '', ('iccifort', compver)),
     ('icc', compver),
     ('ifort', compver),
 ]

--- a/easybuild/easyconfigs/i/iompi/iompi-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/iompi/iompi-2016.09-GCC-4.9.3-2.25.eb
@@ -1,0 +1,20 @@
+easyblock = "Toolchain"
+
+name = 'iompi'
+version = '2016.09-GCC-4.9.3-2.25'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Toolchain with Intel C, C++ and Fortran compilers, alongside OpenMPI."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+compver = '2016.3.210-GCC-4.9.3-2.25'
+
+dependencies = [
+    ('OpenMPI', '1.10.2', '', ('iccifort', compver)),
+    ('icc', compver),
+    ('ifort', compver),
+]
+
+moduleclass = 'toolchain'
+

--- a/easybuild/easyconfigs/n/numactl/numactl-2.0.11-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/n/numactl/numactl-2.0.11-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,5 +1,3 @@
-# Automatically converted from numactl-2.0.11-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
-# by /gpfs/sysapps/bham/scripts/easybuild/copy_to_toolchain.py
 easyblock = 'ConfigureMake'
 
 name = 'numactl'

--- a/easybuild/easyconfigs/n/numactl/numactl-2.0.11-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/n/numactl/numactl-2.0.11-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,0 +1,25 @@
+# Automatically converted from numactl-2.0.11-iccifort-2016.3.210-GCC-5.4.0-2.26.eb
+# by /gpfs/sysapps/bham/scripts/easybuild/copy_to_toolchain.py
+easyblock = 'ConfigureMake'
+
+name = 'numactl'
+version = '2.0.11'
+
+checksums = ['d3bc88b7ddb9f06d60898f4816ae9127']
+
+homepage = 'http://oss.sgi.com/projects/libnuma/'
+description = """The numactl program allows you to run your application program on specific cpu's and memory nodes.
+ It does this by supplying a NUMA memory policy to the operating system before running your program.
+ The libnuma library provides convenient ways for you to add NUMA memory policies into your own program."""
+
+toolchain = {'name': 'iccifort', 'version': '2016.3.210-GCC-4.9.3-2.25'}
+
+source_urls = ['ftp://oss.sgi.com/www/projects/libnuma/download/']
+sources = [SOURCE_TAR_GZ]
+
+sanity_check_paths = {
+    'files': ['bin/numactl', 'bin/numastat', 'lib/libnuma.%s' % SHLIB_EXT, 'lib/libnuma.a'],
+    'dirs': ['share/man', 'include']
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -9,23 +9,20 @@ description = """The Open MPI Project is an open source MPI-2 implementation."""
 toolchain = {'name': 'iccifort', 'version': '2016.3.210-GCC-4.9.3-2.25'}
 
 sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 
-source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads',]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
-configopts += '--with-hwloc=/usr/local/packages/hwloc '  # hwloc support
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
-configopts += '--with-tm=/usr/local/packages/adaptive/torque ' # we want torque support as well
 
-
-configopts += '--enable-debug '
+dependencies = [('hwloc', '1.11.3')]
 
 # needed for --with-verbs
-osdependencies = [('libibverbs-dev', 'libibverbs-devel'), ('libpciaccess-devel'), ('libudev-devel', 'systemd-devel'),]
+osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
 libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
-
 sanity_check_paths = {
     'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
              ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
@@ -33,9 +30,10 @@ sanity_check_paths = {
     'dirs': ["include/openmpi/ompi/mpi/cxx"],
 }
 
-modextravars = {
-    "MXM_LOG_LEVEL": "ERROR",
-    "MXM_LOG_FILE": "/dev/stderr",
-}
+sanity_check_commands = [
+    ('mpicc --version | grep icc', ''),
+    ('mpicxx --version | grep icpc', ''),
+    ('mpifort --version | grep ifort', ''),
+]
 
 moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,0 +1,41 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = '1.10.2'
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'iccifort', 'version': '2016.3.210-GCC-4.9.3-2.25'}
+
+sources = [SOURCELOWER_TAR_GZ]
+
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads',]
+
+configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=/usr/local/packages/hwloc '  # hwloc support
+configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
+configopts += '--with-tm=/usr/local/packages/adaptive/torque ' # we want torque support as well
+
+
+configopts += '--enable-debug '
+
+# needed for --with-verbs
+osdependencies = [('libibverbs-dev', 'libibverbs-devel'), ('libpciaccess-devel'), ('libudev-devel', 'systemd-devel'),]
+
+libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
+
+modextravars = {
+    "MXM_LOG_LEVEL": "ERROR",
+    "MXM_LOG_FILE": "/dev/stderr",
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.4-iccifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -1,7 +1,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'OpenMPI'
-version = '1.10.2'
+version = '1.10.4'
 
 homepage = 'http://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""


### PR DESCRIPTION
Updated versions of iomkl and iompi toolchains to include iccifort 2016.3.210 and GCC 4.9.3 (intended for building apps with CUDA support).