### PR TITLE
fix hardcoded paths in OrthoMCL 1.4 installation

### DIFF
--- a/easybuild/easyconfigs/o/OrthoMCL/OrthoMCL-1.4-intel-2016b-Perl-5.24.0.eb
+++ b/easybuild/easyconfigs/o/OrthoMCL/OrthoMCL-1.4-intel-2016b-Perl-5.24.0.eb
@@ -19,18 +19,28 @@ dependencies = [
     ('Perl', '5.24.0'),
     ('MCL', '%s.%s' % (mcl_majver, mcl_minver)),
     ('BioPerl', '1.7.1', versionsuffix),
+    ('BLAST', '2.2.26', '-Linux_x86_64', True),
 ]
 
 start_dir = 'ORTHOMCLV%(version)s'
 
-sanity_check_paths = {
-    'files': ['orthomcl_module.pm', 'orthomcl.pl', 'README'],
-    'dirs': ['sample_data'],
-}
+# fix hardcoded paths
+postinstallcmds = [
+    'sed -i"" "s@/usr/bin/perl@$EBROOTPERL/bin/perl@g" %(installdir)s/orthomcl.pl',
+    'sed -i"" "s@\\"/.*blastall\\";@\\"$EBROOTBLAST/bin/blastall\\";@g" %(installdir)s/orthomcl_module.pm',
+    'sed -i"" "s@\\"/.*formatdb\\";@\\"$EBROOTBLAST/bin/formatdb\\";@g" %(installdir)s/orthomcl_module.pm',
+    'sed -i"" "s@\\"/.*mcl\\";@\\"$EBROOTMCL/bin/mcl\\";@g" %(installdir)s/orthomcl_module.pm',
+    'sed -i"" "s@\\"/.*ORTHOMCL.*%(version)s/\\";@\\"\\$ENV{\'PWD\'}/\\";@g" %(installdir)s/orthomcl_module.pm',
+]
 
 modextrapaths = {
     'PATH': '',
     'PERL5LIB': '',
+}
+
+sanity_check_paths = {
+    'files': ['orthomcl_module.pm', 'orthomcl.pl', 'README'],
+    'dirs': ['sample_data'],
 }
 
 sanity_check_commands = [

--- a/easybuild/easyconfigs/o/OrthoMCL/OrthoMCL-1.4-intel-2016b-Perl-5.24.0.eb
+++ b/easybuild/easyconfigs/o/OrthoMCL/OrthoMCL-1.4-intel-2016b-Perl-5.24.0.eb
@@ -29,7 +29,7 @@ postinstallcmds = [
     'sed -i"" "s@/usr/bin/perl@$EBROOTPERL/bin/perl@g" %(installdir)s/orthomcl.pl',
     'sed -i"" "s@/.*blastall@$EBROOTBLAST/bin/blastall@g" %(installdir)s/orthomcl_module.pm',
     'sed -i"" "s@/.*formatdb@$EBROOTBLAST/bin/formatdb@g" %(installdir)s/orthomcl_module.pm',
-    'sed -i"" "s@/.*\(mcl.;\)@$EBROOTMCL/bin/\\1@g" %(installdir)s/orthomcl_module.pm',
+    'sed -i"" "s@/.*/mcl@$EBROOTMCL/bin/mcl@g" %(installdir)s/orthomcl_module.pm',
     'sed -i"" "s@/.*ORTHOMCL.*%(version)s/@\\$ENV{\'PWD\'}/@g" %(installdir)s/orthomcl_module.pm',
 ]
 

--- a/easybuild/easyconfigs/o/OrthoMCL/OrthoMCL-1.4-intel-2016b-Perl-5.24.0.eb
+++ b/easybuild/easyconfigs/o/OrthoMCL/OrthoMCL-1.4-intel-2016b-Perl-5.24.0.eb
@@ -27,10 +27,10 @@ start_dir = 'ORTHOMCLV%(version)s'
 # fix hardcoded paths
 postinstallcmds = [
     'sed -i"" "s@/usr/bin/perl@$EBROOTPERL/bin/perl@g" %(installdir)s/orthomcl.pl',
-    'sed -i"" "s@\\"/.*blastall\\";@\\"$EBROOTBLAST/bin/blastall\\";@g" %(installdir)s/orthomcl_module.pm',
-    'sed -i"" "s@\\"/.*formatdb\\";@\\"$EBROOTBLAST/bin/formatdb\\";@g" %(installdir)s/orthomcl_module.pm',
-    'sed -i"" "s@\\"/.*mcl\\";@\\"$EBROOTMCL/bin/mcl\\";@g" %(installdir)s/orthomcl_module.pm',
-    'sed -i"" "s@\\"/.*ORTHOMCL.*%(version)s/\\";@\\"\\$ENV{\'PWD\'}/\\";@g" %(installdir)s/orthomcl_module.pm',
+    'sed -i"" "s@/.*blastall@$EBROOTBLAST/bin/blastall@g" %(installdir)s/orthomcl_module.pm',
+    'sed -i"" "s@/.*formatdb@$EBROOTBLAST/bin/formatdb@g" %(installdir)s/orthomcl_module.pm',
+    'sed -i"" "s@/.*\(mcl.;\)@$EBROOTMCL/bin/\\1@g" %(installdir)s/orthomcl_module.pm',
+    'sed -i"" "s@/.*ORTHOMCL.*%(version)s/@\\$ENV{\'PWD\'}/@g" %(installdir)s/orthomcl_module.pm',
 ]
 
 modextrapaths = {


### PR DESCRIPTION
follow-up for #4134 and #4182

This is getting a bit messy, but since this is an old unsupported version of OrthoMCL, I won't spend much more time on this...

This version works, with the following workflow:

```
# use --read-only-installdir to make very sure that OrthoMCL doesn't happy throw stuff in the installdir...
$ eb OrthoMCL-1.4-intel-2016b-Perl-5.24.0.eb -dfr --read-only-installdir

$ module load OrthoMCL/1.4-intel-2016b-Perl-5.24.0

# sample_data directory *must* be in the current working directory, that's where the patched OrthoMCL installation will look for the input files
$ cp -a $EBROOTORTHOMCL/sample_data .
$ orthomcl.pl --mode 1 --fa_files Ath.fa,Sce.fa
```