### PR TITLE
added easyconfig for PEAR 0.9.8

### DIFF
--- a/easybuild/easyconfigs/p/PEAR/PEAR-0.9.8-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/PEAR/PEAR-0.9.8-foss-2016b.eb
@@ -1,0 +1,29 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+
+easyblock = 'ConfigureMake'
+
+name = 'PEAR'
+version = '0.9.8'
+
+homepage = 'http://sco.h-its.org/exelixis/web/software/pear/'
+description = """PEAR is an ultrafast, memory-efficient and highly accurate pair-end read merger. 
+ It is fully parallelized and can run with as low as just a few kilobytes of memory."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+
+source_urls = ['http://sco.h-its.org/exelixis/web/software/pear/files/']
+sources = ['%(namelower)s-%(version)s.tar.gz']
+
+dependencies = [
+    ('zlib', '1.2.8'),  
+    ('bzip2', '1.0.6'),
+]
+
+parallel = 1
+
+sanity_check_paths = {
+    'files': ['bin/pear'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/p/PEAR/PEAR-0.9.8-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/PEAR/PEAR-0.9.8-foss-2016b.eb
@@ -14,6 +14,8 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 source_urls = ['http://sco.h-its.org/exelixis/web/software/pear/files/']
 sources = ['%(namelower)s-%(version)s.tar.gz']
 
+checksums = ['1ab079a2cea61aee816012966b7ccacd']
+
 dependencies = [
     ('zlib', '1.2.8'),  
     ('bzip2', '1.0.6'),


### PR DESCRIPTION
Starting from version 0.9.8 there is no `-src` suffix for the source files.

Tested also with `--try-software-version=0.9.10` which is the latest version.

Should I add checksums?