### PR TITLE
Eliminate dependency on mpi-mic-rt in ifort.

### DIFF
--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3-2.25.eb
@@ -10,6 +10,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 
 sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran.tgz']
 
+# remove dependency on intel-mpi-rt-mic
+patches = ['ifort_2016_no_mpi_mic_dependency.patch']
+
 checksums = ['bce7f6a71f7e44f67956197501d00b7c']
 
 gccver = '4.9.3'

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
@@ -12,6 +12,9 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran.tg
 
 checksums = ['bce7f6a71f7e44f67956197501d00b7c']
 
+# remove dependency on intel-mpi-rt-mic
+patches = ['ifort_2016_no_mpi_mic_dependency.patch']
+
 # list of regex for components to install
 # full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
 # cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -12,6 +12,9 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran_up
 
 checksums = ['1e848c8283cf6a0210bce1d35ecd748b']
 
+# remove dependency on intel-mpi-rt-mic
+patches = ['ifort_2016_no_mpi_mic_dependency.patch']
+
 gccver = '4.9.3'
 binutilsver = '2.25'
 versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-4.9.3-2.25.eb
@@ -12,6 +12,9 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran_up
 
 checksums = ['70e88db11efc59b1d8ff8b5aadf50f7f']
 
+# remove dependency on intel-mpi-rt-mic
+patches = ['ifort_2016_no_mpi_mic_dependency.patch']
+
 gccver = '4.9.3'
 binutilsver = '2.25'
 versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-5.3.0-2.26.eb
@@ -12,6 +12,9 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran_up
 
 checksums = ['70e88db11efc59b1d8ff8b5aadf50f7f']
 
+# remove dependency on intel-mpi-rt-mic
+patches = ['ifort_2016_no_mpi_mic_dependency.patch']
+
 gccver = '5.3.0'
 binutilsver = '2.26'
 versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -12,6 +12,9 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran_up
 
 checksums = ['70cf1ea91280e3e8ba4bc216bae63e4a']
 
+# remove dependency on intel-mpi-rt-mic
+patches = ['ifort_2016_no_mpi_mic_dependency.patch']
+
 gccver = '4.9.3'
 binutilsver = '2.25'
 versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.3.0-2.26.eb
@@ -12,6 +12,9 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran_up
 
 checksums = ['70cf1ea91280e3e8ba4bc216bae63e4a']
 
+# remove dependency on intel-mpi-rt-mic
+patches = ['ifort_2016_no_mpi_mic_dependency.patch']
+
 gccver = '5.3.0'
 binutilsver = '2.26'
 versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -12,6 +12,9 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran_up
 
 checksums = ['70cf1ea91280e3e8ba4bc216bae63e4a']
 
+# remove dependency on intel-mpi-rt-mic
+patches = ['ifort_2016_no_mpi_mic_dependency.patch']
+
 gccver = '5.4.0'
 binutilsver = '2.26'
 versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.0.098-GCC-5.4.0-2.26.eb
@@ -12,6 +12,9 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran.tg
 
 checksums = ['8787795951fe10f90ce7dcdcec1b9341']
 
+# remove dependency on intel-mpi-rt-mic
+patches = ['ifort_2017_no_mpi_mic_dependency.patch']
+
 gccver = '5.4.0'
 binutilsver = '2.26'
 versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -12,6 +12,9 @@ sources = ['parallel_studio_xe_%(version_major)s_update%(version_minor)s_compose
 
 checksums = ['612169f4b40cdded8e212bf097925e4f']
 
+# remove dependency on intel-mpi-rt-mic
+patches = ['ifort_2017_no_mpi_mic_dependency.patch']
+
 gccver = '5.4.0'
 binutilsver = '2.26'
 versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)

--- a/easybuild/easyconfigs/i/ifort/ifort_2016_no_mpi_mic_dependency.patch
+++ b/easybuild/easyconfigs/i/ifort/ifort_2016_no_mpi_mic_dependency.patch
@@ -1,0 +1,13 @@
+Eliminate dependency on intel-mpi-rt-mic which in turn brings in intel-mpi-rt.
+author: Bart Oldeman (McGill HPC)
+--- pset/mediaconfig.xml.orig	2016-11-14 12:57:14.214649000 -0500
++++ pset/mediaconfig.xml	2016-11-14 12:57:30.108947210 -0500
+@@ -1758,7 +1758,7 @@
+       <RPMFileDir>${PACKAGE_DIR}/rpm</RPMFileDir>
+       <Type>rpm</Type>
+     </Component>
+-    <Component cafe="false" depend="14.3;42.23;42.111;42.112;14.432;42.24;11.3" id="114" invisible="0" mandatory="0" platform="INTEL64">
++    <Component cafe="false" depend="14.3;42.23;42.111;42.112;14.432;42.24" id="114" invisible="0" mandatory="0" platform="INTEL64">
+       <Name>Intel Fortran Compiler for Intel(R) 64</Name>
+       <Description>Intel(R) Fortran Compiler 16.0 Update 2</Description>
+       <Name locale="ja_JP.UTF-8">インテル(R) Fortran コンパイラー (インテル(R) 64)</Name>

--- a/easybuild/easyconfigs/i/ifort/ifort_2017_no_mpi_mic_dependency.patch
+++ b/easybuild/easyconfigs/i/ifort/ifort_2017_no_mpi_mic_dependency.patch
@@ -1,0 +1,13 @@
+Eliminate dependency on intel-mpi-rt-mic which in turn brings in intel-mpi-rt.
+author: Bart Oldeman (McGill HPC) 
+--- pset/mediaconfig.xml.orig      2016-10-20 09:02:57.000000000 +0000
++++ pset/mediaconfig.xml   2016-11-11 20:09:08.084892189 +0000
+@@ -1551,7 +1551,7 @@
+       <MapFileDir>${BUNDLE_MAPFILE_DIR}</MapFileDir>
+       <ChklicIA32>${BUNDLE_CHKLIC_IA32}</ChklicIA32>
+     </Component>
+-    <Component depend="1.3;33.111;33.112;1.432;118.3" id="114" invisible="0" mandatory="0" platform="INTEL64">
++    <Component depend="1.3;33.111;33.112;1.432" id="114" invisible="0" mandatory="0" platform="INTEL64">
+       <Name>Intel Fortran Compiler for Intel(R) 64</Name>
+       <Description>Intel(R) Fortran Compiler 17.0 Update 1</Description>
+       <Name locale="ja_JP.UTF-8">インテル(R) Fortran コンパイラー (インテル(R) 64)</Name>


### PR DESCRIPTION
This dependency causes Intel mpirun/mpiexec to be added to $PATH
when the ifort module is loaded, which is not always desirable,
for instance when OpenMPI is already loaded.

Fixes hpcugent/easybuild-easyblocks#1032.