### PR TITLE
add patch for Boost v1.61-1.63 to fix problem with make_array/array_wrapper in boost serialization library

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.61.0-intel-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.61.0-intel-2016a-Python-2.7.11.eb
@@ -11,6 +11,8 @@ toolchainopts = {'pic': True, 'usempi': True}
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 
+patches = ['Boost-1.61_fix-make_array-icpc.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.8'),

--- a/easybuild/easyconfigs/b/Boost/Boost-1.61.0-intel-2016a.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.61.0-intel-2016a.eb
@@ -10,6 +10,8 @@ toolchainopts = {'pic': True, 'usempi': True}
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 
+patches = ['Boost-1.61_fix-make_array-icpc.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.8'),

--- a/easybuild/easyconfigs/b/Boost/Boost-1.61.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.61.0-intel-2016b-Python-2.7.12.eb
@@ -11,6 +11,8 @@ toolchainopts = {'pic': True, 'usempi': True}
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 
+patches = ['Boost-1.61_fix-make_array-icpc.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.8'),

--- a/easybuild/easyconfigs/b/Boost/Boost-1.61.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.61.0-intel-2016b.eb
@@ -10,6 +10,8 @@ toolchainopts = {'pic': True, 'usempi': True}
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 
+patches = ['Boost-1.61_fix-make_array-icpc.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.8'),

--- a/easybuild/easyconfigs/b/Boost/Boost-1.61_fix-make_array-icpc.patch
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.61_fix-make_array-icpc.patch
@@ -1,0 +1,14 @@
+fix bug with make_array/array_wrapper introduced in Boost v1.61; cfr.:
+* https://svn.boost.org/trac/boost/ticket/12516
+* https://github.com/boostorg/serialization/pull/46 (source of this patch)
+--- boost_1_63_0/boost/serialization/array.hpp.orig	2017-02-23 10:38:00.487842679 +0100
++++ boost_1_63_0/boost/serialization/array.hpp	2017-02-23 10:38:13.918969000 +0100
+@@ -44,7 +44,7 @@
+     // note: I would like to make the copy constructor private but this breaks
+     // make_array.  So I try to make make_array a friend - but that doesn't
+     // build.  Need a C++ guru to explain this!
+-    template<class S>
++    template<class T, class S>
+     friend const boost::serialization::array_wrapper<T> make_array( T* t, S s);
+ 
+     array_wrapper(const array_wrapper & rhs) :

--- a/easybuild/easyconfigs/b/Boost/Boost-1.62.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.62.0-intel-2016b-Python-2.7.12.eb
@@ -11,6 +11,8 @@ toolchainopts = {'pic': True, 'usempi': True}
 source_urls = [SOURCEFORGE_SOURCE]
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 
+patches = ['Boost-1.61_fix-make_array-icpc.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.8'),

--- a/easybuild/easyconfigs/b/Boost/Boost-1.63.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.63.0-intel-2016b-Python-2.7.12.eb
@@ -11,6 +11,8 @@ toolchainopts = {'usempi': True, 'pic': True}
 sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
 source_urls = ['https://sourceforge.net/projects/%(namelower)s/files/%(namelower)s/%(version)s']
 
+patches = ['Boost-1.61_fix-make_array-icpc.patch']
+
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.8'),


### PR DESCRIPTION
This fixes a problem that manifests itself with Yade, as follows:

```
$ ml Yade/2016.06a-intel-2016b-Python-2.7.12 

$ python -c "import yade"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/prefix/software/Yade/2016.06a-intel-2016b-Python-2.7.12/lib64/yade-2016.06a/py/yade/__init__.py", line 65, in <module>
    import boot
ImportError: /prefix/software/Yade/2016.06a-intel-2016b-Python-2.7.12/lib64/yade-2016.06a/libyade.so: undefined symbol: _ZN5boost13serialization10make_arrayImEEKNS0_13array_wrapperIN5Eigen6MatrixIdLi2ELi1ELi0ELi2ELi1EEEEEPS5_T_
```

The problem does not occur if Boost & Yade were built with GCC rather than Intel compilers.