### PR TITLE
{bio}[foss/2016b] Circos 0.69-4

### DIFF
--- a/easybuild/easyconfigs/c/Circos/Circos-0.69-4-foss-2016b-Perl-5.24.0.eb
+++ b/easybuild/easyconfigs/c/Circos/Circos-0.69-4-foss-2016b-Perl-5.24.0.eb
@@ -1,0 +1,37 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+
+easyblock = 'Tarball'
+
+name = 'Circos'
+version = '0.69-4'
+
+homepage = 'http://www.circos.ca/'
+description = """Circos is a software package for visualizing data and information.
+ It visualizes data in a circular layout - this makes Circos ideal for exploring
+ relationships between objects or positions."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+
+source_urls = ['http://circos.ca/distribution/']
+sources = [SOURCELOWER_TGZ]
+
+checksums = ['d84a23f03ebcba08671e0108182737b7']
+
+perl = 'Perl'
+perlver = '5.24.0'
+versionsuffix = '-Perl-%(perlver)s'
+dependencies = [
+    (perl, perlver),
+    ('GD', '2.52', versionsuffix),
+]
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': ['lib/%(name)s'],
+}
+
+modextrapaths = {'PERL5LIB': 'lib'}
+
+sanity_check_commands = [('perl', '-e "use Circos"')]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/c/Circos/Circos-0.69-4-foss-2016b-Perl-5.24.0.eb
+++ b/easybuild/easyconfigs/c/Circos/Circos-0.69-4-foss-2016b-Perl-5.24.0.eb
@@ -4,6 +4,7 @@ easyblock = 'Tarball'
 
 name = 'Circos'
 version = '0.69-4'
+versionsuffix = '-Perl-%(perlver)s'
 
 homepage = 'http://www.circos.ca/'
 description = """Circos is a software package for visualizing data and information.
@@ -17,11 +18,8 @@ sources = [SOURCELOWER_TGZ]
 
 checksums = ['d84a23f03ebcba08671e0108182737b7']
 
-perl = 'Perl'
-perlver = '5.24.0'
-versionsuffix = '-Perl-%(perlver)s'
 dependencies = [
-    (perl, perlver),
+    ('Perl', '5.24.0'),
     ('GD', '2.52', versionsuffix),
 ]
 

--- a/easybuild/easyconfigs/g/GD/GD-2.52-foss-2016b-Perl-5.24.0.eb
+++ b/easybuild/easyconfigs/g/GD/GD-2.52-foss-2016b-Perl-5.24.0.eb
@@ -1,0 +1,29 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+
+easyblock = 'PerlModule'
+
+name = 'GD'
+version = '2.52'
+
+homepage = 'http://search.cpan.org/~lds/GD/'
+description = """GD.pm - Interface to Gd Graphics Library"""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+
+source_urls = ['http://cpan.metacpan.org/authors/id/L/LD/LDS/']
+sources = [SOURCE_TAR_GZ]
+
+checksums = ['646a4b5ba587763ed791bad4f2f79e95']
+
+perl = 'Perl'
+perlver = '5.24.0'
+versionsuffix = '-Perl-%(perlver)s'
+
+dependencies = [
+    (perl, perlver),
+    ('libgd', '2.2.3'),
+    ('libpng', '1.6.26'),
+    ('libjpeg-turbo', '1.5.0'),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GD/GD-2.52-foss-2016b-Perl-5.24.0.eb
+++ b/easybuild/easyconfigs/g/GD/GD-2.52-foss-2016b-Perl-5.24.0.eb
@@ -4,8 +4,9 @@ easyblock = 'PerlModule'
 
 name = 'GD'
 version = '2.52'
+versionsuffix = '-Perl-%(perlver)s'
 
-homepage = 'http://search.cpan.org/~lds/GD/'
+homepage = 'http://search.cpan.org/~lds/%(name)s/'
 description = """GD.pm - Interface to Gd Graphics Library"""
 
 toolchain = {'name': 'foss', 'version': '2016b'}
@@ -15,15 +16,16 @@ sources = [SOURCE_TAR_GZ]
 
 checksums = ['646a4b5ba587763ed791bad4f2f79e95']
 
-perl = 'Perl'
-perlver = '5.24.0'
-versionsuffix = '-Perl-%(perlver)s'
-
 dependencies = [
-    (perl, perlver),
+    ('Perl', '5.24.0'),
     ('libgd', '2.2.3'),
     ('libpng', '1.6.26'),
     ('libjpeg-turbo', '1.5.0'),
 ]
+
+sanity_check_paths = {
+    'files': ['bin/bdf2gdfont.pl', 'lib/perl5/site_perl/%(perlver)s/x86_64-linux-thread-multi/%(name)s.pm'],
+    'dirs': ['lib/perl5/site_perl/%(perlver)s/x86_64-linux-thread-multi/%(name)s'],
+}
 
 moduleclass = 'bio'


### PR DESCRIPTION
Circos and GD with toolchain foss-2016b because `--try-toolchain=foss-2016b` on existing EasyConfigs fails.