### PR TITLE
X11: Add Bison and gettext as build deps

### DIFF
--- a/easybuild/easyconfigs/x/X11/X11-20160819-foss-2015a.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20160819-foss-2015a.eb
@@ -18,6 +18,8 @@ source_urls = [
 
 builddependencies = [
     ('Autotools', '20150215'),
+    ('Bison', '3.0.4'),
+    ('gettext', '0.19.4'),
     ('pkg-config', '0.29.1'),
 ]
 dependencies = [

--- a/easybuild/easyconfigs/x/X11/X11-20160819-foss-2016b.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20160819-foss-2016b.eb
@@ -18,6 +18,8 @@ source_urls = [
 
 builddependencies = [
     ('Autotools', '20150215'),
+    ('Bison', '3.0.4'),
+    ('gettext', '0.19.8'),
     ('pkg-config', '0.29.1'),
 ]
 dependencies = [

--- a/easybuild/easyconfigs/x/X11/X11-20160819-intel-2016b.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20160819-intel-2016b.eb
@@ -18,6 +18,8 @@ source_urls = [
 
 builddependencies = [
     ('Autotools', '20150215'),
+    ('Bison', '3.0.4'),
+    ('gettext', '0.19.8'),
     ('pkg-config', '0.29.1'),
 ]
 dependencies = [


### PR DESCRIPTION
On a fairly minimal system, X11 failed to build due to missing build dependencies:
 - libxkbcommon failed due to missing yacc/Bison
 - libXpm failed due to missing `xgettext` (provided by gettext)

Both `foss` versions have been tested and suffer from the same issue (and the fix has been confirmed to work); the `intel` version has been extrapolated.
