### PR TITLE
use 'use_fma4' rather than deprecated 'use_fma' easyconfig parameter in FFTW easyconfigs using intel toolchain

### DIFF
--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.5-intel-2016b.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.5-intel-2016b.eb
@@ -15,8 +15,8 @@ source_urls = [homepage]
 # see also http://www.fftw.org/doc/Extended-and-quadruple-precision-in-Fortran.html
 with_quad_prec = False
 
-# compilation fails when configuring with --enable-avx-128-fma
-use_fma = False
+# compilation fails when configuring with --enable-avx-128-fma, Intel compilers do not support FMA4 instructions
+use_fma4 = False
 
 runtest = 'check'
 

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.6-intel-2017a.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.6-intel-2017a.eb
@@ -21,8 +21,8 @@ patches = [
 # http://www.fftw.org/doc/Extended-and-quadruple-precision-in-Fortran.html
 with_quad_prec = False
 
-# compilation fails when configuring with --enable-avx-128-fma
-use_fma = False
+# compilation fails when configuring with --enable-avx-128-fma, Intel compilers do not support FMA4 instructions
+use_fma4 = False
 
 runtest = 'check'
 


### PR DESCRIPTION
requires https://github.com/hpcugent/easybuild-easyblocks/pull/1142