### PR TITLE
Fileset for recent CMake versions in GCCcore compilers

### DIFF
--- a/easybuild/easyconfigs/c/CMake/CMake-3.6.2-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.6.2-GCCcore-5.4.0.eb
@@ -1,0 +1,36 @@
+easyblock = 'ConfigureMake'
+
+name = 'CMake'
+version = '3.6.2'
+
+homepage = 'http://www.cmake.org'
+description = """CMake, the cross-platform, open-source build system.
+ CMake is a family of tools designed to build, test and package software."""
+
+toolchain = {'name': 'GCCcore', 'version': '5.4.0'}
+
+source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = '-- -DCMAKE_USE_OPENSSL=1'
+
+builddependencies = [
+    ('binutils', '2.26'),
+]
+
+
+dependencies = [
+    ('ncurses', '6.0'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    #('OpenSSL', '1.1.0c'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/c/CMake/CMake-3.7.1-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.7.1-GCCcore-5.4.0.eb
@@ -1,0 +1,36 @@
+easyblock = 'ConfigureMake'
+
+name = 'CMake'
+version = '3.7.1'
+
+homepage = 'http://www.cmake.org'
+description = """CMake, the cross-platform, open-source build system.
+ CMake is a family of tools designed to build, test and package software."""
+
+toolchain = {'name': 'GCCcore', 'version': '5.4.0'}
+
+source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = '-- -DCMAKE_USE_OPENSSL=1'
+
+builddependencies = [
+    ('binutils', '2.26'),
+]
+
+
+dependencies = [
+    ('ncurses', '6.0'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    #('OpenSSL', '1.1.0c'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/c/CMake/CMake-3.7.1-GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.7.1-GCCcore-6.2.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'ConfigureMake'
+
+name = 'CMake'
+version = '3.7.1'
+homepage = 'http://www.cmake.org'
+description = """CMake, the cross-platform, open-source build system.
+ CMake is a family of tools designed to build, test and package software."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.2.0'}
+
+source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = '-- -DCMAKE_USE_OPENSSL=1'
+
+builddependencies = [
+    ('binutils', '2.27'),
+]
+
+
+dependencies = [
+    ('ncurses', '6.0'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    #('OpenSSL', '1.1.0c'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-5.4.0.eb
@@ -1,0 +1,38 @@
+easyblock = 'ConfigureMake'
+
+name = 'ncurses'
+version = '6.0'
+
+homepage = 'http://www.gnu.org/software/ncurses/'
+description = """The Ncurses (new curses) library is a free software emulation of curses in System V Release 4.0,
+ and more. It uses Terminfo format, supports pads and color and multiple highlights and forms characters and
+ function-key mapping, and has all the other SYSV-curses enhancements over BSD Curses."""
+
+toolchain = {'name': 'GCCcore', 'version': '5.4.0'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+patches = ['ncurses-%(version)s_gcc-5.patch']
+
+builddependencies = [('binutils', '2.26')]
+
+configopts = [
+    # default build
+    '--with-shared --enable-overwrite',
+    # the UTF-8 enabled version (ncursesw)
+    '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
+]
+
+libs = ["form", "menu", "ncurses", "panel"]
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
+                                     "reset", "tabs", "tic", "toe", "tput", "tset"]] +
+             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/libncurses++%s.a' % x for x in ['', 'w']],
+    'dirs': ['include', 'include/ncursesw'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-6.2.0.eb
@@ -1,0 +1,38 @@
+easyblock = 'ConfigureMake'
+
+name = 'ncurses'
+version = '6.0'
+
+homepage = 'http://www.gnu.org/software/ncurses/'
+description = """The Ncurses (new curses) library is a free software emulation of curses in System V Release 4.0,
+ and more. It uses Terminfo format, supports pads and color and multiple highlights and forms characters and
+ function-key mapping, and has all the other SYSV-curses enhancements over BSD Curses."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.2.0'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+patches = ['ncurses-%(version)s_gcc-5.patch']
+
+builddependencies = [('binutils', '2.27')]
+
+configopts = [
+    # default build
+    '--with-shared --enable-overwrite',
+    # the UTF-8 enabled version (ncursesw)
+    '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
+]
+
+libs = ["form", "menu", "ncurses", "panel"]
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
+                                     "reset", "tabs", "tic", "toe", "tput", "tset"]] +
+             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/libncurses++%s.a' % x for x in ['', 'w']],
+    'dirs': ['include', 'include/ncursesw'],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
CMake in the GCCcore will support all foss, intel and pomkl toolchains
using that GCCcore.

PR contains matching ncurses.