### PR TITLE
install numpy/scipy as .egg to ensure shadowing of numpy/scipy in parent Python installation

### DIFF
--- a/easybuild/easyconfigs/n/numpy/numpy-1.9.2-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/n/numpy/numpy-1.9.2-intel-2016b-Python-2.7.12.eb
@@ -25,4 +25,8 @@ dependencies = [
 # using easy_install does not work...
 use_pip = True
 
+# install as zipped egg to get a .pth file in lib/python*/site-packages;
+# this enables shadowing of the numpy that is part of the Python installation
+zipped_egg = True
+
 moduleclass = 'math'

--- a/easybuild/easyconfigs/s/scipy/scipy-0.16.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/s/scipy/scipy-0.16.0-intel-2016b-Python-2.7.12.eb
@@ -22,8 +22,12 @@ dependencies = [
 prebuildopts = "cython scipy/linalg/_decomp_update.pyx && "
 
 # need to use pip rather than regular 'setup.py install,'
-# to ensure that this numpy wins over the one in the Python installation;
+# to ensure that this scipy wins over the one in the Python installation;
 # using easy_install does not work...
 use_pip = True
+
+# install as zipped egg to get a .pth file in lib/python*/site-packages;
+# this enables shadowing of the scipy that is part of the Python installation
+zipped_egg = True
 
 moduleclass = 'math'


### PR DESCRIPTION
https://github.com/hpcugent/easybuild-easyblocks/pull/1067 revealed that the shadowing of the `numpy`/`scipy` in the parent Python installation didn't actually work yet...

follow-up for #3905