### PR TITLE
bump X11 to version 20170314 in Mesa 17.0.2 easyconfig

### DIFF
--- a/easybuild/easyconfigs/l/libdrm/libdrm-2.4.76-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/libdrm/libdrm-2.4.76-intel-2017a.eb
@@ -12,7 +12,7 @@ sources = [SOURCELOWER_TAR_GZ]
 toolchain = {'name': 'intel', 'version': '2017a'}
 
 dependencies = [
-    ('X11', '20170129'),
+    ('X11', '20170314'),
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/Mesa/Mesa-17.0.2-intel-2017a.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-17.0.2-intel-2017a.eb
@@ -42,7 +42,7 @@ dependencies = [
     ('nettle', '3.3'),
     ('libdrm', '2.4.76'),
     ('LLVM', '4.0.0'),
-    ('X11', '20170129'),
+    ('X11', '20170314'),
 ]
 
 # GLU is not part anymore of Mesa package!


### PR DESCRIPTION
follow-up for ~~#4416~~, requires ~~#4428~~

triggered by `libpng` version conflict in #4425