### PR TITLE
SAMtools-1.4-goolf-1.4.10.eb and ncurses-6.0-goolf-1.4.10.eb

### DIFF
--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-goolf-1.4.10.eb
@@ -1,0 +1,38 @@
+# Modified for goolf-1.4.10 by: Daniel Navarro-Gomez, MEEI Bioinformatics Center (MBC) 
+
+easyblock = 'ConfigureMake'
+
+name = 'ncurses'
+version = '6.0'
+
+homepage = 'http://www.gnu.org/software/ncurses/'
+description = """The Ncurses (new curses) library is a free software emulation of curses in System V Release 4.0,
+ and more. It uses Terminfo format, supports pads and color and multiple highlights and forms characters and
+ function-key mapping, and has all the other SYSV-curses enhancements over BSD Curses."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+patches = ['ncurses-%(version)s_gcc-5.patch']
+
+configopts = [
+    # default build
+    '--with-shared --enable-overwrite',
+    # the UTF-8 enabled version (ncursesw)
+    '--with-shared --enable-overwrite --enable-ext-colors --enable-widec --includedir=%(installdir)s/include/ncursesw/'
+]
+
+libs = ["form", "menu", "ncurses", "panel"]
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp", "infotocap", "ncurses%(version_major)s-config",
+                                     "reset", "tabs", "tic", "toe", "tput", "tset"]] +
+             ['lib/lib%s%s.a' % (x, y) for x in libs for y in ['', '_g', 'w', 'w_g']] +
+             ['lib/lib%s%s.so' % (x, y) for x in libs for y in ['', 'w']] +
+             ['lib/libncurses++%s.a' % x for x in ['', 'w']],
+    'dirs': ['include', 'include/ncursesw'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.4-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.4-goolf-1.4.10.eb
@@ -1,0 +1,40 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Robert Schmidt <roschmidt@ohri.ca>, Cedric Laczny <cedric.laczny@uni.lu>, Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# Modified by: Adam Huffman
+# The Francis Crick Institute
+#
+# Modified for version 1.4 by: Kurt Lust, UAntwerpen
+#
+# Modified for goolf-1.4.10 by: Daniel Navarro-Gomez, MEEI Bioinformatics Center (MBC) 
+#
+##
+name = 'SAMtools'
+version = '1.4'
+
+homepage = 'http://www.htslib.org/'
+description = """SAM Tools provide various utilities for manipulating alignments in the SAM format, 
+ including sorting, merging, indexing and generating alignments in a per-position format."""
+
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = ['https://github.com/samtools/%(namelower)s/releases/download/%(version)s']
+sources = [SOURCELOWER_TAR_BZ2]
+
+# The htslib component of SAMtools 1.4 uses zlib, bzip2 and lzma compression.
+# The latter is currently provided by XZ.
+#
+dependencies = [
+    ('ncurses', '6.0'),
+    ('zlib',    '1.2.7'),
+    ('bzip2',   '1.0.6'),
+    ('XZ',      '5.2.2'),
+]
+
+moduleclass = 'bio'


### PR DESCRIPTION
Added SAMtools-1.4-goolf-1.4.10.eb and ncurses-6.0-goolf-1.4.10.eb, the second one is a dependece of the first. By Daniel Navarro-Gomez, MEEI Bioinformatics Center

	new file:   easyconfigs/n/ncurses/ncurses-6.0-goolf-1.4.10.eb
	new file:   easyconfigs/s/SAMtools/SAMtools-1.4-goolf-1.4.10.eb