### PR TITLE
enable execution permissions on all Perl scripts in /bin for miRDeep2

### DIFF
--- a/easybuild/easyconfigs/m/miRDeep2/miRDeep2-2.0.0.8-intel-2016b.eb
+++ b/easybuild/easyconfigs/m/miRDeep2/miRDeep2-2.0.0.8-intel-2016b.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('randfold', '2.0.1'),  # also provides SQUID
 ]
 
-install_cmd = "cp -a mirdeep%s/src %%(installdir)s/bin" % altver
+install_cmd = "chmod a+x mirdeep*/src/*.pl && cp -a mirdeep*/src %(installdir)s/bin"
 
 sanity_check_paths = {
     'files': ['bin/make_html.pl'],


### PR DESCRIPTION
follow-up for #4229, two scripts are missing execution rights by default:

```
$ ls -l $EASYBUILD_PREFIX/software/miRDeep2/2.0.0.8-intel-2016b/bin | grep -v 'r-x'
total 1472
-rwxr--r-- 1 vsc40023 vsc40023   5950 Apr 20  2016 get_mirdeep2_precursors.pl
-rwxr--r-- 1 vsc40023 vsc40023    686 Apr 20  2016 mirdeep2bed.pl
```