### PR TITLE
{vis}[intel/2016b] Ghostscript 9.20 use external freetype, libpng, jpeg, and zlib (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.20-intel-2016b.eb
+++ b/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.20-intel-2016b.eb
@@ -24,6 +24,9 @@ dependencies = [
     ('LibTIFF', '4.0.6'),
 ]
 
+#Do not use local copies of zlib, jpeg, freetype, and png
+preconfigopts = "mv zlib zlib.no && mv jpeg jpeg.no && mv freetype freetype.no && mv libpng libpng.no &&"
+
 configopts = "--with-system-libtiff --enable-dynamic"
 
 moduleclass = 'tools'


### PR DESCRIPTION
In the `configure`  file the search order is local, system, so bundled linraryes are renamed.