### PR TITLE
build Mono with --with-large-heap=yes

### DIFF
--- a/easybuild/easyconfigs/m/Mono/Mono-4.6.2.7-intel-2016b.eb
+++ b/easybuild/easyconfigs/m/Mono/Mono-4.6.2.7-intel-2016b.eb
@@ -16,4 +16,6 @@ builddependencies = [
     ('gettext', '0.19.8'),
 ]
 
+configopts = "--with-large-heap=yes"
+
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/m/Mono/Mono-4.6.2.7.eb
+++ b/easybuild/easyconfigs/m/Mono/Mono-4.6.2.7.eb
@@ -16,4 +16,6 @@ builddependencies = [
     ('gettext', '0.19.8'),
 ]
 
+configopts = "--with-large-heap=yes"
+
 moduleclass = 'lang'


### PR DESCRIPTION
This is required for memory-intensive Mono applications, see also http://stackoverflow.com/questions/7248980/mono-too-many-heap-sections-increase-maxhincr-or-max-heap-sects-when-app-takes

cc @backelj