### PR TITLE
fix version (& homepage) in ea-utils easyconfigs

### DIFF
--- a/easybuild/easyconfigs/e/ea-utils/ea-utils-1.04.807-foss-2016a.eb
+++ b/easybuild/easyconfigs/e/ea-utils/ea-utils-1.04.807-foss-2016a.eb
@@ -1,9 +1,9 @@
 easyblock = 'MakeCp'
 
 name = 'ea-utils'
-version = '27a4809'
+version = '1.04.807'
 
-homepage = 'https://code.google.com/p/ea-utils/'
+homepage = 'http://expressionanalysis.github.io/ea-utils/'
 description = """Command-line tools for processing biological sequencing data.
 Barcode demultiplexing, adapter trimming, etc.
 
@@ -11,12 +11,12 @@ Primarily written to support an Illumina based pipeline -
 but should work with any FASTQs."""
 
 toolchain = {'name': 'foss', 'version': '2016a'}
-toolchainopts = {'optarch': True, 'pic': True}
+toolchainopts = {'pic': True}
 
-source_urls = ['https://github.com/ExpressionAnalysis/%(name)s/tarball/master']
-sources = [SOURCE_TGZ]
+source_urls = ['https://github.com/ExpressionAnalysis/ea-utils/archive/']
+sources = ['%(version)s.tar.gz']
 
-checksums = ['45eef4b040f83abe2c9f51d4a7d18271']
+checksums = ['5972b9f712920603b7527f46c0063a09']
 
 start_dir = 'clipper'
 
@@ -38,10 +38,8 @@ files_to_copy = [([
 
 
 sanity_check_paths = {
-    'files': [
-        'bin/fastq-mcf', 'bin/fastq-multx', 'bin/fastq-join', 'bin/fastq-stats', 
-        'bin/fastq-clipper', 'bin/sam-stats', 'bin/varcall'
-    ],
+    'files': ['bin/fastq-mcf', 'bin/fastq-multx', 'bin/fastq-join', 'bin/fastq-stats',
+              'bin/fastq-clipper', 'bin/sam-stats', 'bin/varcall'],
     'dirs': []
 }
 

--- a/easybuild/easyconfigs/e/ea-utils/ea-utils-1.04.807-foss-2016b.eb
+++ b/easybuild/easyconfigs/e/ea-utils/ea-utils-1.04.807-foss-2016b.eb
@@ -1,9 +1,9 @@
 easyblock = 'MakeCp'
 
 name = 'ea-utils'
-version = '27a4809'
+version = '1.04.807'
 
-homepage = 'https://code.google.com/p/ea-utils/'
+homepage = 'http://expressionanalysis.github.io/ea-utils/'
 description = """Command-line tools for processing biological sequencing data.
 Barcode demultiplexing, adapter trimming, etc.
 
@@ -11,12 +11,12 @@ Primarily written to support an Illumina based pipeline -
 but should work with any FASTQs."""
 
 toolchain = {'name': 'foss', 'version': '2016b'}
-toolchainopts = {'optarch': True, 'pic': True}
+toolchainopts = {'pic': True}
 
-source_urls = ['https://github.com/ExpressionAnalysis/%(name)s/tarball/master']
-sources = [SOURCE_TGZ]
+source_urls = ['https://github.com/ExpressionAnalysis/ea-utils/archive/']
+sources = ['%(version)s.tar.gz']
 
-checksums = ['45eef4b040f83abe2c9f51d4a7d18271']
+checksums = ['5972b9f712920603b7527f46c0063a09']
 
 start_dir = 'clipper'
 
@@ -38,10 +38,8 @@ files_to_copy = [([
 
 
 sanity_check_paths = {
-    'files': [
-        'bin/fastq-mcf', 'bin/fastq-multx', 'bin/fastq-join', 'bin/fastq-stats', 
-        'bin/fastq-clipper', 'bin/sam-stats', 'bin/varcall'
-    ],
+    'files': ['bin/fastq-mcf', 'bin/fastq-multx', 'bin/fastq-join', 'bin/fastq-stats',
+              'bin/fastq-clipper', 'bin/sam-stats', 'bin/varcall'],
     'dirs': []
 }
 


### PR DESCRIPTION
when looking into #4204, I noticed that `ea-utils` now available with a proper version on GitHub, so we don't need to use the commit as a version anymore...

Originally contributed by @RvDijk (#3634), and updatd by @verdurin (#3834), so feedback from the both of you would be great since this is a 'breaking' change.

As far as I can tell `ea-utils` is not used as a dependency somewhere else, so changing the version like we do here is acceptable imho (since it won't break other easyconfigs).