### PR TITLE
{vis}[GCCcore/6.3.0] Updated X11 bundle and dependencies for GCCcore-6.3.0

### DIFF
--- a/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-GCCcore-6.3.0.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'Autoconf'
+version = '2.69'
+
+homepage = 'http://www.gnu.org/software/autoconf/'
+description = """Autoconf is an extensible package of M4 macros that produce shell scripts
+ to automatically configure software source code packages. These scripts can adapt the
+ packages to many kinds of UNIX-like systems without manual user intervention. Autoconf
+ creates a configuration script for a package from a template file that lists the
+ operating system features that the package can use, in the form of M4 macro calls."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('M4', '1.4.18')]
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.27', '', True)]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["autoconf", "autoheader", "autom4te", "autoreconf", "autoscan",
+                                     "autoupdate", "ifnames"]],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Automake/Automake-1.15-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/a/Automake/Automake-1.15-GCCcore-6.3.0.eb
@@ -1,0 +1,36 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'Automake'
+version = "1.15"
+
+homepage = 'http://www.gnu.org/software/automake/automake.html'
+description = "Automake: GNU Standards-compliant Makefile generator"
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('Autoconf', '2.69')]
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.27', '', True)]
+
+sanity_check_paths = {
+    'files': ['bin/automake', 'bin/aclocal'],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/a/Autotools/Autotools-20150215-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/a/Autotools/Autotools-20150215-GCCcore-6.3.0.eb
@@ -1,0 +1,18 @@
+easyblock = 'Bundle'
+
+name = 'Autotools'
+version = '20150215'  # date of the most recent change
+
+homepage = 'http://autotools.io'
+description = """This bundle collect the standard GNU build tools: Autoconf, Automake and libtool"""
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+
+dependencies = [
+    ('Autoconf', '2.69'),  # 20120424
+    ('Automake', '1.15'),  # 20150105
+    ('libtool', '2.4.6'),  # 20150215
+]
+# Pure bundle -- no need to specify 'binutils' used when building GCCcore toolchain as build dependency
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6-GCCcore-6.3.0.eb
@@ -1,0 +1,18 @@
+name = 'bzip2'
+version = '1.0.6'
+
+homepage = 'http://www.bzip.org/'
+description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
+ compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
+ compressors), whilst being around twice as fast at compression and six times faster at decompression."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.bzip.org/%(version)s']
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.27', '', True)]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/e/expat/expat-2.2.0-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/e/expat/expat-2.2.0-GCCcore-6.3.0.eb
@@ -1,0 +1,19 @@
+easyblock = 'ConfigureMake'
+
+name = 'expat'
+version = '2.2.0'
+
+homepage = 'http://expat.sourceforge.net/'
+description = """Expat is an XML parser library written in C. It is a stream-oriented parser in which an application
+ registers handlers for things the parser might find in the XML document (like start tags)"""
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = [SOURCEFORGE_SOURCE]
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.27', '', True)]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/f/fontconfig/fontconfig-2.12.1-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/f/fontconfig/fontconfig-2.12.1-GCCcore-6.3.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'fontconfig'
+version = '2.12.1'
+
+homepage = 'http://www.freedesktop.org/software/fontconfig'
+description = """Fontconfig is a library designed to provide system-wide font configuration, customization and
+application access."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+
+source_urls = ['http://www.freedesktop.org/software/fontconfig/release/']
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('expat', '2.2.0'),
+    ('freetype', '2.7.1'),
+]
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.27', '', True)]
+
+configopts = '--disable-docs '
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/f/freetype/freetype-2.7.1-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.7.1-GCCcore-6.3.0.eb
@@ -1,0 +1,29 @@
+name = 'freetype'
+version = '2.7.1'
+
+homepage = 'http://freetype.org'
+description = """FreeType 2 is a software font engine that is designed to be small, efficient, highly customizable, and
+ portable while capable of producing high-quality output (glyph images). It can be used in graphics libraries, display
+ servers, font conversion tools, text image generation tools, and many other products as well."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+
+source_urls = [GNU_SAVANNAH_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('libpng', '1.6.28'),
+    ('zlib', '1.2.11'),
+]
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.27', '', True)]
+
+sanity_check_paths = {
+    'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
+              'lib/pkgconfig/freetype2.pc'],
+    'dirs': ['include/freetype2'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-6.3.0.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.8.1'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1-GCCcore-6.3.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'gettext'
+version = '0.19.8.1'
+
+homepage = 'http://www.gnu.org/software/gettext/'
+description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
+and documentation"""
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [
+    ('libxml2', '2.9.4'),
+    ('ncurses', '6.0'),
+]
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.27', '', True)]
+
+configopts = '--without-emacs --with-libxml2-prefix=$EBROOTLIBXML2'
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'gettext'
+version = '0.19.8.1'
+
+homepage = 'http://www.gnu.org/software/gettext/'
+description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
+and documentation"""
+
+# This is a basic stripped down version of gettext without any
+# dependencies on other packages used as initial builddep for XZ
+# It is the first step in the cyclic dependency chain of
+# XZ -> libxml2 -> gettext -> XZ
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [('ncurses', '6.0')]
+
+configopts = '--without-emacs --with-included-libxml --without-xz --without-bzip2'
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1.eb
+++ b/easybuild/easyconfigs/g/gettext/gettext-0.19.8.1.eb
@@ -4,7 +4,7 @@ name = 'gettext'
 version = '0.19.8.1'
 
 homepage = 'http://www.gnu.org/software/gettext/'
-description = """GNU `gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
+description = """GNU 'gettext' is an important step for the GNU Translation Project, as it is an asset on which we may
 build many other steps. This package offers to programmers, translators, and even users, a well integrated set of tools
 and documentation"""
 

--- a/easybuild/easyconfigs/l/libpng/libpng-1.6.28-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/l/libpng/libpng-1.6.28-GCCcore-6.3.0.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'libpng'
+version = '1.6.28'
+
+homepage = 'http://www.libpng.org/pub/png/libpng.html'
+description = "libpng is the official PNG reference library"
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('zlib', '1.2.11')]
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.27', '', True)]
+
+configopts = "--with-pic"
+
+majminver = ''.join(version.split('.')[:2])
+sanity_check_paths = {
+    'files': ['include/pngconf.h', 'include/png.h', 'include/pnglibconf.h', 'lib/libpng.a',
+              'lib/libpng.%s' % SHLIB_EXT, 'lib/libpng%s.a' % majminver, 'lib/libpng%s.%s' % (majminver, SHLIB_EXT)],
+    'dirs': ['bin', 'include/libpng%s' % majminver, 'share/man'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libtool/libtool-2.4.6-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/l/libtool/libtool-2.4.6-GCCcore-6.3.0.eb
@@ -1,0 +1,20 @@
+easyblock = 'ConfigureMake'
+
+name = 'libtool'
+version = '2.4.6'
+
+homepage = 'http://www.gnu.org/software/libtool'
+description = """GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries
+ behind a consistent, portable interface."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [('M4', '1.4.18')]
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.27', '', True)]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxml2/libxml2-2.9.4-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/l/libxml2/libxml2-2.9.4-GCCcore-6.3.0.eb
@@ -1,0 +1,26 @@
+name = 'libxml2'
+version = '2.9.4'
+
+homepage = 'http://xmlsoft.org/'
+description = """Libxml2 is the XML C parser and 
+toolchain developed for the Gnome project
+ (but usable outside of the Gnome platform)."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [
+    'http://xmlsoft.org/sources/',
+    'http://xmlsoft.org/sources/old/'
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('XZ', '5.2.3'),
+]
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.27', '', True)]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-GCCcore-6.3.0.eb
@@ -1,0 +1,39 @@
+easyblock = 'ConfigureMake'
+
+name = 'ncurses'
+version = '6.0'
+
+homepage = 'http://www.gnu.org/software/ncurses/'
+description = """The Ncurses (new curses) library is a free software emulation of curses in System V Release 4.0,
+ and more. It uses Terminfo format, supports pads and color and multiple highlights and forms characters and
+ function-key mapping, and has all the other SYSV-curses enhancements over BSD Curses."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+patches = ['ncurses-%(version)s_gcc-5.patch']
+
+# use same binutils version that was used when building GCCcore toolchain
+builddependencies = [('binutils', '2.27')]
+
+configopts = [
+    # default build
+    '--with-shared --enable-overwrite',
+    # the UTF-8 enabled version (ncursesw)
+    '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
+]
+
+libs = ["form", "menu", "ncurses", "panel"]
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
+                                     "reset", "tabs", "tic", "toe", "tput", "tset"]] +
+             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.%s' % (x, y, SHLIB_EXT) for x in libs for y in ['', 'w']] +
+             ['lib/libncurses++%s.a' % x for x in ['', 'w']],
+    'dirs': ['include', 'include/ncursesw'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/x/X11/X11-20170129-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20170129-GCCcore-6.3.0.eb
@@ -1,0 +1,136 @@
+easyblock = 'Bundle'
+
+name = 'X11'
+version = '20170129'
+
+homepage = 'https://www.x.org'
+description = "The X Window System (X11) is a windowing system for bitmap displays"
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+
+source_urls = [
+    XORG_LIB_SOURCE,
+    XORG_PROTO_SOURCE,
+    'http://xcb.freedesktop.org/dist/',
+    'http://xkbcommon.org/download/',
+    'http://cgit.freedesktop.org/xorg/util/macros/snapshot',
+]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('fontconfig', '2.12.1'),
+    ('freetype', '2.7.1'),
+    ('zlib', '1.2.11'),
+]
+builddependencies = [
+    ('Autotools', '20150215'),
+    ('Bison', '3.0.4'),
+    ('gettext', '0.19.8.1'),
+    ('pkg-config', '0.29.1'),
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.27', '', True),
+]
+
+default_easyblock = 'ConfigureMake'
+
+common_specs = {
+    'sources': [SOURCE_TAR_GZ],
+    'start_dir': '%(name)s-%(version)s',
+}
+components = [
+    ('xorg-macros', '1.19.1', {                             # 2017-01-29
+        'sources': ['util-macros-%(version)s.tar.gz'],
+        'start_dir': 'util-macros-%(version)s',
+    }),
+    ('libpthread-stubs', '0.3', common_specs),              # 2009-10-14
+    ('bigreqsproto', '1.1.2', common_specs),                # 2012-03-23
+    ('compositeproto', '0.4.2', common_specs),              # 2010-10-30
+    ('damageproto', '1.2.1', common_specs),                 # 2010-10-30
+    ('dmxproto', '2.3.1', common_specs),                    # 2011-01-06
+    ('dri2proto', '2.8', common_specs),                     # 2012-07-11
+    ('dri3proto', '1.0', common_specs),                     # 2013-11-01
+    ('fixesproto', '5.0', common_specs),                    # 2011-03-08
+    ('fontsproto', '2.1.3', common_specs),                  # 2014-04-14
+    ('glproto', '1.4.17', common_specs),                    # 2013-12-10
+    ('inputproto', '2.3.2', common_specs),                  # 2016-04-04
+    ('kbproto', '1.0.7', common_specs),                     # 2015-05-01
+    ('presentproto', '1.1', common_specs),                  # 2017-01-26
+    ('randrproto', '1.5.0', common_specs),                  # 2015-05-17
+    ('recordproto', '1.14.2', common_specs),                # 2012-03-23
+    ('renderproto', '0.11.1', common_specs),                # 2010-08-10
+    ('resourceproto', '1.2.0', common_specs),               # 2011-05-28
+    ('scrnsaverproto', '1.2.2', common_specs),              # 2012-03-23
+    ('videoproto', '2.3.3', common_specs),                  # 2016-03-11
+    ('xcmiscproto', '1.2.2', common_specs),                 # 2012-03-23
+    ('xextproto', '7.3.0', common_specs),                   # 2013-12-27
+    ('xf86bigfontproto', '1.2.0', common_specs),            # 2009-08-27
+    ('xf86dgaproto', '2.1', common_specs),                  # 2009-10-01
+    ('xf86driproto', '2.1.1', common_specs),                # 2011-01-06
+    ('xf86vidmodeproto', '2.3.1', common_specs),            # 2011-01-06
+    ('xineramaproto', '1.2.1', common_specs),               # 2011-01-06
+    ('xproto', '7.0.31', common_specs),                     # 2016-09-23
+    ('libXau', '1.0.8', common_specs),                      # 2013-05-24
+    ('libXdmcp', '1.1.2', common_specs),                    # 2015-03-21
+    ('xcb-proto', '1.12', common_specs),                    # 2016-05-18
+    ('libxcb', '1.12', common_specs),                       # 2016-05-18
+    ('xtrans', '1.3.5', common_specs),                      # 2014-09-22
+    ('libxkbcommon', '0.7.1', {                             # 2017-01-18
+        'sources': ['libxkbcommon-%(version)s.tar.xz'],
+        'start_dir': 'libxkbcommon-%(version)s',
+    }),
+    ('libX11', '1.6.4', common_specs),                      # 2016-10-04
+    ('libXext', '1.3.3', common_specs),                     # 2014-07-24
+    ('libFS', '1.0.7', common_specs),                       # 2015-05-01
+    ('libICE', '1.0.9', common_specs),                      # 2014-06-07
+    ('libSM', '1.2.2', common_specs),                       # 2013-09-08
+    ('libXScrnSaver', '1.2.2', common_specs),               # 2012-03-08
+    ('libXt', '1.1.5', common_specs),                       # 2015-05-01
+    ('libXmu', '1.1.2', common_specs),                      # 2013-09-08
+    ('libXpm', '3.5.12', common_specs),                     # 2016-12-15
+    ('libXaw', '1.0.13', common_specs),                     # 2015-05-01
+    ('libXfixes', '5.0.3', common_specs),                   # 2016-10-04
+    ('libXcomposite', '0.4.4', common_specs),               # 2013-01-03
+    ('libXrender', '0.9.10', common_specs),                 # 2016-10-04
+    ('libXcursor', '1.1.14', common_specs),                 # 2013-05-30
+    ('libXdamage', '1.1.4', common_specs),                  # 2013-01-03
+    ('libfontenc', '1.1.3', common_specs),                  # 2015-05-01
+    ('libXfont', '1.5.2', common_specs),                    # 2016-08-31
+    ('libXfont2', '2.0.1', common_specs),                   # 2015-12-11
+    ('libXft', '2.3.2', common_specs),                      # 2014-06-06
+    ('libXi', '1.7.9', common_specs),                       # 2017-01-23
+    ('libXinerama', '1.1.3', common_specs),                 # 2013-05-31
+    ('libXrandr', '1.5.1', common_specs),                   # 2016-10-04
+    ('libXres', '1.0.7', common_specs),                     # 2013-05-31
+    ('libXtst', '1.2.3', common_specs),                     # 2016-10-04
+    ('libXv', '1.0.11', common_specs),                      # 2016-10-04
+    ('libXvMC', '1.0.10', common_specs),                    # 2016-10-04
+    ('libXxf86dga', '1.1.4', common_specs),                 # 2013-05-31
+    ('libXxf86vm', '1.1.4', common_specs),                  # 2015-02-24
+    ('libdmx', '1.1.3', common_specs),                      # 2013-05-28
+    ('libpciaccess', '0.13.4', common_specs),               # 2015-05-01
+    ('libxkbfile', '1.0.9', common_specs),                  # 2015-05-01
+    ('libxshmfence', '1.2', common_specs),                  # 2015-01-02
+    ('xcb-util', '0.4.0', common_specs),                    # 2014-10-15
+    ('xcb-util-image', '0.4.0', common_specs),              # 2014-10-15
+    ('xcb-util-keysyms', '0.4.0', common_specs),            # 2014-10-01
+    ('xcb-util-renderutil', '0.3.9', common_specs),         # 2014-06-13
+    ('xcb-util-wm', '0.4.1', common_specs),                 # 2014-02-19
+    ('xcb-util-cursor', '0.1.3', common_specs),             # 2016-05-12
+]
+
+# Python is required for xcb-proto
+allow_system_deps = [('Python', SYS_PYTHON_VERSION)]
+pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[0:2])
+
+preconfigopts = "if [ ! -f configure ]; then ./autogen.sh; fi && "
+
+# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
+full_sanity_check = True
+
+sanity_check_paths = {
+    'files': ['include/X11/Xlib.h', 'include/X11/Xutil.h'],
+    'dirs': ['include/GL', 'include/X11', 'include/X11/extensions', 'lib',
+             'lib/python%s/site-packages/xcbgen' % pyshortver, 'lib/pkgconfig', 'share/pkgconfig'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.3-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.3-GCCcore-6.3.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'XZ'
+version = '5.2.3'
+
+homepage = 'http://tukaani.org/xz/'
+description = "xz: XZ utilities"
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = ['http://tukaani.org/xz/']
+
+builddependencies = [
+    ('gettext', '0.19.8.1', '', True),
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.27', '', True),
+]
+
+# may become useful in non-x86 archs
+# configopts = ' --disable-assembler '
+
+sanity_check_paths = {
+    'files': ["bin/xz", "bin/lzmainfo"],
+    'dirs': []
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
 - Bumped components and dependencies to the latest available versions (fixes a number of CVEs, see https://lists.x.org/archives/xorg-announce/2016-October/002720.html)
 - Added libXfont2