### PR TITLE
{bio}[foss/2016b] ViennaRNA 2.3.4 + fixed homepage and source_urls

### DIFF
--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-goolf-1.4.10.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'ViennaRNA'
 version = '2.0.7'
 
-homepage = 'http://www.tbi.univie.ac.at/~ronny/RNA/vrna2.html'
+homepage = 'http://www.tbi.univie.ac.at/RNA/'
 description = """The Vienna RNA Package consists of a C code library and several
 stand-alone programs for the prediction and comparison of RNA secondary structures."""
 
@@ -23,7 +23,7 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 toolchainopts = {'optarch': True, 'pic': True}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tbi.univie.ac.at/~ronny/RNA']
+source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/2_0_x/']
 
 # Prevents the "make install" step from trying to copy to _global_ perl dir and thus make easybuild fail.
 configopts = '--without-perl'

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-goolf-1.4.10.eb
@@ -23,7 +23,7 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 toolchainopts = {'optarch': True, 'pic': True}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/2_0_x/']
+source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/%(version_major)s_%(version_minor)s_x/']
 
 # Prevents the "make install" step from trying to copy to _global_ perl dir and thus make easybuild fail.
 configopts = '--without-perl'

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-ictce-5.3.0.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'ViennaRNA'
 version = '2.0.7'
 
-homepage = 'http://www.tbi.univie.ac.at/~ronny/RNA/vrna2.html'
+homepage = 'http://www.tbi.univie.ac.at/RNA/'
 description = """The Vienna RNA Package consists of a C code library and several
 stand-alone programs for the prediction and comparison of RNA secondary structures."""
 
@@ -24,7 +24,7 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'optarch': True, 'pic': True}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tbi.univie.ac.at/~ronny/RNA']
+source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/2_0_x/']
 
 patches = ['ViennaRNA_ictce-pragma.patch']
 

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.0.7-ictce-5.3.0.eb
@@ -24,7 +24,7 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'optarch': True, 'pic': True}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/2_0_x/']
+source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/%(version_major)s_%(version_minor)s_x/']
 
 patches = ['ViennaRNA_ictce-pragma.patch']
 

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.1.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.1.6-ictce-5.5.0.eb
@@ -23,7 +23,7 @@ toolchain = {'name': 'ictce', 'version': '5.5.0'}
 toolchainopts = {'optarch': True, 'pic': True}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/2_1_x/']
+source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/%(version_major)s_%(version_minor)s_x/']
 
 patches = ['ViennaRNA-2.1.6_ictce.patch']
 

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.1.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.1.6-ictce-5.5.0.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'ViennaRNA'
 version = '2.1.6'
 
-homepage = 'http://www.tbi.univie.ac.at/~ronny/RNA/vrna2.html'
+homepage = 'http://www.tbi.univie.ac.at/RNA/'
 description = """The Vienna RNA Package consists of a C code library and several
 stand-alone programs for the prediction and comparison of RNA secondary structures."""
 
@@ -23,7 +23,7 @@ toolchain = {'name': 'ictce', 'version': '5.5.0'}
 toolchainopts = {'optarch': True, 'pic': True}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tbi.univie.ac.at/~ronny/RNA/packages/source']
+source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/2_1_x/']
 
 patches = ['ViennaRNA-2.1.6_ictce.patch']
 

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.2.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.2.3-intel-2016b.eb
@@ -15,7 +15,7 @@ easyblock = 'ConfigureMake'
 name = 'ViennaRNA'
 version = '2.2.3'
 
-homepage = 'http://www.tbi.univie.ac.at/~ronny/RNA/vrna2.html'
+homepage = 'http://www.tbi.univie.ac.at/RNA/'
 description = """The Vienna RNA Package consists of a C code library and several
 stand-alone programs for the prediction and comparison of RNA secondary structures."""
 
@@ -23,7 +23,7 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'pic': True, 'openmp': True}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tbi.univie.ac.at/~ronny/RNA/packages/source']
+source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/2_2_x/']
 
 patches = ['ViennaRNA-%(version)s_fix-pragma.patch']
 

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.2.3-intel-2016b.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.2.3-intel-2016b.eb
@@ -23,7 +23,7 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'pic': True, 'openmp': True}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/2_2_x/']
+source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/%(version_major)s_%(version_minor)s_x/']
 
 patches = ['ViennaRNA-%(version)s_fix-pragma.patch']
 

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.3.4-foss-2016b.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.3.4-foss-2016b.eb
@@ -13,7 +13,7 @@ toolchain = {'name': 'foss', 'version': '2016b'}
 toolchainopts = {'pic': True}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/2_3_x/']
+source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/%(version_major)s_%(version_minor)s_x/']
 
 checksums = ['c77bff267606d22557a4f867df635822']
 

--- a/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.3.4-foss-2016b.eb
+++ b/easybuild/easyconfigs/v/ViennaRNA/ViennaRNA-2.3.4-foss-2016b.eb
@@ -1,0 +1,36 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+
+easyblock = 'ConfigureMake'
+
+name = 'ViennaRNA'
+version = '2.3.4'
+
+homepage = 'http://www.tbi.univie.ac.at/RNA/'
+description = """The Vienna RNA Package consists of a C code library and several
+stand-alone programs for the prediction and comparison of RNA secondary structures."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.tbi.univie.ac.at/RNA/download/sourcecode/2_3_x/']
+
+checksums = ['c77bff267606d22557a4f867df635822']
+
+# Prevents the "make install" step from trying to copy to _global_ perl dir and thus make easybuild fail.
+configopts = '--without-perl'
+# Alternatively, you may want to use the following to copy the perl-module to a "local" directory
+# Code NOT yet tested, therefor left here for future recycling
+# preconfigopts = 'env PERLPREFIX="/path/where/the/perl/module/shoud/go"'
+
+sanity_check_paths = {
+    'files': ['bin/RNA%s' % x for x in ['fold', 'eval', 'heat', 'pdist', 'distance',
+                                        'inverse', 'plot', 'subopt', 'Lfold', 'cofold',
+                                        'paln', 'duplex', 'alifold', 'plfold', 'up',
+                                        'aliduplex', 'Lalifold', '2Dfold', 'parconv',
+                                        'PKplex', 'plex', 'snoop', 'forester']] +
+    ['bin/Kinfold'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
The homepage of ViennaRNA has changed and the old link has no redirection. Also the source_urls have changed. They now use a different directory for each minor version.