### PR TITLE
{devel}[*] CMake: Set CMAKE_PREFIX_PATH to ncurses install directory

### DIFF
--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.0-intel-2015b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2015b'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '5.9'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.1-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.1-GCC-4.9.2.eb
@@ -12,10 +12,12 @@ toolchain = {'name': 'GCC', 'version': '4.9.2'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
+configopts = '-- -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
+
 dependencies = [('ncurses', '5.9')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.1-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.1-GCCcore-4.9.3.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 
 builddependencies = [('binutils', '2.25')]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -26,7 +26,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.1-foss-2015a.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '5.9'),
@@ -21,7 +21,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.1-foss-2015b.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.1-foss-2015b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'foss', 'version': '2015b'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '5.9'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.1-foss-2016a.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.1-intel-2015b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2015b'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '5.9'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.1-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.1-intel-2016.02-GCC-4.9.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake, 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.1-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.1-intel-2016.02-GCC-4.9.eb
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['ccmake, 'cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.1-intel-2016a.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.1-iomkl-2016.07.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.1-iomkl-2016.07.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'iomkl', 'version': '2016.07'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.1-iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.1-iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'iomkl', 'version': '2016.09-GCC-4.9.3-2.25'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.3-foss-2016a.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.3-foss-2016a.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.3-foss-2016b.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.3-foss-2016b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.3-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.3-gimkl-2.11.5.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'gimkl', 'version': '2.11.5'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '5.9'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.3-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.3-goolf-1.7.20.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'goolf', 'version': '1.7.20'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '5.9'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.3-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.3-ictce-7.3.5.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'ictce', 'version': '7.3.5'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '5.9'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.4.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.4.3-intel-2016a.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.5.0-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.5.0-CrayGNU-2015.11.eb
@@ -13,10 +13,12 @@ toolchain = {'name': 'CrayGNU', 'version': '2015.11'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
+configopts = '-- -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
+
 dependencies = [('ncurses', '5.9')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.5.0-CrayGNU-2016.03.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.5.0-CrayGNU-2016.03.eb
@@ -13,10 +13,12 @@ toolchain = {'name': 'CrayGNU', 'version': '2016.03'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
+configopts = '-- -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
+
 dependencies = [('ncurses', '6.0')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.5.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.5.1-intel-2016a.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.5.2-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.5.2-GCC-4.9.3-2.25.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0', '', ('GCCcore', '4.9.3')),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.5.2-foss-2016a.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.5.2-foss-2016a.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.5.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.5.2-foss-2016b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.5.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.5.2-goolf-1.7.20.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'goolf', 'version': '1.7.20'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '5.9'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.5.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.5.2-intel-2016a.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2016a'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.5.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.5.2-intel-2016b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.5.2.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.5.2.eb
@@ -12,10 +12,12 @@ toolchain = {'name': 'dummy', 'version': ''}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
+configopts = '-- -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
+
 dependencies = [('ncurses', '6.0')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.6.1-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.6.1-GCC-5.4.0-2.26.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.6.1-GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.6.1-GCCcore-4.9.3.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '4.9.3'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 builddependencies = [
     ('binutils', '2.25'),
@@ -28,7 +28,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.6.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.6.1-foss-2016b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.6.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.6.1-intel-2016b.eb
@@ -14,7 +14,7 @@ sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['%(name)s-%(version)s-use-gnu11.patch']
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -26,7 +26,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.6.2-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.6.2-GCCcore-5.4.0.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '5.4.0'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 builddependencies = [
     ('binutils', '2.26'),
@@ -29,7 +29,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.6.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.6.2-foss-2016b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.6.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.6.2-intel-2016b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.7.1-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.7.1-GCCcore-5.4.0.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'GCCcore', 'version': '5.4.0'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 builddependencies = [
     ('binutils', '2.26'),
@@ -29,7 +29,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.7.1-GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.7.1-GCCcore-6.2.0.eb
@@ -11,7 +11,7 @@ toolchain = {'name': 'GCCcore', 'version': '6.2.0'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 builddependencies = [
     ('binutils', '2.27'),
@@ -28,7 +28,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.7.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.7.1-foss-2016b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.7.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.7.1-intel-2016b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 

--- a/easybuild/easyconfigs/c/CMake/CMake-3.7.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.7.2-intel-2016b.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
 
-configopts = '-- -DCMAKE_USE_OPENSSL=1'
+configopts = '-- -DCMAKE_USE_OPENSSL=1 -DCMAKE_PREFIX_PATH=$EBROOTNCURSES'
 
 dependencies = [
     ('ncurses', '6.0'),
@@ -24,7 +24,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 sanity_check_paths = {
-    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'files': ["bin/%s" % x for x in ['ccmake', 'cmake', 'cpack', 'ctest']],
     'dirs': [],
 }
 


### PR DESCRIPTION
Also, include ccmake in sanity check.

This fixes https://github.com/hpcugent/easybuild-easyconfigs/issues/4171 for 28 configurations (2016 toolchains).  Fixing the remaining 64 configurations is left as an exercise for someone who wants to (re-)install CMake with older toolchains.
