### PR TITLE
also use patch for METIS 5.1.0 to enable use of doubles in easyconfig for foss/2016b

### DIFF
--- a/easybuild/easyconfigs/m/METIS/METIS-5.1.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/m/METIS/METIS-5.1.0-foss-2016b.eb
@@ -15,6 +15,9 @@ source_urls = [
     'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD',
 ]
 
+# We use 32bit for indices and 64bit for content
+patches = ['METIS-5.1.0-use-doubles.patch']
+
 builddependencies = [('CMake', '3.6.1')]
 
 configopts = ['', 'shared=1']


### PR DESCRIPTION
Needed for OpenFOAM

# We use 32bit for indices and 64bit for content
patches = ['METIS-5.1.0-use-doubles.patch']