### PR TITLE
iomkl toolchain with GCC-5.4.0-2.26 and OpenMPI 1.10.3

### DIFF
--- a/easybuild/easyconfigs/h/HPL/HPL-2.2-iomkl-2016.09-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.2-iomkl-2016.09-GCC-5.4.0-2.26.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.2'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'iomkl', 'version': '2016.09-GCC-5.4.0-2.26'}
+toolchainopts = {'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iompi-2016.09-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.3.210-iompi-2016.09-GCC-5.4.0-2.26.eb
@@ -1,0 +1,36 @@
+name = 'imkl'
+version = '11.3.3.210'
+
+homepage = 'http://software.intel.com/en-us/intel-mkl/'
+description = """Intel Math Kernel Library is a library of highly optimized,
+ extensively threaded math routines for science, engineering, and financial
+ applications that require maximum performance. Core math functions include
+ BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
+
+toolchain = {'name': 'iompi', 'version': '2016.09-GCC-5.4.0-2.26'}
+
+sources = ['l_mkl_%(version)s.tgz']
+checksums = ['f72546df27f5ebb0941b5d21fd804e34']
+
+dontcreateinstalldir = 'True'
+
+components = ['intel-mkl']
+
+interfaces = True
+
+license_file = HOME + '/licenses/intel/license.lic'
+
+postinstallcmds = [
+    # extract the examples
+    'tar xvzf %(installdir)s/mkl/examples/examples_cluster.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_c.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_core_f.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_f95.tgz -C %(installdir)s/mkl/examples/',
+    'tar xvzf %(installdir)s/mkl/examples/examples_mic.tgz -C %(installdir)s/mkl/examples/'
+]
+
+modextravars = {
+    'MKL_EXAMPLES': '%(installdir)s/mkl/examples/',
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/i/iomkl/iomkl-2016.09-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iomkl/iomkl-2016.09-GCC-5.4.0-2.26.eb
@@ -1,0 +1,20 @@
+easyblock = "Toolchain"
+
+name = 'iomkl'
+version = '2016.09-GCC-5.4.0-2.26'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Intel Cluster Toolchain Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MKL & OpenMPI."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+compver = '2016.3.210-GCC-5.4.0-2.26'
+
+dependencies = [
+    ('icc', compver),
+    ('ifort', compver),
+    ('OpenMPI', '1.10.3', '', ('iccifort', compver)),
+    ('imkl', '11.3.3.210', '', ('iompi', version)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iompi/iompi-2016.09-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iompi/iompi-2016.09-GCC-5.4.0-2.26.eb
@@ -1,0 +1,20 @@
+easyblock = "Toolchain"
+
+name = 'iompi'
+version = '2016.09-GCC-5.4.0-2.26'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Toolchain with Intel C, C++ and Fortran compilers, alongside OpenMPI."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+compver = '2016.3.210-GCC-5.4.0-2.26'
+
+dependencies = [
+    ('OpenMPI', '1.10.3', '', ('iccifort', compver)),
+    ('icc', compver),
+    ('ifort', compver),
+]
+
+moduleclass = 'toolchain'
+


### PR DESCRIPTION
These files are based upon the {iomkl,iompi,imkl}-2016.09-GCC-4.9.3-2.25.eb files.
GCC compiler updated to GCC-5.4.0-2.26 because we already have this from the foss2016b toolchain.
OpenMPI 1.10.3 is used because we also have this in the foss2016b toolchain.

The iomkl toolchain MUST be built in a certain order:
1. The OpenMPI requires the Intel compilers.
2. The iompi requires the correct OpenMPI.
3. The iomkl requires imkl.

Commands used and tested:
eb icc-2016.3.210-GCC-5.4.0-2.26.eb iccifort-2016.3.210-GCC-5.4.0-2.26.eb ifort-2016.3.210-GCC-5.4.0-2.26.eb -r
eb OpenMPI-1.10.3-Slurm-iccifort-2016.3.210-GCC-5.4.0-2.26.eb -r	# For Slurm support
eb iompi-2016.09-GCC-5.4.0-2.26.eb imkl-11.3.3.210-iompi-2016.09-GCC-5.4.0-2.26.eb -r
eb iomkl-2016.09-GCC-5.4.0-2.26.eb -r

When the modules are ready, the iomkl toolchain can be loaded.  The mpirun command is working correctly with one of our production codes.
Warning: If users load the iompi module, this picks up the mpirun command from the ifort compiler, and this fails miserably for reasons that we don't understand.
