### PR TITLE
{bio}[foss/2016b] RNAz v2.1

### DIFF
--- a/easybuild/easyconfigs/r/RNAz/RNAz-2.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/r/RNAz/RNAz-2.1-foss-2016b.eb
@@ -10,12 +10,10 @@ description = """RNAz is a program for predicting structurally conserved and
 thermodynamically stable RNA secondary structures in multiple sequence alignments."""
 
 toolchain = {'name': 'foss', 'version': '2016b'}
-toolchainopts = {'optarch': True, 'pic': True}
-
-buildopts = 'CFLAGS="-std=gnu89 $CFLAGS"'
+toolchainopts = {'cstd': 'gnu89', 'pic': True}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tbi.univie.ac.at/~wash/%s' % name]
+source_urls = ['http://www.tbi.univie.ac.at/~wash/%(name)s']
 
 sanity_check_paths = {
     'files': ['bin/RNAz'],

--- a/easybuild/easyconfigs/r/RNAz/RNAz-2.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/r/RNAz/RNAz-2.1-foss-2016b.eb
@@ -1,0 +1,25 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+
+easyblock = 'ConfigureMake'
+
+name = 'RNAz'
+version = '2.1'
+
+homepage = 'http://www.tbi.univie.ac.at/~wash/RNAz/'
+description = """RNAz is a program for predicting structurally conserved and
+thermodynamically stable RNA secondary structures in multiple sequence alignments."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+buildopts = 'CFLAGS="-std=gnu89 $CFLAGS"'
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.tbi.univie.ac.at/~wash/%s' % name]
+
+sanity_check_paths = {
+    'files': ['bin/RNAz'],
+    'dirs': []
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
[GCC changed the default C standard from gnu89 to gnu11](https://gcc.gnu.org/gcc-5/changes.html), RNAz needs gnu89, otherwise it fails during the build, see also https://github.com/wash/rnaz/issues/8.

I added the C standard like that: `buildopts = 'CFLAGS="-std=gnu89 $CFLAGS"'`.

@wookietreiber: you mentioned in the issue on RNAz that `-g -O2` should also be added? Compilation now looks like this: `gcc -DHAVE_CONFIG_H -I. -I..   -I/beegfs/easybuild/16.04/software/OpenBLAS/0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1/include -I/beegfs/easybuild/16.04/software/ScaLAPACK/2.0.2-gompi-2016b-OpenBLAS-0.2.18-LAPACK-3.6.1/include -I/beegfs/easybuild/16.04/software/FFTW/3.3.4-gompi-2016b/include  -std=gnu89 -O2 -march=corei7 -fPIC -MT fold_vars.o -MD -MP -MF .deps/fold_vars.Tpo -c -o fold_vars.o fold_vars.c`. Before it looked like this: `gcc -DHAVE_CONFIG_H -I. -I..   -I/beegfs/easybuild/16.04/software/OpenBLAS/0.2.18-GCC-5.4.0-2.26-LAPACK-3.6.1/include -I/beegfs/easybuild/16.04/software/ScaLAPACK/2.0.2-gompi-2016b-OpenBLAS-0.2.18-LAPACK-3.6.1/include -I/beegfs/easybuild/16.04/software/FFTW/3.3.4-gompi-2016b/include  -O2 -march=corei7 -fPIC -MT fold_vars.o -MD -MP -MF .deps/fold_vars.Tpo -c -o fold_vars.o fold_vars.c`. So `-O2` is still there and `-g` wasn't there before?

Also one thing that was in the build log with the existing easyconfig: `environment.py:97 INFO Environment variable CFLAGS set to -O2 -march=corei7 -fPIC (previous value: '-g -O2 -std=gnu89 ')`. So the options are there but get replaced? The commandline for easybuild with the existing easyconfig was: `eb --buildpath=/dev/shm --optarch=march=corei7 --prefix=/beegfs/easybuild/16.04 --try-toolchain=foss,2016b RNAz-2.1-goolf-1.4.10.eb -dr`.