### PR TITLE
include Pillow as a proper dep for scikit-image rather than as extension, since it has deps itself

### DIFF
--- a/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.5.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-1.5.1-intel-2016b.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'libjpeg-turbo'
+version = '1.5.1'
+
+homepage = 'http://sourceforge.net/projects/libjpeg-turbo/'
+description = """libjpeg-turbo is a fork of the original IJG libjpeg which uses SIMD to accelerate baseline JPEG
+compression and decompression. libjpeg is a library that implements JPEG image encoding, decoding and transcoding.
+"""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('NASM', '2.12.02'),
+]
+
+configopts = "--with-jpeg8"
+runtest = "test"
+
+sanity_check_paths = {
+    'files': ['bin/cjpeg', 'bin/djpeg', 'bin/jpegtran', 'bin/rdjpgcom', 'bin/tjbench', 'bin/wrjpgcom',
+              'lib/libjpeg.a', 'lib/libjpeg.%s' % SHLIB_EXT, 'lib/libturbojpeg.a', 'lib/libturbojpeg.%s' % SHLIB_EXT],
+    'dirs': ['include', 'share'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/Pillow/Pillow-3.4.2-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/p/Pillow/Pillow-3.4.2-intel-2016b-Python-2.7.12.eb
@@ -1,0 +1,27 @@
+easyblock = 'PythonPackage'
+
+name = 'Pillow'
+version = '3.4.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://pillow.readthedocs.org/'
+description = """Pillow is the 'friendly PIL fork' by Alex Clark and Contributors.
+ PIL is the Python Imaging Library by Fredrik Lundh and Contributors."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('Python', '2.7.12'),
+    ('libjpeg-turbo', '1.5.1'),
+    ('libpng', '1.6.26'),
+    ('zlib', '1.2.8'),
+    ('LibTIFF', '4.0.6'),
+    ('freetype', '2.7'),
+]
+
+options = {'modulename': 'PIL'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/Pillow/Pillow-3.4.2-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/p/Pillow/Pillow-3.4.2-intel-2016b-Python-3.5.2.eb
@@ -1,0 +1,27 @@
+easyblock = 'PythonPackage'
+
+name = 'Pillow'
+version = '3.4.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://pillow.readthedocs.org/'
+description = """Pillow is the 'friendly PIL fork' by Alex Clark and Contributors.
+ PIL is the Python Imaging Library by Fredrik Lundh and Contributors."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('Python', '3.5.2'),
+    ('libjpeg-turbo', '1.5.1'),
+    ('libpng', '1.6.26'),
+    ('zlib', '1.2.8'),
+    ('LibTIFF', '4.0.6'),
+    ('freetype', '2.7'),
+]
+
+options = {'modulename': 'PIL'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.12.3-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.12.3-intel-2016b-Python-2.7.12.eb
@@ -19,15 +19,12 @@ dependencies = [
     ('Python', '2.7.12'),
     ('Qhull', '2015.2'),
     ('matplotlib', '1.5.3', versionsuffix),
+    ('Pillow', '3.4.2', versionsuffix),
 ]
 
 exts_list = [
     ('networkx', '1.11', {
         'source_urls': ['https://pypi.python.org/packages/source/n/networkx'],
-    }),
-    ('Pillow', '3.4.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/P/Pillow'],
-        'modulename': 'PIL',
     }),
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/s/scikit-image'],

--- a/easybuild/easyconfigs/s/scikit-image/scikit-image-0.12.3-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/s/scikit-image/scikit-image-0.12.3-intel-2016b-Python-3.5.2.eb
@@ -19,15 +19,12 @@ dependencies = [
     ('Python', '3.5.2'),
     ('Qhull', '2015.2'),
     ('matplotlib', '1.5.3', versionsuffix),
+    ('Pillow', '3.4.2', versionsuffix),
 ]
 
 exts_list = [
     ('networkx', '1.11', {
         'source_urls': ['https://pypi.python.org/packages/source/n/networkx'],
-    }),
-    ('Pillow', '3.4.2', {
-        'source_urls': ['https://pypi.python.org/packages/source/P/Pillow'],
-        'modulename': 'PIL',
     }),
     (name, version, {
         'source_urls': ['https://pypi.python.org/packages/source/s/scikit-image'],


### PR DESCRIPTION
fix for scikit-image easyconfigs added in #3720