### PR TITLE
add requests and psycopg2 as dependencies for QGIS

### DIFF
--- a/easybuild/easyconfigs/q/QGIS/QGIS-2.14.12-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/q/QGIS/QGIS-2.14.12-intel-2016b-Python-2.7.12.eb
@@ -32,6 +32,8 @@ dependencies = [
     ('QScintilla', '2.10', versionsuffix),
     ('GSL', '2.3'),
     ('QJson', '0.9.0'),
+    ('requests', '2.13.0', versionsuffix),
+    ('psycopg2', '2.7', versionsuffix),
 ]
 builddependencies = [
     ('CMake', '3.7.2'),


### PR DESCRIPTION
these were missing in #4307, 

depends on ~~#4317~~, ~~#4319~~