### PR TITLE
disable patching of GCC to make it prefer /lib over /lib64 to avoid breaking the build

### DIFF
--- a/easybuild/easyconfigs/g/GCC/GCC-4.2.4.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.2.4.eb
@@ -21,6 +21,8 @@ dependencies = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 configopts = "--with-gmp=$EBROOTGMP --with-mpfr=$EBROOTMPFR"
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it

--- a/easybuild/easyconfigs/g/GCC/GCC-4.3.6.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.3.6.eb
@@ -21,6 +21,8 @@ dependencies = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 configopts = "--with-gmp=$EBROOTGMP --with-mpfr=$EBROOTMPFR"
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it

--- a/easybuild/easyconfigs/g/GCC/GCC-4.4.7.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.4.7.eb
@@ -21,6 +21,8 @@ dependencies = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 # the build will fail if a new version of texinfo is found, so disable
 configopts = "--with-gmp=$EBROOTGMP --with-mpfr=$EBROOTMPFR MAKEINFO=MISSING"
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.5.2.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.5.2.eb
@@ -29,6 +29,8 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.5.3-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.5.3-CLooG-PPL.eb
@@ -40,6 +40,8 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 withcloog = True
 withppl = True
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.5.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.5.3.eb
@@ -29,6 +29,8 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.6.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.6.0.eb
@@ -29,6 +29,8 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.6.3-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.6.3-CLooG-PPL.eb
@@ -40,6 +40,8 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 withcloog = True
 withppl = True
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.6.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.6.3.eb
@@ -29,6 +29,8 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.0-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.0-CLooG-PPL.eb
@@ -43,6 +43,8 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 withcloog = True
 withppl = True
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.0.eb
@@ -32,6 +32,8 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.1-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.1-CLooG-PPL.eb
@@ -43,6 +43,8 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 withcloog = True
 withppl = True
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.1.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.1.eb
@@ -32,6 +32,8 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4
 

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.2.eb
@@ -32,6 +32,8 @@ checksums = [
 
 languages = ['c', 'c++', 'fortran']
 
+prefer_lib_subdir = False
+
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4
 


### PR DESCRIPTION
In https://github.com/hpcugent/easybuild-easyblocks/pull/1030, patching of GCC was enabled to make it prefer `/lib` over `/lib64` directories.

This causes problems with older versions of GCC (4.7.2 and earlier, except for 4.6.4):

```
/usr/lib/crti.o: could not read symbols: File in wrong format
collect2: ld returned 1 exit status
```

with:

```
$ file /usr/lib/crti.o
/usr/lib/crti.o: ELF 32-bit LSB relocatable, Intel 80386, version 1 (SYSV), not stripped
```

This change simply disables the patching, to fix the build.
If needed, this can be revisited once the cause of the problem (and a fix) is figured out...

cc @sebth