### PR TITLE
SPAdes 3.9.0 with foss 2016a

### DIFF
--- a/easybuild/easyconfigs/s/SPAdes/SPAdes-3.9.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/s/SPAdes/SPAdes-3.9.0-foss-2016a.eb
@@ -1,0 +1,44 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Pablo Escobar Lopez
+# sciCORE - University of Basel
+# SIB Swiss Institute of Bioinformatics 
+# 3.9.0:
+# Modified by:
+# Adam Huffman
+# The Francis Crick Institute
+
+easyblock = "CMakeMake"
+
+name = 'SPAdes'
+version = '3.9.0'
+
+homepage = 'http://bioinf.spbau.ru/en/spades'
+description = """Genome assembler for single-cell and isolates data sets"""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['http://spades.bioinf.spbau.ru/release%(version)s/']
+sources = [SOURCE_TAR_GZ]
+
+builddependencies = [('CMake', '3.5.2')]
+
+dependencies = [
+    ('zlib', '1.2.8'),
+    ('bzip2', '1.0.6'),
+]
+
+start_dir = 'src'
+
+separate_build_dir = True
+
+configopts = ' -DBoost_NO_BOOST_CMAKE=ON'
+
+sanity_check_commands = [('spades.py', '--test')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["bwa-spades", "dipspades", "dipspades.py",
+                                     "hammer", "ionhammer", "spades",  "spades.py"]],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
Based on the existing version for foss 2016b, created using --try-toolchain. Since everyone can install them like that and the only difference now is 2016b->2016a, should I even create PRs for such easyconfigs?