### PR TITLE
fix source spec in PBSuite easyconfig

### DIFF
--- a/easybuild/easyconfigs/p/PBSuite/PBSuite-15.8.24-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/p/PBSuite/PBSuite-15.8.24-intel-2016b-Python-2.7.12.eb
@@ -11,7 +11,7 @@ description = """PBJelly is a highly automated pipeline that aligns long sequenc
 toolchain = {'name': 'intel', 'version': '2016b'}
 
 source_urls = ['https://sourceforge.net/projects/pb-jelly/files/latest/download']
-sources = ['%(name)s_%(version)s.tar.gz']
+sources = ['%(name)s_%(version)s.tgz']
 
 dependencies = [
     ('Python', '2.7.12'),


### PR DESCRIPTION
I managed to screw up the sources spec in #4224 by manually downloading the tarball and my browser automagically renaming the `.tgz` to `.tar.gz`... >_<