### PR TITLE
{lang}[intel/2017a] Python v2.7.13 (REVIEW)

### DIFF
--- a/easybuild/easyconfigs/g/GMP/GMP-6.1.2-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/g/GMP/GMP-6.1.2-GCCcore-6.3.0.eb
@@ -1,0 +1,31 @@
+easyblock = 'ConfigureMake'
+
+name = 'GMP'
+version = '6.1.2'
+
+homepage = 'http://gmplib.org/'
+description = """GMP is a free library for arbitrary precision arithmetic,
+operating on signed integers, rational numbers, and floating point numbers. """
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+toolchainopts = {'pic': True, 'precise': True}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = ['http://ftp.gnu.org/gnu/gmp']
+
+builddependencies = [
+    ('binutils', '2.27'),
+    ('Autotools', '20150215'),
+]
+
+# enable C++ interface
+configopts = '--enable-cxx'
+
+runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['lib/libgmp.%s' % SHLIB_EXT, 'include/gmp.h'],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/l/libreadline/libreadline-7.0-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-7.0-GCCcore-6.3.0.eb
@@ -15,8 +15,6 @@ toolchainopts = {'pic': True}
 sources = ['readline-%(version)s.tar.gz']
 source_urls = ['http://ftp.gnu.org/gnu/readline']
 
-patches = ['libreadline-%(version)s-bugfix.patch']
-
 builddependencies = [('binutils', '2.27')]
 dependencies = [('ncurses', '6.0')]
 

