### PR TITLE
bump VTK to 7.1.0 in meshio easyconfig for compatibility with Yade 2017.01a

### DIFF
--- a/easybuild/easyconfigs/m/meshio/meshio-1.7.1-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/m/meshio/meshio-1.7.1-intel-2016b-Python-2.7.12.eb
@@ -15,7 +15,7 @@ sources = [SOURCE_TAR_GZ]
 dependencies = [
     ('Python', '2.7.12'),  # includes numpy
     ('h5py', '2.6.0', versionsuffix + '-HDF5-1.8.18'),
-    ('VTK', '6.3.0', versionsuffix),
+    ('VTK', '7.1.0', versionsuffix),
 ]
 
 exts_defaultclass = 'PythonPackage'


### PR DESCRIPTION
follow-up for #4178, cfr. #4187 

depends on #4186