### PR TITLE
remove maxparallel in GCC 4.9.x easyconfigs

### DIFF
--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG-multilib.eb
@@ -48,7 +48,4 @@ clooguseisl = True
 
 multilib = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG.eb
@@ -46,7 +46,4 @@ withcloog = True
 withisl = True
 clooguseisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.0.eb
@@ -34,7 +34,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG-multilib.eb
@@ -48,7 +48,4 @@ clooguseisl = True
 
 multilib = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG.eb
@@ -46,7 +46,4 @@ withcloog = True
 withisl = True
 clooguseisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.1.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.1.eb
@@ -34,7 +34,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG-multilib.eb
@@ -48,7 +48,4 @@ clooguseisl = True
 
 multilib = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG.eb
@@ -46,7 +46,4 @@ withcloog = True
 withisl = True
 clooguseisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2-binutils-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2-binutils-2.25.eb
@@ -39,7 +39,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2.eb
@@ -34,7 +34,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3-binutils-2.25.eb
@@ -39,7 +39,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3.eb
@@ -34,7 +34,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'


### PR DESCRIPTION
Building in parallel works fine for recent versions of GCC, there should be no reason to limit it.