### PR TITLE
h5py for Python 3.5 in foss 2016b and h5py for intel 2016b

### DIFF
--- a/easybuild/easyconfigs/h/h5py/h5py-2.6.0-foss-2016b-Python-3.5.2-HDF5-1.10.0-patch1.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.6.0-foss-2016b-Python-3.5.2-HDF5-1.10.0-patch1.eb
@@ -1,0 +1,34 @@
+easyblock = "PythonPackage"
+
+name = 'h5py'
+version = '2.6.0'
+
+homepage = 'http://www.h5py.org/'
+description = """HDF5 for Python (h5py) is a general-purpose Python interface to the Hierarchical Data Format library,
+ version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
+ amounts of data."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'usempi': True}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+hdf5ver = '1.10.0-patch1'
+versionsuffix = '-Python-%%(pyver)s-HDF5-%s' % hdf5ver
+
+# to really use mpi enabled hdf5 we now seem to need a configure step
+prebuildopts = ' python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
+
+dependencies = [
+    ('Python', '3.5.2'),
+    ('HDF5', hdf5ver),
+    ('pkgconfig', '1.1.0', '-Python-%(pyver)s'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.6.0-foss-2016b-Python-3.5.2-HDF5-1.8.18.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.6.0-foss-2016b-Python-3.5.2-HDF5-1.8.18.eb
@@ -1,0 +1,34 @@
+easyblock = "PythonPackage"
+
+name = 'h5py'
+version = '2.6.0'
+
+homepage = 'http://www.h5py.org/'
+description = """HDF5 for Python (h5py) is a general-purpose Python interface to the Hierarchical Data Format library,
+ version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
+ amounts of data."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'usempi': True}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+hdf5ver = '1.8.18'
+versionsuffix = '-Python-%%(pyver)s-HDF5-%s' % hdf5ver
+
+# to really use mpi enabled hdf5 we now seem to need a configure step
+prebuildopts = ' python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
+
+dependencies = [
+    ('Python', '3.5.2'),
+    ('HDF5', hdf5ver),
+    ('pkgconfig', '1.1.0', '-Python-%(pyver)s'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.6.0-intel-2016b-Python-2.7.12-HDF5-1.10.0-patch1.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.6.0-intel-2016b-Python-2.7.12-HDF5-1.10.0-patch1.eb
@@ -1,0 +1,34 @@
+easyblock = "PythonPackage"
+
+name = 'h5py'
+version = '2.6.0'
+
+homepage = 'http://www.h5py.org/'
+description = """HDF5 for Python (h5py) is a general-purpose Python interface to the Hierarchical Data Format library,
+ version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
+ amounts of data."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+toolchainopts = {'usempi': True}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+hdf5ver = '1.10.0-patch1'
+versionsuffix = '-Python-%%(pyver)s-HDF5-%s' % hdf5ver
+
+# to really use mpi enabled hdf5 we now seem to need a configure step
+prebuildopts = ' python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
+
+dependencies = [
+    ('Python', '2.7.12'),
+    ('HDF5', hdf5ver),
+    ('pkgconfig', '1.1.0', '-Python-%(pyver)s'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.6.0-intel-2016b-Python-2.7.12-HDF5-1.8.18.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.6.0-intel-2016b-Python-2.7.12-HDF5-1.8.18.eb
@@ -1,0 +1,34 @@
+easyblock = "PythonPackage"
+
+name = 'h5py'
+version = '2.6.0'
+
+homepage = 'http://www.h5py.org/'
+description = """HDF5 for Python (h5py) is a general-purpose Python interface to the Hierarchical Data Format library,
+ version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
+ amounts of data."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+toolchainopts = {'usempi': True}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+hdf5ver = '1.8.18'
+versionsuffix = '-Python-%%(pyver)s-HDF5-%s' % hdf5ver
+
+# to really use mpi enabled hdf5 we now seem to need a configure step
+prebuildopts = ' python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
+
+dependencies = [
+    ('Python', '2.7.12'),
+    ('HDF5', hdf5ver),
+    ('pkgconfig', '1.1.0', '-Python-%(pyver)s'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.6.0-intel-2016b-Python-3.5.2-HDF5-1.10.0-patch1.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.6.0-intel-2016b-Python-3.5.2-HDF5-1.10.0-patch1.eb
@@ -1,0 +1,34 @@
+easyblock = "PythonPackage"
+
+name = 'h5py'
+version = '2.6.0'
+
+homepage = 'http://www.h5py.org/'
+description = """HDF5 for Python (h5py) is a general-purpose Python interface to the Hierarchical Data Format library,
+ version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
+ amounts of data."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+toolchainopts = {'usempi': True}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+hdf5ver = '1.10.0-patch1'
+versionsuffix = '-Python-%%(pyver)s-HDF5-%s' % hdf5ver
+
+# to really use mpi enabled hdf5 we now seem to need a configure step
+prebuildopts = ' python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
+
+dependencies = [
+    ('Python', '3.5.2'),
+    ('HDF5', hdf5ver),
+    ('pkgconfig', '1.1.0', '-Python-%(pyver)s'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.6.0-intel-2016b-Python-3.5.2-HDF5-1.8.18.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.6.0-intel-2016b-Python-3.5.2-HDF5-1.8.18.eb
@@ -1,0 +1,34 @@
+easyblock = "PythonPackage"
+
+name = 'h5py'
+version = '2.6.0'
+
+homepage = 'http://www.h5py.org/'
+description = """HDF5 for Python (h5py) is a general-purpose Python interface to the Hierarchical Data Format library,
+ version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
+ amounts of data."""
+
+toolchain = {'name': 'intel', 'version': '2016b'}
+toolchainopts = {'usempi': True}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+hdf5ver = '1.8.18'
+versionsuffix = '-Python-%%(pyver)s-HDF5-%s' % hdf5ver
+
+# to really use mpi enabled hdf5 we now seem to need a configure step
+prebuildopts = ' python setup.py configure --mpi --hdf5=$EBROOTHDF5 && '
+
+dependencies = [
+    ('Python', '3.5.2'),
+    ('HDF5', hdf5ver),
+    ('pkgconfig', '1.1.0', '-Python-%(pyver)s'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/p/pkgconfig/pkgconfig-1.1.0-foss-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/p/pkgconfig/pkgconfig-1.1.0-foss-2016b-Python-3.5.2.eb
@@ -1,0 +1,26 @@
+easyblock = 'PythonPackage'
+
+name = 'pkgconfig'
+version = '1.1.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://github.com/matze/pkgconfig'
+description = """pkgconfig is a Python module to interface with the pkg-config command line tool"""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'usempi': True}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('Python', '3.5.2'),
+    ('pkg-config', '0.29.1'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/'],
+}
+
+moduleclass = 'data'


### PR DESCRIPTION
This is a follow up on the earlier PR #3900 the provides the latest HDF5 versions
1.8.18 and 1.10.0-patch1.  This new PR contains python bindings for Python
3.5 in foss 2016b and Python 2.7 & 3.5 in Intel 2016b