### PR TITLE
{data][goolfc/2016.10] HDF5 1.10.0-patch1

### DIFF
--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-goolfc-2016.10.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-goolfc-2016.10.eb
@@ -1,0 +1,22 @@
+name = 'HDF5'
+version = '1.10.0-patch1'
+
+homepage = 'http://www.hdfgroup.org/HDF5/'
+description = """HDF5 is a unique technology suite that makes possible the management of
+ extremely large and complex data collections."""
+
+toolchain = {'name': 'goolfc', 'version': '2016.10'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['9180ff0ef8dc2ef3f61bd37a7404f295']
+
+buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
+
+dependencies = [
+    ('zlib', '1.2.8'),
+    ('Szip', '2.1'),
+]
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/s/Szip/Szip-2.1-goolfc-2016.10.eb
+++ b/easybuild/easyconfigs/s/Szip/Szip-2.1-goolfc-2016.10.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'Szip'
+version = '2.1'
+
+homepage = 'http://www.hdfgroup.org/doc_resource/SZIP/'
+description = "Szip compression software, providing lossless compression of scientific data"
+
+toolchain = {'name': 'goolfc', 'version': '2016.10'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.hdfgroup.org/ftp/lib-external/szip/%(version)s/src']
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = "--with-pic"
+
+sanity_check_paths = {
+    'files': ["lib/libsz.a", "lib/libsz.%s" % SHLIB_EXT] +
+             ["include/%s" % x for x in ["ricehdf.h", "szip_adpt.h", "szlib.h"]],
+    'dirs': [],
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
HDF5 1.10.0 patch 1 for goolfc 2016.10.  No GPU magic here, just a copy over from foss/2016b.  Includes the Szip dependency. 