### PR TITLE
{bio} [intel-2015b] InterProScan-5.21-60.0 . Includes fix for centos6

### DIFF
--- a/easybuild/easyconfigs/i/InterProScan/InterProScan-5.21-60.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/i/InterProScan/InterProScan-5.21-60.0-intel-2015b.eb
@@ -1,0 +1,33 @@
+easyblock = 'Tarball'
+
+name = 'InterProScan'
+version = '5.21-60.0'
+
+homepage = 'http://www.ebi.ac.uk/interpro/'
+description = """InterProScan is a sequence analysis application (nucleotide and protein sequences) that combines
+ different protein signature recognition methods into one resource."""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+
+source_urls = ['http://ftp.ebi.ac.uk/pub/software/unix/iprscan/%(version_major)s/%(version)s/',
+	       'ftp://ftp.ebi.ac.uk/pub/databases/interpro/iprscan/5/bin/']
+sources = ['%(namelower)s-%(version)s-64-bit.tar.gz', 'sfld_binary.zip']
+
+dependencies = [
+    ('Java', '1.7.0_80', '', True),
+    ('Perl', '5.20.3'),
+    ('libgd', '2.1.1'),
+    ('Python', '2.7.10'),
+]
+
+sanity_check_paths = {
+    'files': ['interproscan-%(version_major)s.jar', 'interproscan.sh', 'interproscan.properties'],
+    'dirs': ['bin', 'lib', 'data'],
+}
+
+# Workaround required for CentOS 6 systems. Details here:
+# https://github.com/ebi-pf-team/interproscan/issues/16
+postinstallcmds = ['cp -f %(builddir)s/sfld_postprocess %(installdir)s/bin/sfld/',
+		   'cp -f %(builddir)s/sfld_preprocess %(installdir)s/bin/sfld/']
+
+moduleclass = 'bio'


### PR DESCRIPTION
latest InterProScan. Including required fix for centos6 systems