### PR TITLE
Fix incorrect descriptions for ifort.

### DIFF
--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109-GCC-4.9.3-2.25.eb
@@ -4,7 +4,7 @@ name = 'ifort'
 version = '2016.0.109'
 
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
-description = "C and C++ compiler from Intel"
+description = "Fortran compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': ''}
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.0.109.eb
@@ -4,7 +4,7 @@ name = 'ifort'
 version = '2016.0.109'
 
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
-description = "C and C++ compiler from Intel"
+description = "Fortran compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -4,7 +4,7 @@ name = 'ifort'
 version = '2016.1.150'
 
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
-description = "C and C++ compiler from Intel"
+description = "Fortran compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': ''}
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-4.9.3-2.25.eb
@@ -4,7 +4,7 @@ name = 'ifort'
 version = '2016.2.181'
 
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
-description = "C and C++ compiler from Intel"
+description = "Fortran compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.2.181-GCC-5.3.0-2.26.eb
@@ -4,7 +4,7 @@ name = 'ifort'
 version = '2016.2.181'
 
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
-description = "C and C++ compiler from Intel"
+description = "Fortran compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-4.9.3-2.25.eb
@@ -4,7 +4,7 @@ name = 'ifort'
 version = '2016.3.210'
 
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
-description = "C and C++ compiler from Intel"
+description = "Fortran compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.3.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.3.0-2.26.eb
@@ -4,7 +4,7 @@ name = 'ifort'
 version = '2016.3.210'
 
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
-description = "C and C++ compiler from Intel"
+description = "Fortran compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.3.210-GCC-5.4.0-2.26.eb
@@ -4,7 +4,7 @@ name = 'ifort'
 version = '2016.3.210'
 
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
-description = "C and C++ compiler from Intel"
+description = "Fortran compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.0.098-GCC-5.4.0-2.26.eb
@@ -4,7 +4,7 @@ name = 'ifort'
 version = '2017.0.098'
 
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
-description = "C and C++ compiler from Intel"
+description = "Fortran compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -4,7 +4,7 @@ name = 'ifort'
 version = '2017.1.132'
 
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
-description = "C and C++ compiler from Intel"
+description = "Fortran compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 


### PR DESCRIPTION
Some of the ifort .eb files had gotten an incorrect description,
claiming to be C/C++ instead of Fortran.