### PR TITLE
remove maxparallel in GCC 4.8.x easyconfigs

### DIFF
--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.1-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.1-CLooG.eb
@@ -41,7 +41,4 @@ withcloog = True
 withisl = True
 clooguseisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.1.eb
@@ -29,7 +29,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.2-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.2-CLooG-multilib.eb
@@ -43,7 +43,4 @@ clooguseisl = True
 
 multilib = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.2-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.2-CLooG.eb
@@ -41,7 +41,4 @@ withcloog = True
 withisl = True
 clooguseisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.2-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.2-multilib.eb
@@ -32,7 +32,4 @@ languages = ['c', 'c++', 'fortran']
 
 multilib = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.2.eb
@@ -29,7 +29,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.3-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.3-CLooG-multilib.eb
@@ -43,7 +43,4 @@ clooguseisl = True
 
 multilib = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.3.eb
@@ -29,7 +29,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.4-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.4-CLooG-multilib.eb
@@ -43,7 +43,4 @@ clooguseisl = True
 
 multilib = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.4-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.4-CLooG.eb
@@ -41,7 +41,4 @@ withcloog = True
 withisl = True
 clooguseisl = True
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.4.eb
@@ -29,7 +29,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.5.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.5.eb
@@ -29,7 +29,4 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
-# building GCC sometimes fails if make parallelism is too high, so let's limit it
-maxparallel = 4
-
 moduleclass = 'compiler'


### PR DESCRIPTION
Building in parallel works fine for recent versions of GCC, there should be no reason to limit it.