### PR TITLE
Switch to lowopt=True for libxc v2.2.* and v3.*

### DIFF
--- a/easybuild/easyconfigs/l/libxc/libxc-2.0.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.0.1-goolf-1.4.10.eb
@@ -11,7 +11,8 @@ sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
-toolchainopts = {'opt': True}
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared'
 

--- a/easybuild/easyconfigs/l/libxc/libxc-2.0.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.0.1-ictce-5.3.0.eb
@@ -11,7 +11,8 @@ sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
-toolchainopts = {'opt': True}
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared'
 

--- a/easybuild/easyconfigs/l/libxc/libxc-2.0.1-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.0.1-ictce-5.5.0.eb
@@ -8,7 +8,8 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
-toolchainopts = {'opt': True}
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.0.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.0.1-intel-2014b.eb
@@ -8,7 +8,8 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2014b'}
-toolchainopts = {'opt': True}
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.0.2-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.0.2-goolf-1.4.10.eb
@@ -11,7 +11,8 @@ sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
-toolchainopts = {'opt': True}
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 configopts = 'FC="$F77" FCFLAGS="$FFLAGS" FCCPP="/lib/cpp -ansi" --enable-shared'
 

--- a/easybuild/easyconfigs/l/libxc/libxc-2.0.2-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.0.2-ictce-5.3.0.eb
@@ -11,7 +11,8 @@ sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
-toolchainopts = {'opt': True}
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared  --enable-fortran'
 

--- a/easybuild/easyconfigs/l/libxc/libxc-2.0.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.0.3-goolf-1.4.10.eb
@@ -11,7 +11,8 @@ sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
-toolchainopts = {'opt': True}
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 configopts = 'FC="$F77" FCFLAGS="$FFLAGS" FCCPP="/lib/cpp -ansi" --enable-shared'
 

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.0-intel-2014b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.0-intel-2014b.eb
@@ -9,7 +9,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
 
 toolchain = {'name': 'intel', 'version': '2014b'}
 # Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
-toolchainopts = {'opt': False, 'lowopt': True}
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.0-intel-2014b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.0-intel-2014b.eb
@@ -8,6 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2014b'}
+# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
 toolchainopts = {'opt': False, 'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.0-intel-2014b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.0-intel-2014b.eb
@@ -8,7 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2014b'}
-# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.0-intel-2014b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.0-intel-2014b.eb
@@ -8,7 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2014b'}
-toolchainopts = {'opt': True}
+toolchainopts = {'opt': False, 'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.1-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.1-CrayGNU-2015.06.eb
@@ -8,7 +8,8 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'CrayGNU', 'version': '2015.06'}
-toolchainopts = {'opt': True}
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.1-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.1-CrayGNU-2015.11.eb
@@ -8,7 +8,8 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'CrayGNU', 'version': '2015.11'}
-toolchainopts = {'opt': True}
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.1-intel-2015a.eb
@@ -8,7 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
-# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.1-intel-2015a.eb
@@ -9,7 +9,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
 
 toolchain = {'name': 'intel', 'version': '2015a'}
 # Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
-toolchainopts = {'opt': False, 'lowopt': True}
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.1-intel-2015a.eb
@@ -8,7 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
-toolchainopts = {'opt': True}
+toolchainopts = {'opt': False, 'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.1-intel-2015a.eb
@@ -8,6 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
+# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
 toolchainopts = {'opt': False, 'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.2-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.2-CrayGNU-2015.11.eb
@@ -9,7 +9,8 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'CrayGNU', 'version': '2015.11'}
-toolchainopts = {'opt': True}
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.2-foss-2015b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.2-foss-2015b.eb
@@ -8,7 +8,8 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'foss', 'version': '2015b'}
-toolchainopts = {'opt': True}
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015a.eb
@@ -8,7 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
-# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015a.eb
@@ -9,7 +9,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
 
 toolchain = {'name': 'intel', 'version': '2015a'}
 # Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
-toolchainopts = {'opt': False, 'lowopt': True}
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015a.eb
@@ -8,7 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
-toolchainopts = {'opt': True}
+toolchainopts = {'opt': False, 'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015a.eb
@@ -8,6 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
+# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
 toolchainopts = {'opt': False, 'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015b.eb
@@ -8,7 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2015b'}
-# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015b.eb
@@ -9,7 +9,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
 
 toolchain = {'name': 'intel', 'version': '2015b'}
 # Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
-toolchainopts = {'opt': False, 'lowopt': True}
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015b.eb
@@ -8,7 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2015b'}
-toolchainopts = {'opt': True}
+toolchainopts = {'opt': False, 'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.2-intel-2015b.eb
@@ -8,6 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2015b'}
+# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
 toolchainopts = {'opt': False, 'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-foss-2016b.eb
@@ -8,6 +8,8 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'foss', 'version': '2016b'}
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016a.eb
@@ -8,6 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2016a'}
+# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
 toolchainopts = {'opt': False, 'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016a.eb
@@ -8,7 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2016a'}
-# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016a.eb
@@ -9,7 +9,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
 
 toolchain = {'name': 'intel', 'version': '2016a'}
 # Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
-toolchainopts = {'opt': False, 'lowopt': True}
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016a.eb
@@ -8,6 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2016a'}
+toolchainopts = {'opt': False, 'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016b.eb
@@ -9,7 +9,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 # Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
-toolchainopts = {'opt': False, 'lowopt': True}
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016b.eb
@@ -8,7 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
-# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016b.eb
@@ -8,6 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
+# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
 toolchainopts = {'opt': False, 'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-2.2.3-intel-2016b.eb
@@ -8,6 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
+toolchainopts = {'opt': False, 'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2016a.eb
@@ -8,6 +8,8 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2016a'}
+# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2016a.eb
@@ -8,7 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2016a'}
-# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2016b.eb
@@ -8,7 +8,7 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
-# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
+# Results for some functionals (e.g. mgga_c_tpss) deviate with too aggressive optimization settings.
 toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-intel-2016b.eb
@@ -8,6 +8,8 @@ description = """Libxc is a library of exchange-correlation functionals for dens
  The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
+# Results for some functions (e.g. mgga_c_tpss) change with too aggressive optimization settings.
+toolchainopts = {'lowopt': True}
 
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']


### PR DESCRIPTION
I've noticed that some functionals in LibXC give significantly different results with too much compiler optimization. For example, the energy of a water molecule computed with the TPSS functional changes by 6.5 kJ/mol with lowopt=False. (The problem is in the TPSS correlation functional, somewhere in mgga_c_pkzb.c. I've ruled out numerical integration issues. Similar relative errors appear on every grid point of the tpss_c energy density.)

I can only test with libx-2.2.* and intel compilers at the moment. I'll make similar changes for other versions and compilers when the opportunity arises.

Can someone check if the combination `{'opt': False, 'lowopt': True}` is meaningful for `toolchainopts`? It seems to work for me.