### PR TITLE
use $CC,$CXX rather than $I_MPI_CC,$I_MPI_CXX in patch for OpenFOAM 4.0

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-4.0-cleanup.patch
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-4.0-cleanup.patch
@@ -235,8 +235,8 @@ diff -ur OpenFOAM-4.0.orig/etc/config.sh/settings OpenFOAM-4.0/etc/config.sh/set
 -            export WM_CFLAGS='-m64 -fPIC'
 -            export WM_CXXFLAGS='-m64 -fPIC -std=c++0x'
 -            export WM_LDFLAGS='-m64'
-+            export WM_CC=$I_MPI_CC
-+            export WM_CXX=$I_MPI_CXX
++            export WM_CC=$CC
++            export WM_CXX=$CXX
 +            export WM_CFLAGS=$CFLAGS
 +            export WM_CXXFLAGS=$CXXFLAGS
 +            export WM_LDFLAGS=$LDFLAGS


### PR DESCRIPTION
@wpoely86 just to ensure that this patch can be reused with other (non-Intel MPI) toolchains