### PR TITLE
Make OpenBLAS use the LAPACK version specified in the easyconfig.

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
@@ -3,6 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.18'
 
+obv = '%s-%s' % (name, version) # To be used in the lapack-x.y.z unpack cmd
+
 lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
@@ -16,7 +18,7 @@ large_src = 'large.tgz'
 timing_src = 'timing.tgz'
 sources = [
     'v%(version)s.tar.gz',
-    lapack_src,
+    (lapack_src, 'mv %s/lapack-netlib %s/lapack-netlib.old; mkdir %s/lapack-netlib; tar -C %s/lapack-netlib --strip-components=1 -zxf %%s' % (obv, obv, obv, obv)),
     large_src,
     timing_src,
 ]
@@ -28,7 +30,6 @@ source_urls = [
 ]
 
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1.eb
@@ -3,8 +3,6 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.18'
 
-obv = '%s-%s' % (name, version) # To be used in the lapack-x.y.z unpack cmd
-
 lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
@@ -16,9 +14,14 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
+
+lapack_unpack_cmd = 'cd %s-%s; rm -rf lapack-netlib;' % (name, version)
+lapack_unpack_cmd += 'mkdir lapack-netlib;'
+lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
+
 sources = [
     'v%(version)s.tar.gz',
-    (lapack_src, 'mv %s/lapack-netlib %s/lapack-netlib.old; mkdir %s/lapack-netlib; tar -C %s/lapack-netlib --strip-components=1 -zxf %%s' % (obv, obv, obv, obv)),
+    (lapack_src, lapack_unpack_cmd),
     large_src,
     timing_src,
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
@@ -3,6 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.18'
 
+obv = '%s-%s' % (name, version) # To be used in the lapack-x.y.z unpack cmd
+
 lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
@@ -16,7 +18,7 @@ large_src = 'large.tgz'
 timing_src = 'timing.tgz'
 sources = [
     'v%(version)s.tar.gz',
-    lapack_src,
+    (lapack_src, 'mv %s/lapack-netlib %s/lapack-netlib.old; mkdir %s/lapack-netlib; tar -C %s/lapack-netlib --strip-components=1 -zxf %%s' % (obv, obv, obv, obv)),
     large_src,
     timing_src,
 ]
@@ -28,7 +30,6 @@ source_urls = [
 ]
 
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.18-gompi-2016.07-LAPACK-3.6.1.eb
@@ -3,8 +3,6 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.18'
 
-obv = '%s-%s' % (name, version) # To be used in the lapack-x.y.z unpack cmd
-
 lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
@@ -16,9 +14,14 @@ toolchain = {'name': 'gompi', 'version': '2016.07'}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
+
+lapack_unpack_cmd = 'cd %s-%s; rm -rf lapack-netlib;' % (name, version)
+lapack_unpack_cmd += 'mkdir lapack-netlib;'
+lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
+
 sources = [
     'v%(version)s.tar.gz',
-    (lapack_src, 'mv %s/lapack-netlib %s/lapack-netlib.old; mkdir %s/lapack-netlib; tar -C %s/lapack-netlib --strip-components=1 -zxf %%s' % (obv, obv, obv, obv)),
+    (lapack_src, lapack_unpack_cmd),
     large_src,
     timing_src,
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
@@ -3,6 +3,8 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.19'
 
+obv = '%s-%s' % (name, version) # To be used in the lapack-x.y.z unpack cmd
+
 lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
@@ -16,7 +18,7 @@ large_src = 'large.tgz'
 timing_src = 'timing.tgz'
 sources = [
     'v%(version)s.tar.gz',
-    lapack_src,
+    (lapack_src, 'mv %s/lapack-netlib %s/lapack-netlib.old; mkdir %s/lapack-netlib; tar -C %s/lapack-netlib --strip-components=1 -zxf %%s' % (obv, obv, obv, obv)),
     large_src,
     timing_src,
 ]
@@ -28,7 +30,6 @@ source_urls = [
 ]
 
 patches = [
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
     (large_src, '.'),
     (timing_src, '.'),
 ]

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.2.19-gompi-2016.09-LAPACK-3.6.1.eb
@@ -3,8 +3,6 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.19'
 
-obv = '%s-%s' % (name, version) # To be used in the lapack-x.y.z unpack cmd
-
 lapackver = '3.6.1'
 versionsuffix = '-LAPACK-%s' % lapackver
 
@@ -16,9 +14,14 @@ toolchain = {'name': 'gompi', 'version': '2016.09'}
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'
+
+lapack_unpack_cmd = 'cd %s-%s; rm -rf lapack-netlib;' % (name, version)
+lapack_unpack_cmd += 'mkdir lapack-netlib;'
+lapack_unpack_cmd += 'tar -C lapack-netlib --strip-components=1 -zxf %s; cd -'
+
 sources = [
     'v%(version)s.tar.gz',
-    (lapack_src, 'mv %s/lapack-netlib %s/lapack-netlib.old; mkdir %s/lapack-netlib; tar -C %s/lapack-netlib --strip-components=1 -zxf %%s' % (obv, obv, obv, obv)),
+    (lapack_src, lapack_unpack_cmd),
     large_src,
     timing_src,
 ]


### PR DESCRIPTION
The OpenBLAS Makefile only handles large.tgz and timing.tgz and ignores
lapack-x.y.z.tgz. We need to manually unpack the lapack-x.y.z specified
in the easyconfig.

Doing it this way makes it possible to add patches on top of the
unpacked lapack version, which is neccesary to deal with various
compiler problems.

This solves easyconfig issue #1050.
