### PR TITLE
OpenMPI-2.*: remove --with-threads configure option.

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.0-GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.0-GCC-5.2.0.eb
@@ -14,7 +14,7 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/d
 
 dependencies = [('hwloc', '1.11.3')]
 
-configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-GCC-6.2.0-2.27.eb
@@ -14,7 +14,7 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/d
 
 dependencies = [('hwloc', '1.11.4')]
 
-configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-gcccuda-2016.10.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-gcccuda-2016.10.eb
@@ -14,7 +14,7 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/d
 
 dependencies = [('hwloc', '1.11.4')]
 
-configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--with-cuda=$CUDA_HOME '             # CUDA-aware build; N.B. --disable-dlopen is incompatible

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.1-iccifort-2017.1.132-GCC-5.4.0-2.26.eb
@@ -14,7 +14,7 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/d
 
 dependencies = [('hwloc', '1.11.4')]
 
-configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-2.0.2-GCC-6.3.0-2.27.eb
@@ -15,7 +15,7 @@ checksums = ['886698becc5bea8c151c0af2074b8392']
 
 dependencies = [('hwloc', '1.11.5')]
 
-configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
 configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading


### PR DESCRIPTION
OpenMPI builds now warn they don't know --with-threads.
See OpenMPI commit at
https://github.com/open-mpi/ompi/commit/7a55d49ca78bcc157749c04027515f12b026ec33
sed -i 's/--with-threads=posix //' OpenMPI-2*.eb