### PR TITLE
fix check for Szip library in configure script for netCDF 4.1.3

### DIFF
--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.1.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.1.3-goolf-1.4.10.eb
@@ -5,6 +5,7 @@ homepage = 'http://www.unidata.ucar.edu/software/netcdf/'
 description = """NetCDF (network Common Data Form) is a set of software libraries 
 and machine-independent data formats that support the creation, access, and sharing of array-oriented 
 scientific data."""
+
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 toolchainopts = {'pic': True}
 
@@ -13,6 +14,8 @@ source_urls = [
     'ftp://ftp.unidata.ucar.edu/pub/netcdf/',
     'ftp://ftp.unidata.ucar.edu/pub/netcdf/old',
 ]
+
+patches = ['netCDF-%(version)s_fix-Szip-link-check.patch']
 
 dependencies = [('HDF5', '1.8.7')]
 

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.1.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.1.3-ictce-5.3.0.eb
@@ -15,6 +15,8 @@ source_urls = [
     'ftp://ftp.unidata.ucar.edu/pub/netcdf/old',
 ]
 
+patches = ['netCDF-%(version)s_fix-Szip-link-check.patch']
+
 dependencies = [
     ('HDF5', '1.8.9'),
     ('Doxygen', '1.8.1.1'),

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.1.3_fix-Szip-link-check.patch
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.1.3_fix-Szip-link-check.patch
@@ -1,0 +1,16 @@
+make configure script look for correct Szip library
+see also https://www.unidata.ucar.edu/support/help/MailArchives/netcdf/msg10433.html
+
+author: Kenneth Hoste (HPC-UGent)
+
+--- netcdf-4.1.3/configure.orig	2017-02-28 17:55:46.681729087 +0100
++++ netcdf-4.1.3/configure	2017-02-28 17:55:52.391876458 +0100
+@@ -27142,7 +27142,7 @@
+   return 0;
+ }
+ _ACEOF
+-for ac_lib in '' szip; do
++for ac_lib in '' sz; do
+   if test -z "$ac_lib"; then
+     ac_res="none required"
+   else


### PR DESCRIPTION
I have a use case for an old netCDF version, so I figured out why it didn't build anymore.

Not sure how this ever worked without the patch, maybe because an old Szip library that provides `-lszip` was installed system-wide?