### PR TITLE
Fixed broken Qhull patch

### DIFF
--- a/easybuild/easyconfigs/q/Qhull/Qhull_pkgconfig.patch
+++ b/easybuild/easyconfigs/q/Qhull/Qhull_pkgconfig.patch
@@ -3,7 +3,7 @@ requires making CMake to fill in the gaps via 'configure_file(... @ONLY)'
 author: Kenneth Hoste (UGent)
 --- qhull/CMakeLists.txt.orig	2015-09-21 15:27:38.424110227 +0200
 +++ qhull/CMakeLists.txt	2015-09-21 15:27:06.403494984 +0200
-@@ -430,3 +430,9 @@
+@@ -430,3 +430,10 @@
  install(FILES html/rbox.man          DESTINATION ${MAN_INSTALL_DIR} RENAME rbox.1)
  install(FILES ${doc_FILES}           DESTINATION ${DOC_INSTALL_DIR})
  install(DIRECTORY html/              DESTINATION ${DOC_INSTALL_DIR})
@@ -11,6 +11,7 @@ author: Kenneth Hoste (UGent)
 +CONFIGURE_FILE(
 +  "${CMAKE_CURRENT_SOURCE_DIR}/qhull.pc.in"
 +  "${CMAKE_CURRENT_BINARY_DIR}/qhull.pc"
++  @ONLY
 +)
 +INSTALL(FILES "${CMAKE_BINARY_DIR}/qhull.pc"  DESTINATION lib/pkgconfig)
 --- qhull/qhull.pc.in	1970-01-01 01:00:00.000000000 +0100


### PR DESCRIPTION
This got me scratching my head for a while...........

Octave depends on Qhull. Octave was failing with an obscure libtool error:

`require no space between -L and -L/one/path`

After much digging through the octave logs I found that `QHULL_LDFLAGS` was set to `-L`. That came from `pkg-config`. The issue is that in the patch applied to `Qhull`, `CMake` replaces both `@variable@` and `${variable}` kind of variables. So `${prefix}` and family are replaced with nothing, since they are not defined. See https://cmake.org/cmake/help/v3.0/command/configure_file.html The solution is to add `@ONLY` to the cmake command