### PR TITLE
get rid of backticks in gettext descriptions, causes problems when packaging with FPM

### DIFF
--- a/easybuild/easyconfigs/g/gettext/gettext-0.18.2-foss-2015b.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.18.2-foss-2015b.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.18.2'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.18.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.18.2-goolf-1.4.10.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.18.2'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.18.2-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.18.2-goolf-1.5.14.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.18.2'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.18.2-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.18.2-ictce-5.2.0.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.18.2'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.18.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.18.2-ictce-5.3.0.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.18.2'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.18.2.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.18.2.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.18.2'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.2-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.2-goolf-1.5.14.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.2'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.2-goolf-1.7.20.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.2'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
  build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
  and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.2-intel-2014.06.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.2-intel-2014.06.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.2'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.2-intel-2014b.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.2-intel-2014b.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.2'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.2-intel-2015a.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.2'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.2-intel-2015b.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.2'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.4-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.4-GCC-4.9.2.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.4'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.4-foss-2015a.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.4-foss-2015a.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.4'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.4-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.4-intel-2015a.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.4'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.4.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.4.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.4'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.6-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.6-GNU-4.9.3-2.25.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.6'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.6-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.6-foss-2016a.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.6'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.6-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.6-gimkl-2.11.5.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.6'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.6-intel-2015b.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.6-intel-2015b.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.6'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.6-intel-2016a.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.6-intel-2016a.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.6'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.6.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.6.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.6'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.7-foss-2015b.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.7-foss-2015b.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.7'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.7-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.7-foss-2016a.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.7'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.7-intel-2016a.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.7-intel-2016a.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.7'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.7.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.7.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.7'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8-GCCcore-4.9.3.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.8'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8-foss-2016.04.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8-foss-2016.04.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.8'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8-foss-2016b.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8-foss-2016b.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.8'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8-intel-2016b.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8-intel-2016b.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.8'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.8'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 


### PR DESCRIPTION
EasyBuild fails to create RPM packages with backticks in the
description. The backticks are not escaped by EasyBuild or fpm.