### PR TITLE
remove maxparallel in GCCcore and GCC 5.x easyconfigs

### DIFF
--- a/easybuild/easyconfigs/g/GCC/GCC-5.1.0-binutils-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.1.0-binutils-2.25.eb
@@ -49,7 +49,4 @@ languages = ['c', 'c++', 'fortran']
 
 withisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-5.1.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.1.0.eb
@@ -43,7 +43,4 @@ languages = ['c', 'c++', 'fortran']
 
 withisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.2.0.eb
@@ -43,7 +43,4 @@ languages = ['c', 'c++', 'fortran']
 
 withisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-5.3.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.3.0.eb
@@ -43,7 +43,4 @@ languages = ['c', 'c++', 'fortran']
 
 withisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.2.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.2.eb
@@ -42,7 +42,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.3.eb
@@ -41,7 +41,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.4.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.4.eb
@@ -41,7 +41,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-5.3.0.eb
@@ -48,7 +48,4 @@ languages = ['c', 'c++', 'fortran']
 
 withisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-5.4.0.eb
@@ -48,7 +48,4 @@ languages = ['c', 'c++', 'fortran']
 
 withisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.1.0.eb
@@ -51,7 +51,4 @@ languages = ['c', 'c++', 'fortran']
 
 withisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.2.0.eb
@@ -50,7 +50,4 @@ languages = ['c', 'c++', 'fortran']
 
 withisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'


### PR DESCRIPTION
Building in parallel works fine for recent versions of GCC, there should be no reason to limit it.