### PR TITLE
remove incorrect definition for $ROSETTA3_DB, now (correctly) defined via Rosetta easyblock

### DIFF
--- a/easybuild/easyconfigs/r/Rosetta/Rosetta-2015.31.58019-intel-2015a.eb
+++ b/easybuild/easyconfigs/r/Rosetta/Rosetta-2015.31.58019-intel-2015a.eb
@@ -13,8 +13,4 @@ sources = ['%(namelower)s_src_%(version)s_bundle.tgz']
 
 builddependencies = [('SCons', '2.3.6', '-Python-2.7.9')]
 
-modextravars = {
-    'ROSETTA3_DB': '$root/database',
-}
-
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/r/Rosetta/Rosetta-2016.13.58602-foss-2016a.eb
+++ b/easybuild/easyconfigs/r/Rosetta/Rosetta-2016.13.58602-foss-2016a.eb
@@ -13,8 +13,4 @@ sources = ['%(namelower)s_src_%(version)s_bundle.tgz']
 
 builddependencies = [('SCons', '2.4.1', '-Python-2.7.11')]
 
-modextravars = {
-    'ROSETTA3_DB': '$root/database',
-}
-
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/r/Rosetta/Rosetta-3.7-foss-2016b.eb
+++ b/easybuild/easyconfigs/r/Rosetta/Rosetta-3.7-foss-2016b.eb
@@ -13,8 +13,4 @@ sources = ['%(namelower)s_src_%(version)s_bundle.tgz']
 
 builddependencies = [('SCons', '2.5.0', '-Python-2.7.12')]
 
-modextravars = {
-    'ROSETTA3_DB': '$root/database',
-}
-
 moduleclass = 'bio'


### PR DESCRIPTION
requires ~~https://github.com/hpcugent/easybuild-easyblocks/pull/1092~~