### PR TITLE
Remove unnecessary dependency in libmatheval

### DIFF
--- a/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-foss-2015b.eb
+++ b/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-foss-2015b.eb
@@ -16,7 +16,6 @@ source_urls = [GNU_SOURCE]
 dependencies = [
     ('flex', '2.5.39'),
     ('Bison', '3.0.4'),
-    ('byacc', '20150711'),
     ('Guile', '1.8.8'),
 ]
 

--- a/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-intel-2015b.eb
@@ -16,7 +16,6 @@ source_urls = [GNU_SOURCE]
 dependencies = [
     ('flex', '2.5.39'),
     ('Bison', '3.0.4'),
-    ('byacc', '20150711'),
     ('Guile', '1.8.8'),
 ]
 

--- a/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-intel-2016a.eb
@@ -16,7 +16,6 @@ source_urls = [GNU_SOURCE]
 dependencies = [
     ('flex', '2.6.0'),
     ('Bison', '3.0.4'),
-    ('byacc', '20160324'),
     ('Guile', '1.8.8'),
 ]
 

--- a/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-intel-2016b.eb
@@ -16,7 +16,6 @@ source_urls = [GNU_SOURCE]
 dependencies = [
     ('flex', '2.6.0'),
     ('Bison', '3.0.4'),
-    ('byacc', '20160606'),
     ('Guile', '1.8.8'),
 ]
 

--- a/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.8-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.8-goolf-1.4.10.eb
@@ -16,7 +16,6 @@ toolchainopts = {'pic': True}
 dependencies = [
     ('flex', '2.5.35'),
     ('Bison', '2.5'),
-    ('byacc', '20120526'),
     ('Guile', '1.8.8'),
 ]
 

--- a/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.8-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.8-ictce-5.3.0.eb
@@ -16,7 +16,6 @@ toolchainopts = {'pic': True}
 dependencies = [
     ('flex', '2.5.35'),
     ('Bison', '2.5'),
-    ('byacc', '20120526'),
     ('Guile', '1.8.8'),
 ]
 


### PR DESCRIPTION
The `bison` and `byacc` dependencies cover the same ground, only one is necessary.
