### PR TITLE
libGLU dep for freeglut

### DIFF
--- a/easybuild/easyconfigs/f/freeglut/freeglut-3.0.0-foss-2016a-Mesa-11.2.1.eb
+++ b/easybuild/easyconfigs/f/freeglut/freeglut-3.0.0-foss-2016a-Mesa-11.2.1.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('libXext', '1.3.3'),
     ('libXrandr', '1.5.0'),
     ('libXi', '1.7.6'),
-    ('libGLU', '9.0.0'),
+    ('libGLU', '9.0.0', versionsuffix),
     ('Mesa', mesa_ver),
 ]
 

--- a/easybuild/easyconfigs/f/freeglut/freeglut-3.0.0-foss-2016a-Mesa-11.2.1.eb
+++ b/easybuild/easyconfigs/f/freeglut/freeglut-3.0.0-foss-2016a-Mesa-11.2.1.eb
@@ -21,6 +21,7 @@ dependencies = [
     ('libXext', '1.3.3'),
     ('libXrandr', '1.5.0'),
     ('libXi', '1.7.6'),
+    ('libGLU', '9.0.0'),
     ('Mesa', mesa_ver),
 ]
 

--- a/easybuild/easyconfigs/f/freeglut/freeglut-3.0.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/freeglut/freeglut-3.0.0-foss-2016a.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('libXext', '1.3.3'),
     ('libXrandr', '1.5.0'),
     ('libXi', '1.7.6'),
+    ('libGLU', '9.0.0'),
     ('Mesa', '11.1.2'),
 ]
 

--- a/easybuild/easyconfigs/f/freeglut/freeglut-3.0.0-intel-2016a-Mesa-11.2.1.eb
+++ b/easybuild/easyconfigs/f/freeglut/freeglut-3.0.0-intel-2016a-Mesa-11.2.1.eb
@@ -21,6 +21,7 @@ dependencies = [
     ('libXext', '1.3.3'),
     ('libXrandr', '1.5.0'),
     ('libXi', '1.7.6'),
+    ('libGLU', '9.0.0', versionsuffix),
     ('Mesa', mesa_ver),
 ]
 

--- a/easybuild/easyconfigs/f/freeglut/freeglut-3.0.0-intel-2016a.eb
+++ b/easybuild/easyconfigs/f/freeglut/freeglut-3.0.0-intel-2016a.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('libXext', '1.3.3'),
     ('libXrandr', '1.5.0'),
     ('libXi', '1.7.6'),
+    ('libGLU', '9.0.0'),
     ('Mesa', '11.1.2'),
 ]
 

--- a/easybuild/easyconfigs/f/freeglut/freeglut-3.0.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/f/freeglut/freeglut-3.0.0-intel-2016b.eb
@@ -15,6 +15,7 @@ builddependencies = [('CMake', '3.6.1')]
 
 dependencies = [
     ('X11', '20160819'),
+    ('libGLU', '9.0.0'),
     ('Mesa', '12.0.2'),
 ]
 


### PR DESCRIPTION
Mesa has stopped including glu.h in its newer versions (as stated in their easyconfigs), this causes freeglut to complain when it is not present. Including the libGLU dependency fixed this problem in my case. 