### PR TITLE
fix definition of buildopts/installopts in Cantera easyconfig

### DIFF
--- a/easybuild/easyconfigs/c/Cantera/Cantera-2.2.1-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/c/Cantera/Cantera-2.2.1-intel-2016b-Python-2.7.12.eb
@@ -26,7 +26,7 @@ common_opts = 'env_vars=all CC="$CC" CXX="$CXX" blas_lapack_libs=mkl_rt blas_lap
 common_opts += ' sundials_include=$EBROOTSUNDIALS/include sundials_libdir=$EBROOTSUNDIALS/lib'
 buildopts = 'build ' + common_opts
 runtest = 'test ' + common_opts
-buildopts = 'install ' + common_opts
+installopts = 'install ' + common_opts
 prefix_arg = 'prefix='
 
 modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}


### PR DESCRIPTION
`buildopts` was redefined twice, second time with `scons install`, so that should have been `installopts` being defined

this was mostly harmless for Cantera 2.2.1, but proved not to work with Cantera 2.3.0 (see #4133 & https://github.com/Cantera/cantera/issues/432)