### PR TITLE
fix source_urls in pkg-config easyconfigs

### DIFF
--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1-foss-2015b.eb
@@ -15,7 +15,7 @@ tar_config_opts = True
 toolchain = {'name': 'foss', 'version': '2015b'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 configopts = " --with-internal-glib"
 

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1-goolf-1.4.10.eb
@@ -12,7 +12,7 @@ for instance, rather than hard-coding values on where to find glib (or other lib
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 configopts = " --with-internal-glib"
 

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1-ictce-5.3.0.eb
@@ -13,7 +13,7 @@ description = """pkg-config is a helper tool used when compiling applications an
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 configopts = " --with-internal-glib"
 

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1-ictce-5.5.0.eb
@@ -15,7 +15,7 @@ tar_config_opts = True
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 configopts = " --with-internal-glib"
 

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1-intel-2015a.eb
@@ -15,7 +15,7 @@ tar_config_opts = True
 toolchain = {'name': 'intel', 'version': '2015a'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 configopts = " --with-internal-glib"
 

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.27.1-intel-2015b.eb
@@ -15,7 +15,7 @@ tar_config_opts = True
 toolchain = {'name': 'intel', 'version': '2015b'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 configopts = " --with-internal-glib"
 

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.28-GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.28-GCC-4.8.2.eb
@@ -15,7 +15,7 @@ tar_config_opts = True
 toolchain = {'name': 'GCC', 'version': '4.8.2'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 configopts = " --with-internal-glib"
 

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.28-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.28-GCC-4.9.2.eb
@@ -15,7 +15,7 @@ tar_config_opts = True
 toolchain = {'name': 'GCC', 'version': '4.9.2'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 configopts = " --with-internal-glib"
 

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.28-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.28-GNU-4.9.3-2.25.eb
@@ -15,7 +15,7 @@ tar_config_opts = True
 toolchain = {'name': 'GNU', 'version': '4.9.3-2.25'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 configopts = " --with-internal-glib"
 

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.28-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.28-ictce-5.5.0.eb
@@ -15,7 +15,7 @@ tar_config_opts = True
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 configopts = " --with-internal-glib"
 

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.28-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.28-intel-2015a.eb
@@ -15,7 +15,7 @@ tar_config_opts = True
 toolchain = {'name': 'intel', 'version': '2015a'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 configopts = " --with-internal-glib"
 

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29-foss-2016a.eb
@@ -12,7 +12,7 @@ description = """pkg-config is a helper tool used when compiling applications an
 toolchain = {'name': 'foss', 'version': '2016a'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 # don't use PAX, it might break.
 tar_config_opts = True

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29-gimkl-2.11.5.eb
@@ -12,7 +12,7 @@ description = """pkg-config is a helper tool used when compiling applications an
 toolchain = {'name': 'gimkl', 'version': '2.11.5'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 # don't use PAX, it might break.
 tar_config_opts = True

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29-intel-2015a.eb
@@ -12,7 +12,7 @@ description = """pkg-config is a helper tool used when compiling applications an
 toolchain = {'name': 'intel', 'version': '2015a'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 # don't use PAX, it might break.
 tar_config_opts = True

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29-intel-2015b.eb
@@ -12,7 +12,7 @@ description = """pkg-config is a helper tool used when compiling applications an
 toolchain = {'name': 'intel', 'version': '2015b'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 # don't use PAX, it might break.
 tar_config_opts = True

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29-intel-2016a.eb
@@ -12,7 +12,7 @@ description = """pkg-config is a helper tool used when compiling applications an
 toolchain = {'name': 'intel', 'version': '2016a'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 # don't use PAX, it might break.
 tar_config_opts = True

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-GCCcore-4.9.3.eb
@@ -12,7 +12,7 @@ description = """pkg-config is a helper tool used when compiling applications an
 toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 builddependencies = [('binutils', '2.25')]
 

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-foss-2016a.eb
@@ -12,7 +12,7 @@ description = """pkg-config is a helper tool used when compiling applications an
 toolchain = {'name': 'foss', 'version': '2016a'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 # don't use PAX, it might break.
 tar_config_opts = True

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-foss-2016b.eb
@@ -12,7 +12,7 @@ description = """pkg-config is a helper tool used when compiling applications an
 toolchain = {'name': 'foss', 'version': '2016b'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 # don't use PAX, it might break.
 tar_config_opts = True

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-intel-2016a.eb
@@ -12,7 +12,7 @@ description = """pkg-config is a helper tool used when compiling applications an
 toolchain = {'name': 'intel', 'version': '2016a'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 # don't use PAX, it might break.
 tar_config_opts = True

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-intel-2016b.eb
@@ -12,7 +12,7 @@ description = """pkg-config is a helper tool used when compiling applications an
 toolchain = {'name': 'intel', 'version': '2016b'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
 
 # don't use PAX, it might break.
 tar_config_opts = True


### PR DESCRIPTION
Apparently this got moved (the old URL auto-directs to the new).