### PR TITLE
{lang}[dummy,intel/2016b] Mono 4.6.2.7 (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/m/Mono/Mono-4.6.2.7-intel-2016b.eb
+++ b/easybuild/easyconfigs/m/Mono/Mono-4.6.2.7-intel-2016b.eb
@@ -1,0 +1,20 @@
+easyblock = 'ConfigureMake'
+
+name = 'Mono'
+version = '4.6.2.7'
+
+homepage = 'http://mono-framework.com' 
+description = """An open source, cross-platform, implementation of C# and the CLR that is
+ binary compatible with Microsoft.NET."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+
+source_urls = ['http://download.mono-project.com/sources/mono/']
+sources = [SOURCELOWER_TAR_BZ2]
+
+builddependencies = [
+    ('Bison', '3.0.4'),
+    ('gettext', '0.19.8'),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/m/Mono/Mono-4.6.2.7.eb
+++ b/easybuild/easyconfigs/m/Mono/Mono-4.6.2.7.eb
@@ -1,0 +1,17 @@
+easyblock = 'ConfigureMake'
+
+name = 'Mono'
+version = '4.6.2.7'
+
+homepage = 'http://mono-framework.com' 
+description = """An open source, cross-platform, implementation of C# and the CLR that is
+ binary compatible with Microsoft.NET."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+source_urls = ['http://download.mono-project.com/sources/mono/']
+sources = [SOURCELOWER_TAR_BZ2]
+
+osdependencies = ['gettext']
+
+moduleclass = 'lang'


### PR DESCRIPTION
- Added Mono 4.6.2.7 with both dummy and intel-2016b toolchains
- No longer using mono.py easyblock, only ConfigureMake instead