### PR TITLE
add patch for XZ 5.2.2 to include 5.1.2alpha symbols required by 'rpm' command on CentOS 7.x

### DIFF
--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-GCC-5.4.0-2.26.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://tukaani.org/xz/']
 
+patches = ['XZ-%(version)s_compat-libs.patch']
+
 builddependencies = [
     ('Autotools', '20150215'),
     ('gettext', '0.19.8', '', True),

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-GCCcore-4.9.3.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
 sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://tukaani.org/xz/']
 
+patches = ['XZ-%(version)s_compat-libs.patch']
+
 builddependencies = [
     ('Autotools', '20150215'),
     ('gettext', '0.19.8', '', True),

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2015a.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://tukaani.org/xz/']
 
+patches = ['XZ-%(version)s_compat-libs.patch']
+
 builddependencies = [
     ('Autotools', '20150215'),
     ('gettext', '0.19.4', '', True),

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2016.04.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2016.04.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'foss', 'version': '2016.04'}
 sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://tukaani.org/xz/']
 
+patches = ['XZ-%(version)s_compat-libs.patch']
+
 builddependencies = [
     ('Autotools', '20150215'),
     ('gettext', '0.19.8', '', True),

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2016a-gettext-0.19.7.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2016a-gettext-0.19.7.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://tukaani.org/xz/']
 
+patches = ['XZ-%(version)s_compat-libs.patch']
+
 gettext_ver = '0.19.7'
 versionsuffix = '-gettext-%s' % gettext_ver
 

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2016a.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2016a.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://tukaani.org/xz/']
 
+patches = ['XZ-%(version)s_compat-libs.patch']
+
 builddependencies = [
     ('Autotools', '20150215'),
     ('gettext', '0.19.6', '', True),

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-foss-2016b.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://tukaani.org/xz/']
 
+patches = ['XZ-%(version)s_compat-libs.patch']
+
 builddependencies = [
     ('Autotools', '20150215'),
     ('gettext', '0.19.8', '', True),

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-goolf-1.4.10.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://tukaani.org/xz/']
 
+patches = ['XZ-%(version)s_compat-libs.patch']
+
 builddependencies = [
     ('Autotools', '20150215', '', ('GCC', '4.7.2')),
     ('gettext', '0.18.2', '', True),

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-ictce-5.3.0.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://tukaani.org/xz/']
 
+patches = ['XZ-%(version)s_compat-libs.patch']
+
 builddependencies = [
     ('Autotools', '20150215'),
     ('gettext', '0.18.2', '', True),

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-intel-2016a-gettext-0.19.7.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-intel-2016a-gettext-0.19.7.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://tukaani.org/xz/']
 
+patches = ['XZ-%(version)s_compat-libs.patch']
+
 gettext_ver = '0.19.7'
 versionsuffix = '-gettext-%s' % gettext_ver
 

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-intel-2016a.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://tukaani.org/xz/']
 
+patches = ['XZ-%(version)s_compat-libs.patch']
+
 builddependencies = [
     ('Autotools', '20150215'),
     ('gettext', '0.19.6', '', True),

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2-intel-2016b.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 sources = [SOURCELOWER_TAR_BZ2]
 source_urls = ['http://tukaani.org/xz/']
 
+patches = ['XZ-%(version)s_compat-libs.patch']
+
 builddependencies = [
     ('Autotools', '20150215'),
     ('gettext', '0.19.8', '', True),

--- a/easybuild/easyconfigs/x/XZ/XZ-5.2.2_compat-libs.patch
+++ b/easybuild/easyconfigs/x/XZ/XZ-5.2.2_compat-libs.patch
@@ -1,0 +1,27 @@
+include two 5.1.2aplha symbols that were included in XZ 5.1.2alpha which are required by the 'rpm' command on CentOS 7.x
+see also https://github.com/hpcugent/easybuild-easyconfigs/issues/4036
+original patch: xz-5.2.2-compat-libs.patch, cfr. https://git.centos.org/patch/rpms!xz.git/3f035cee1da9f864609885e5ef2a1be77cd37eee
+
+--- src/liblzma/liblzma.map.orig	2015-09-29 12:57:36.000000000 +0200
++++ src/liblzma/liblzma.map	2017-02-22 11:10:33.432868185 +0100
+@@ -95,7 +95,13 @@
+ 	lzma_vli_size;
+ };
+ 
+-XZ_5.2 {
++XZ_5.1.2alpha {
++global:
++   lzma_stream_encoder_mt;
++   lzma_stream_encoder_mt_memusage;
++} XZ_5.0;
++
++XZ_5.2.2 {
+ global:
+ 	lzma_block_uncomp_encode;
+ 	lzma_cputhreads;
+@@ -105,4 +111,4 @@
+ 
+ local:
+ 	*;
+-} XZ_5.0;
++} XZ_5.1.2alpha;


### PR DESCRIPTION
fix for #4036

cc @verdurin, @hajgato: please test whether this also fixes the problem for you?