### PR TITLE
added CD-HIT 4.6.6

### DIFF
--- a/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.6-foss-2016b.eb
+++ b/easybuild/easyconfigs/c/CD-HIT/CD-HIT-4.6.6-foss-2016b.eb
@@ -1,0 +1,34 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+
+easyblock = 'MakeCp'
+
+name = "CD-HIT"
+version = "4.6.6"
+
+homepage = 'http://weizhong-lab.ucsd.edu/cd-hit/'
+description = """ CD-HIT is a very widely used program for clustering and 
+ comparing protein or nucleotide sequences."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'openmp': True}
+
+source_urls = ['https://github.com/weizhongli/cdhit/archive/']
+sources = ['V%(version)s.tar.gz']
+
+checksums = ['14f61c56b48a81edc8f1b6d9e012fe55']
+
+# make sure compilation flags are passed down (e.g. to enable OpenMP)
+buildopts = ' CC="$CXX" CCFLAGS="$CPPFLAGS $CXXFLAGS"'
+
+# put here the list of generated executables when compiling
+list_of_executables = ["cd-hit", "cd-hit-est", "cd-hit-2d", "cd-hit-est-2d", "cd-hit-div", "cd-hit-454"]
+
+# this is the real EasyBuild line to copy all the executables and perl scripts to "bin"
+files_to_copy = [(list_of_executables, "bin"), (["*.pl"], 'bin'), "README", "doc", "license.txt"]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in list_of_executables],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
Changed `source_url` to archive subdirectory. Files there have no `versionsuffix` which prevents the use of
`--try-software-version`.