### PR TITLE
{mpi}[GCC/6.3.0-2.27] OpenMPI: Remove duplicate sources specification

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27.eb
@@ -10,7 +10,7 @@ toolchain = {'name': 'GCC', 'version': '6.3.0-2.27'}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
-sources = ['openmpi-%(version)s.tar.gz']
+
 checksums = ['886698becc5bea8c151c0af2074b8392']
 
 dependencies = [('hwloc', '1.11.5')]


### PR DESCRIPTION
Probably a leftover from some experimentation?