### PR TITLE
Correct libjpeg turbo references

### DIFF
--- a/easybuild/easyconfigs/g/GDAL/GDAL-1.10.1-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-1.10.1-intel-2015b-Python-2.7.10.eb
@@ -37,7 +37,7 @@ dependencies = [
 ]
 
 configopts = '--with-expat=$EBROOTEXPAT --with-libz=$EBROOTLIBZ --with-hdf5=$EBROOTHDF5 --with-netcdf=$EBROOTNETCDF'
-configopts += ' --with-xml2=$EBROOTLIBXML2 --with-geos=$EBROOTGEOS/bin/geos-config --with-jpeg=$EBROOTLIBJPEGTURBO'
+configopts += ' --with-xml2=$EBROOTLIBXML2 --with-geos=$EBROOTGEOS/bin/geos-config --with-jpeg=$EBROOTLIBJPEGMINTURBO'
 configopts += ' --with-png=$EBROOTLIBPNG --with-sqlite3=$EBROOTSQLITE --with-jasper=$EBROOTJASPER'
 configopts += ' --with-libtiff=$EBROOTLIBTIFF --with-pcre=$EBROOTPCRE --with-python=$EBROOTPYTHON/bin/python'
 # there is a bug in the build system causing the build with libtool to fail for the moment

--- a/easybuild/easyconfigs/g/GDAL/GDAL-2.1.1-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-2.1.1-intel-2016b-Python-2.7.12.eb
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 configopts = '--with-expat=$EBROOTEXPAT --with-libz=$EBROOTLIBZ --with-hdf5=$EBROOTHDF5 --with-netcdf=$EBROOTNETCDF'
-configopts += ' --with-xml2=$EBROOTLIBXML2 --with-geos=$EBROOTGEOS/bin/geos-config --with-jpeg=$EBROOTLIBJPEGTURBO'
+configopts += ' --with-xml2=$EBROOTLIBXML2 --with-geos=$EBROOTGEOS/bin/geos-config --with-jpeg=$EBROOTLIBJPEGMINTURBO'
 configopts += ' --with-png=$EBROOTLIBPNG --with-sqlite3=$EBROOTSQLITE --with-jasper=$EBROOTJASPER'
 configopts += ' --with-libtiff=$EBROOTLIBTIFF --with-pcre=$EBROOTPCRE --with-python=$EBROOTPYTHON/bin/python'
 # there is a bug in the build system causing the build with libtool to fail for the moment

--- a/easybuild/easyconfigs/g/GDAL/GDAL-2.1.2-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-2.1.2-intel-2016b-Python-2.7.12.eb
@@ -34,7 +34,7 @@ dependencies = [
 ]
 
 configopts = '--with-expat=$EBROOTEXPAT --with-libz=$EBROOTLIBZ --with-hdf5=$EBROOTHDF5 --with-netcdf=$EBROOTNETCDF'
-configopts += ' --with-xml2=$EBROOTLIBXML2 --with-geos=$EBROOTGEOS/bin/geos-config --with-jpeg=$EBROOTLIBJPEGTURBO'
+configopts += ' --with-xml2=$EBROOTLIBXML2 --with-geos=$EBROOTGEOS/bin/geos-config --with-jpeg=$EBROOTLIBJPEGMINTURBO'
 configopts += ' --with-png=$EBROOTLIBPNG --with-sqlite3=$EBROOTSQLITE --with-jasper=$EBROOTJASPER'
 configopts += ' --with-libtiff=$EBROOTLIBTIFF --with-pcre=$EBROOTPCRE --with-python=$EBROOTPYTHON/bin/python'
 # there is a bug in the build system causing the build with libtool to fail for the moment


### PR DESCRIPTION
Replaced $EBROOTLIBJPEGTURBO by $EBROOTLIBJPEGMINTURBO in 3 .eb-files for GDAL, cfr issue #4264.