--- a/easybuild/easyconfigs/l/libreadline/libreadline-7.0-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-7.0-GCCcore-6.3.0.eb
@@ -1,0 +1,33 @@
+easyblock = 'ConfigureMake'
+
+name = 'libreadline'
+version = '7.0'
+
+homepage = 'http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html'
+description = """The GNU Readline library provides a set of functions for use by applications that
+ allow users to edit command lines as they are typed in. Both Emacs and vi editing modes are available.
+ The Readline library includes additional functions to maintain a list of previously-entered command lines,
+ to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+toolchainopts = {'pic': True}
+
+sources = ['readline-%(version)s.tar.gz']
+source_urls = ['http://ftp.gnu.org/gnu/readline']
+
+patches = ['libreadline-%(version)s-bugfix.patch']
+
+builddependencies = [('binutils', '2.27')]
+dependencies = [('ncurses', '6.0')]
+
+# for the termcap symbols, use EB ncurses
+preconfigopts = "env LDFLAGS='-lncurses'"
+
+sanity_check_paths = {
+    'files': ['lib/libreadline.a', 'lib/libhistory.a'] +
+             ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',
+                                                  'rlstdc.h', 'rltypedefs.h', 'tilde.h']],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/Python/Python-2.7.13-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.13-intel-2017a.eb
@@ -28,7 +28,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
-# package versions updated March 6th 2017
+# package versions updated March 30th 2017
 exts_list = [
     # note: more recent versions of setuptools (v34.x) can not be installed from source anymore,
     # see https://github.com/pypa/setuptools/issues/980
@@ -42,13 +42,14 @@ exts_list = [
     ('nose', '1.3.7', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }),
-    ('numpy', '1.12.0', {
+    ('numpy', '1.12.1', {
         'source_urls': ['https://pypi.python.org/packages/source/n/numpy'],
         'source_tmpl': '%(name)s-%(version)s.zip',
         'patches': ['numpy-1.12.0-mkl.patch'],
     }),
-    ('scipy', '0.18.1', {
+    ('scipy', '0.19.0', {
         'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
+        'source_tmpl': '%(name)s-%(version)s.zip',
     }),
     ('blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
@@ -90,7 +91,7 @@ exts_list = [
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
     }),
-    ('cryptography', '1.7.2', {
+    ('cryptography', '1.8.1', {
         'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
     }),
     ('paramiko', '2.1.2', {
@@ -111,8 +112,9 @@ exts_list = [
     ('mock', '2.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
     }),
-    ('pytz', '2016.10', {
+    ('pytz', '2017.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
+        'source_tmpl': '%(name)s-%(version)s.zip',
     }),
     ('pandas', '0.19.2', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.13-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.13-intel-2017a.eb
@@ -1,0 +1,133 @@
+name = 'Python'
+version = '2.7.13'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+ more effectively."""
+
+toolchain = {'name': 'intel', 'version': '2017a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+    ('libreadline', '7.0'),
+    ('ncurses', '6.0'),
+    ('SQLite', '3.17.0'),
+    ('GMP', '6.1.2'),
+    ('libffi', '3.2.1'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.0.2k'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# order is important!
+# package versions updated March 6th 2017
+exts_list = [
+    # note: more recent versions of setuptools (v34.x) can not be installed from source anymore,
+    # see https://github.com/pypa/setuptools/issues/980
+    ('setuptools', '33.1.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+        'source_tmpl': '%(name)s-%(version)s.zip',
+    }),
+    ('pip', '9.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    ('numpy', '1.12.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy'],
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'patches': ['numpy-1.12.0-mkl.patch'],
+    }),
+    ('scipy', '0.18.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/scipy'],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+    }),
+    ('mpi4py', '2.0.0', {
+        'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+    }),
+    ('paycheck', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+    }),
+    ('pbr', '2.0.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
+    ('Cython', '0.25.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+    }),
+    ('six', '1.10.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+    }),
+    ('dateutil', '2.6.0', {
+        'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+    }),
+    ('deap', '1.0.2', {
+        'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+    }),
+    ('decorator', '4.0.11', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+    }),
+    ('arff', '2.1.0', {
+        'source_tmpl': 'liac-%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+    }),
+    ('cryptography', '1.7.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
+    }),
+    ('paramiko', '2.1.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+    }),
+    ('pyparsing', '2.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+    }),
+    ('netifaces', '0.10.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+    }),
+    ('netaddr', '0.7.19', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('funcsigs', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs'],
+    }),
+    ('mock', '2.0.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
+    }),
+    ('pytz', '2016.10', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
+    }),
+    ('pandas', '0.19.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+    }),
+    ('enum34', '1.1.6', {
+        'modulename': 'enum',
+        'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
+    }),
+    ('bitstring', '3.1.5', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/b/bitstring'],
+    }),
+    ('virtualenv', '15.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/Python/numpy-1.12.0-mkl.patch
+++ b/easybuild/easyconfigs/p/Python/numpy-1.12.0-mkl.patch
@@ -1,0 +1,55 @@
+fix issues in numpy distutils pkg w.r.t. detecting BLAS/LAPACK libraries
+by Kenneth Hoste (HPC-UGent)
+diff -ru numpy-1.12.0.orig/numpy/distutils/fcompiler/__init__.py numpy-1.12.0/numpy/distutils/fcompiler/__init__.py
+--- numpy-1.12.0.orig/numpy/distutils/fcompiler/__init__.py	2017-01-15 11:39:18.000000000 +0100
++++ numpy-1.12.0/numpy/distutils/fcompiler/__init__.py	2017-03-06 17:19:07.262810683 +0100
+@@ -628,7 +628,10 @@
+         return options
+ 
+     def library_option(self, lib):
+-        return "-l" + lib
++        if lib[0]=='-':
++            return lib
++        else:
++            return "-l" + lib
+     def library_dir_option(self, dir):
+         return "-L" + dir
+ 
+diff -ru numpy-1.12.0.orig/numpy/distutils/system_info.py numpy-1.12.0/numpy/distutils/system_info.py
+--- numpy-1.12.0.orig/numpy/distutils/system_info.py	2017-01-15 11:39:18.000000000 +0100
++++ numpy-1.12.0/numpy/distutils/system_info.py	2017-03-06 17:25:38.778143748 +0100
+@@ -675,7 +675,7 @@
+             if is_string(default):
+                 return [default]
+             return default
+-        return [b for b in [a.strip() for a in libs.split(',')] if b]
++        return [b for b in [a.strip().replace(':',',') for a in libs.split(',')] if b]
+ 
+     def get_libraries(self, key='libraries'):
+         if hasattr(self, '_lib_names'):
+@@ -756,6 +756,9 @@
+         # make sure we preserve the order of libs, as it can be important
+         found_dirs, found_libs = [], []
+         for lib in libs:
++            if lib[0] == '-':
++                found_libs.append(lib)
++                continue
+             for lib_dir in lib_dirs:
+                 found_lib = self._find_lib(lib_dir, lib, exts)
+                 if found_lib:
+diff -ru numpy-1.12.0.orig/numpy/distutils/unixccompiler.py numpy-1.12.0/numpy/distutils/unixccompiler.py
+--- numpy-1.12.0.orig/numpy/distutils/unixccompiler.py	2016-12-21 16:46:24.000000000 +0100
++++ numpy-1.12.0/numpy/distutils/unixccompiler.py	2017-03-06 17:19:07.262810683 +0100
+@@ -123,3 +123,12 @@
+ 
+ replace_method(UnixCCompiler, 'create_static_lib',
+                UnixCCompiler_create_static_lib)
++
++def UnixCCompiler_library_option(self, lib):
++    if lib[0]=='-':
++        return lib
++    else:
++        return "-l" + lib
++
++replace_method(UnixCCompiler, 'library_option',
++               UnixCCompiler_library_option)

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.17.0-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.17.0-GCCcore-6.3.0.eb
@@ -1,0 +1,44 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'SQLite'
+version = '3.17.0'
+
+homepage = 'http://www.sqlite.org/'
+description = 'SQLite: SQL Database Engine in a C Library'
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+
+source_urls = ['http://www.sqlite.org/2017/']
+version_minor_etc = version.split('.')[1:]
+version_minor_etc += '0' * (3 - len(version_minor_etc))
+version_str = '%(version_major)s' + ''.join('%02d' % int(x) for x in version_minor_etc)
+sources = ['sqlite-autoconf-%s.tar.gz' % version_str]
+
+builddependencies = [
+    ('binutils', '2.27'),
+]
+
+dependencies = [
+    ('libreadline', '7.0'),
+    ('Tcl', '8.6.6'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/sqlite3', 'include/sqlite3ext.h', 'include/sqlite3.h', 'lib/libsqlite3.a',
+              'lib/libsqlite3.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.6-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.6-GCCcore-6.3.0.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'Tcl'
+version = '8.6.6'
+
+homepage = 'http://www.tcl.tk/'
+description = """Tcl (Tool Command Language) is a very powerful but easy to learn dynamic programming language,
+suitable for a very wide range of uses, including web and desktop applications, networking, administration,
+testing and many more."""
+
+toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
+
+source_urls = ["http://prdownloads.sourceforge.net/tcl"]
+sources = ['%(namelower)s%(version)s-src.tar.gz']
+
+builddependencies = [
+    ('binutils', '2.27'),
+]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+]
+
+configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
+
+runtest = 'test'
+
+start_dir = 'unix'
+
+moduleclass = 'lang'


### PR DESCRIPTION
This Python easyconfig deliberately does not include `Tk` as a dependency (and hence doesn't support 'import Tkinter'), following the example in #4225 by @verdurin, to avoid requiring `X11` as an indirect dependency for `Python`.

I intend to also open a separate PR for a cleaned up version of the `Tkinter` easyconfig in #4225.

TODO:

* [ ] check whether the problem reported in #4049 still occurs (@vanzod: could you check that?)
* ~~[ ] strip out `Tkinter.py` to make it crystal clear that this Python installation doesn't provide it?~~
* ~~[ ] include a sanity check command to ensure that `Tkinter` support isn't added accidentally, e.g. by picking up `Tk` from the OS?~~

In any case, `_tkinter.so` is not a part of the Python installation I obtained using these easyconfigs.

edit: update on TODO: enhanced `Python` easyblock that makes sure that `Tkinter` is there when `Tk` is included as a dependency is done in https://github.com/hpcugent/easybuild-easyblocks/pull/1156; I'm deliberately not enforcing a lack of `Tkinter` when `Tk` is not listed as a dependency, since `Tk` may get picked up from the OS (although unlikely I think) when `--filter-deps=Tk` is used.

#4090 is mostly unrelated to this, so shouldn't be a blocker for this PR.

