### PR TITLE
libharu 2.3.0 with foss2016a

### DIFF
--- a/easybuild/easyconfigs/l/libharu/libharu-2.3.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/libharu/libharu-2.3.0-foss-2016a.eb
@@ -1,0 +1,37 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
+# Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-94.html
+##
+
+easyblock = 'CMakeMake'
+
+name = 'libharu'
+version = '2.3.0'
+
+homepage = 'http://libharu.org/'
+description = """libHaru is a free, cross platform, open source library for generating PDF files."""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = [' https://github.com/libharu/libharu/archive/']
+sources = ['RELEASE_%s.tar.gz' % '_'.join(version.split('.'))]
+
+dependencies = [('libpng', '1.6.23')]
+
+builddependencies = [('CMake', '3.6.1')]
+
+parallel = 1
+
+sanity_check_paths = {
+    'files': ['lib/libhpdf.%s' % SHLIB_EXT],
+    'dirs': ['if', 'include', 'lib']
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
Based on the easyconfig for 2.2.0, but with two additional changes (besides the version and toolchain):
- removed patches, these things have already been patched in 2.3.0.
- changed category from bio to lib: since this is a library for generating pdfs, it seemed more appropriate to me