### PR TITLE
RASPA2 direct running problem solution

### DIFF
--- a/easybuild/easyconfigs/r/RASPA2/RASPA2-2.0.3-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/r/RASPA2/RASPA2-2.0.3-intel-2016b-Python-2.7.12.eb
@@ -18,6 +18,11 @@ dependencies = [
     ('Python', '2.7.12'),
 ]
 
+to_delete = '%(installdir)s/lib/python%(pyshortver)s/site-packages'
+to_delete += '/RASPA2-%(version)s-py%(pyshortver)s-linux-x86_64.egg'
+to_delete += '/RASPA2/simulations/lib/libraspa2.py*'
+postinstallcmds = ['rm %s' % to_delete]
+
 sanity_check_paths = {
     'files': ['bin/raspa-dir', 'bin/simulate'],
     'dirs': ['lib/python%(pyshortver)s/site-packages']

--- a/easybuild/easyconfigs/r/RASPA2/RASPA2-2.0.3-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/r/RASPA2/RASPA2-2.0.3-intel-2016b-Python-2.7.12.eb
@@ -18,10 +18,8 @@ dependencies = [
     ('Python', '2.7.12'),
 ]
 
-to_delete = '%(installdir)s/lib/python%(pyshortver)s/site-packages'
-to_delete += '/RASPA2-%(version)s-py%(pyshortver)s-linux-x86_64.egg'
-to_delete += '/RASPA2/simulations/lib/libraspa2.py*'
-postinstallcmds = ['rm %s' % to_delete]
+# remove stub loader for libraspa2.so, it causes problems like "invalid ELF header" and is not really needed anyway
+postinstallcmds = ["rm %(installdir)s/lib/python*/site-packages/*.egg/RASPA2/simulations/lib/libraspa2.py*"]
 
 sanity_check_paths = {
     'files': ['bin/raspa-dir', 'bin/simulate'],


### PR DESCRIPTION
libraspa2 stub loader confuses the direct command `simulate`, therefore it is deleted after installation.