### PR TITLE
Make OpenBLAS use the designated LAPACK version.

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
@@ -31,11 +31,12 @@ patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+    'OpenBLAS-%(version)s-use-correct-lapack-version.patch',
 ]
 
 skipsteps = ['configure']
 
-buildopts = 'BINARY=64 USE_THREAD=1 CC="$CC" FC="$F77" NO_AFFINITY=1'
+buildopts = 'BINARY=64 USE_THREAD=1 CC="$CC" FC="$F77" NO_AFFINITY=1 LAPACK_VERSION=%s' % lapackver
 installopts = "USE_THREAD=1 PREFIX=%(installdir)s"
 
 # extensive testing can be enabled by uncommenting the line below

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
@@ -31,12 +31,13 @@ patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+    'OpenBLAS-%(version)s-use-correct-lapack-version.patch',
 ]
 
 skipsteps = ['configure']
 
 threading = 'USE_THREAD=1'
-buildopts = 'BINARY=64 ' + threading + ' CC="$CC" FC="$F77"'
+buildopts = 'BINARY=64 ' + threading + ' CC="$CC" FC="$F77" LAPACK_VERSION=%s' % lapackver
 installopts = threading + " PREFIX=%(installdir)s"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-use-correct-lapack-version.patch
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-use-correct-lapack-version.patch
@@ -1,0 +1,16 @@
+diff -ru OpenBLAS-0.2.18.orig/Makefile OpenBLAS-0.2.18/Makefile
+--- OpenBLAS-0.2.18.orig/Makefile	2016-04-12 21:29:19.000000000 +0200
++++ OpenBLAS-0.2.18/Makefile	2016-10-22 13:42:21.502673471 +0200
+@@ -224,6 +224,12 @@
+ 
+ lapack_prebuild :
+ ifndef NOFORTRAN
++	if [ -e lapack-$(LAPACK_VERSION).tgz ]; then \
++	    rm -rf $(NETLIB_LAPACK_DIR).old; \
++	    mv $(NETLIB_LAPACK_DIR) $(NETLIB_LAPACK_DIR).old; \
++	    $(TAR) zxf ./lapack-$(LAPACK_VERSION).tgz; \
++	    mv lapack-$(LAPACK_VERSION) $(NETLIB_LAPACK_DIR); \
++	fi
+ 	-@echo "FORTRAN     = $(FC)" > $(NETLIB_LAPACK_DIR)/make.inc
+ 	-@echo "OPTS        = $(LAPACK_FFLAGS)" >> $(NETLIB_LAPACK_DIR)/make.inc
+ 	-@echo "POPTS       = $(LAPACK_FPFLAGS)" >> $(NETLIB_LAPACK_DIR)/make.inc

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
@@ -31,12 +31,13 @@ patches = [
     (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
+    'OpenBLAS-%(version)s-use-correct-lapack-version.patch',
 ]
 
 skipsteps = ['configure']
 
 threading = 'USE_THREAD=1'
-buildopts = 'BINARY=64 ' + threading + ' CC="$CC" FC="$F77"'
+buildopts = 'BINARY=64 ' + threading + ' CC="$CC" FC="$F77" LAPACK_VERSION=%s' % lapackver
 installopts = threading + " PREFIX=%(installdir)s"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-use-correct-lapack-version.patch
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-use-correct-lapack-version.patch
@@ -1,0 +1,16 @@
+diff -ru OpenBLAS-0.2.18.orig/Makefile OpenBLAS-0.2.18/Makefile
+--- OpenBLAS-0.2.18.orig/Makefile	2016-04-12 21:29:19.000000000 +0200
++++ OpenBLAS-0.2.18/Makefile	2016-10-22 13:42:21.502673471 +0200
+@@ -224,6 +224,12 @@
+ 
+ lapack_prebuild :
+ ifndef NOFORTRAN
++	if [ -e lapack-$(LAPACK_VERSION).tgz ]; then \
++	    rm -rf $(NETLIB_LAPACK_DIR).old; \
++	    mv $(NETLIB_LAPACK_DIR) $(NETLIB_LAPACK_DIR).old; \
++	    $(TAR) zxf ./lapack-$(LAPACK_VERSION).tgz; \
++	    mv lapack-$(LAPACK_VERSION) $(NETLIB_LAPACK_DIR); \
++	fi
+ 	-@echo "FORTRAN     = $(FC)" > $(NETLIB_LAPACK_DIR)/make.inc
+ 	-@echo "OPTS        = $(LAPACK_FFLAGS)" >> $(NETLIB_LAPACK_DIR)/make.inc
+ 	-@echo "POPTS       = $(LAPACK_FPFLAGS)" >> $(NETLIB_LAPACK_DIR)/make.inc


### PR DESCRIPTION
The OpenBLAS Makefile doesn't unpack any lapack-x.y.z.tgz, it only deals
with timing.tgz and large.tgz.
To make OpenBLAS use the version of LAPACK specified in the easyconfig
we need to add a small patch to the OpenBLAS Makefile that unpacks it if
it exists.

This solves easyconfig issue# 1050.