### PR TITLE
bump imager extension to 0.40.1 in R 3.3.3 easyconfig

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.3.3-foss-2016b-X11-20160819.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.3-foss-2016b-X11-20160819.eb
@@ -502,7 +502,8 @@ exts_list = [
     ('bmp', '0.2', ext_options),
     ('readbitmap', '0.1-4', ext_options),
     ('purrr', '0.2.2', ext_options),
-    ('imager', '0.31', ext_options),
+    ('downloader', '0.4', ext_options),
+    ('imager', '0.40.1', ext_options),
 ]
 
 moduleclass = 'lang'


### PR DESCRIPTION
to sync it up with #4427, cfr. https://github.com/hpcugent/easybuild-easyconfigs/pull/4427#pullrequestreview-30860122