### PR TITLE
{devel}[foss-/intel-2017a,GCCcore-6.3.0] pkg-config: Work around build failure with GCC 6

### DIFF
--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-GCCcore-6.3.0.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'pkg-config'
+version = '0.29.1'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/pkg-config/'
+description = """pkg-config is a helper tool used when compiling applications and libraries. It helps you insert the
+ correct compiler options on the command line so an application can use
+  gcc -o test test.c `pkg-config --libs --cflags glib-2.0`
+ for instance, rather than hard-coding values on where to find glib (or other libraries)."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
+patches = [
+    'pkg-config-%(version)s_gcc-6.patch',
+]
+
+# don't use PAX, it might break.
+tar_config_opts = True
+
+configopts = " --with-internal-glib"
+
+sanity_check_paths = {
+    'files': ['bin/pkg-config'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-GCCcore-6.3.0.eb
@@ -17,6 +17,11 @@ patches = [
     'pkg-config-%(version)s_gcc-6.patch',
 ]
 
+builddependencies = [
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.27', '', True),
+]
+
 # don't use PAX, it might break.
 tar_config_opts = True
 

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-foss-2017a.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-foss-2017a.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'pkg-config'
+version = '0.29.1'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/pkg-config/'
+description = """pkg-config is a helper tool used when compiling applications and libraries. It helps you insert the
+ correct compiler options on the command line so an application can use
+  gcc -o test test.c `pkg-config --libs --cflags glib-2.0`
+ for instance, rather than hard-coding values on where to find glib (or other libraries)."""
+
+toolchain = {'name': 'foss', 'version': '2017a'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
+patches = [
+    'pkg-config-%(version)s_gcc-6.patch',
+]
+
+# don't use PAX, it might break.
+tar_config_opts = True
+
+configopts = " --with-internal-glib"
+
+sanity_check_paths = {
+    'files': ['bin/pkg-config'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1-intel-2017a.eb
@@ -1,0 +1,27 @@
+easyblock = 'ConfigureMake'
+
+name = 'pkg-config'
+version = '0.29.1'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/pkg-config/'
+description = """pkg-config is a helper tool used when compiling applications and libraries. It helps you insert the
+ correct compiler options on the command line so an application can use
+  gcc -o test test.c `pkg-config --libs --cflags glib-2.0`
+ for instance, rather than hard-coding values on where to find glib (or other libraries)."""
+
+toolchain = {'name': 'intel', 'version': '2017a'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://pkg-config.freedesktop.org/releases/']
+
+# don't use PAX, it might break.
+tar_config_opts = True
+
+configopts = " --with-internal-glib"
+
+sanity_check_paths = {
+    'files': ['bin/pkg-config'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1_gcc-6.patch
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.29.1_gcc-6.patch
@@ -1,0 +1,22 @@
+Work around for build failures with GCC 6 backported from upstream glib.
+See https://bugzilla.gnome.org/761550 for details.
+
+diff -Nrup pkg-config-0.29.1.orig/glib/glib/gdate.c pkg-config-0.29.1/glib/glib/gdate.c
+--- pkg-config-0.29.1.orig/glib/glib/gdate.c	2016-01-24 22:51:38.000000000 +0100
++++ pkg-config-0.29.1/glib/glib/gdate.c	2017-02-07 17:34:54.372617599 +0100
+@@ -2439,6 +2439,9 @@ win32_strftime_helper (const GDate     *
+  *
+  * Returns: number of characters written to the buffer, or 0 the buffer was too small
+  */
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wformat-nonliteral"
++
+ gsize     
+ g_date_strftime (gchar       *s, 
+                  gsize        slen, 
+@@ -2549,3 +2552,5 @@ g_date_strftime (gchar       *s,
+   return retval;
+ #endif
+ }
++
++#pragma GCC diagnostic pop


### PR DESCRIPTION
While this isn't needed by anything yet, I'm sure people will run into this rather sooner than later...