### PR TITLE
fix missing PYTHONPATH in ROOT v6.08.02 easyconfig

### DIFF
--- a/easybuild/easyconfigs/r/ROOT/ROOT-v6.08.02-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-v6.08.02-foss-2016a-Python-2.7.11.eb
@@ -42,4 +42,6 @@ configopts += '-Doracle=OFF -Dpgsql=OFF -Dqt=OFF -Dsqlite=OFF '
 configopts += '-Dcxx14=ON '
 configopts += '-Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON '
 
+modextrapaths = {'PYTHONPATH': 'lib/'}
+
 moduleclass = 'data'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-v6.08.02-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-v6.08.02-foss-2016a-Python-2.7.11.eb
@@ -42,6 +42,8 @@ configopts += '-Doracle=OFF -Dpgsql=OFF -Dqt=OFF -Dsqlite=OFF '
 configopts += '-Dcxx14=ON '
 configopts += '-Dunuran=ON -Dtable=ON -Dexplicitlink=ON -Dminuit2=ON '
 
+sanity_check_commands = ["python -c 'import ROOT'"]
+
 modextrapaths = {'PYTHONPATH': 'lib/'}
 
 moduleclass = 'data'


### PR DESCRIPTION
as ROOT compiles a ROOT.py module as well and put it in the lib folder, we need to set the PYTHONPATH as well.