### PR TITLE
libdrm: clean up dependencies

### DIFF
--- a/easybuild/easyconfigs/l/libdrm/libdrm-2.4.70-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/libdrm/libdrm-2.4.70-foss-2016b.eb
@@ -13,8 +13,6 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 
 dependencies = [
     ('X11', '20160819'),
-    ('libpthread-stubs', '0.3'),
-    ('libpciaccess', '0.13.4'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/l/libdrm/libdrm-2.4.70-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libdrm/libdrm-2.4.70-intel-2016b.eb
@@ -13,8 +13,6 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 
 dependencies = [
     ('X11', '20160819'),
-    ('libpthread-stubs', '0.3'),
-    ('libpciaccess', '0.13.4'),
 ]
 
 sanity_check_paths = {


### PR DESCRIPTION
Both `libpthread-stubs` and `libpciaccess` are included as components in `X11`, so we can safely remove them here.