### PR TITLE
Fix for R extension nloptr

### DIFF
--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2017a.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2017a.eb
@@ -1,0 +1,26 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# Author: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics
+# Biozentrum - University of Basel
+
+easyblock = 'ConfigureMake'
+
+name = 'NLopt'
+version = '2.4.2'
+
+homepage = 'http://ab-initio.mit.edu/wiki/index.php/NLopt'
+description = """ NLopt is a free/open-source library for nonlinear optimization, 
+ providing a common interface for a number of different free optimization routines 
+ available online as well as original implementations of various other algorithms. """
+
+toolchain = {'name': 'intel', 'version': '2017a'}
+
+source_urls = ['http://ab-initio.mit.edu/nlopt/']
+sources = [SOURCELOWER_TAR_GZ]
+
+sanity_check_paths = {
+    'files': ["lib/libnlopt.a", "include/nlopt.h"],
+    'dirs': [""],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2017a.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.4.2-intel-2017a.eb
@@ -18,6 +18,8 @@ toolchain = {'name': 'intel', 'version': '2017a'}
 source_urls = ['http://ab-initio.mit.edu/nlopt/']
 sources = [SOURCELOWER_TAR_GZ]
 
+configopts = '--enable-shared'
+
 sanity_check_paths = {
     'files': ["lib/libnlopt.a", "include/nlopt.h"],
     'dirs': [""],

--- a/easybuild/easyconfigs/r/R/R-3.3.3-intel-2017a-X11-20170314.eb
+++ b/easybuild/easyconfigs/r/R/R-3.3.3-intel-2017a-X11-20170314.eb
@@ -43,6 +43,7 @@ dependencies = [
     ('GDAL', '2.1.3', '-Python-2.7.13'),  # for rgdal
     ('PROJ', '4.9.3'),  # for rgdal
     ('GMP', '6.1.2'),  # for igraph
+    ('NLopt', '2.4.2'),  # for nloptr
     # OS dependency should be preferred if the os version is more recent then this version,
     # it's nice to have an up to date openssl for security reasons
     # ('OpenSSL', '1.0.2h'),


### PR DESCRIPTION
It needs the NLopt library. It worked until now because it downloads and builds the lib silently. It failed for me with a corrupt download.