### PR TITLE
fix issue with configparser and backports namespace blocking inclusion of nbconvert with IPython

### DIFF
--- a/easybuild/easyconfigs/c/configparser/configparser-3.5.0-foss-2016a-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/c/configparser/configparser-3.5.0-foss-2016a-Python-2.7.11.eb
@@ -12,25 +12,17 @@ toolchain = {'name': 'foss', 'version': '2016a'}
 source_urls = ['https://pypi.python.org/packages/7c/69/c2ce7e91c89dc073eb1aa74c0621c3eefbffe8216b3f9af9d3885265c01c/']
 sources = ['configparser-%(version)s.tar.gz']
 
-dependencies = [
-    ('Python', '2.7.11'),
-]
-builddependencies = [
-    ('pip', '8.1.2', versionsuffix),
-]
+patches = ['configparser-%(version)s_no-backports-namespace.patch']
+
+dependencies = [('Python', '2.7.11')]
+builddependencies = [('pip', '8.1.2', versionsuffix)]
 
 use_pip = True
-unpack_sources = False
 
 sanity_check_paths = {
     'files': ['lib/python%(pyshortver)s/site-packages/configparser.py'],
     'dirs': ['lib/python%(pyshortver)s/site-packages/backports/configparser'],
 }
-
-# XXX: hack! for some reason the sanity check imports fail, even though the
-# PYTHONPATH seems to point to the right directory?!? Creating the __init__.py
-# in backports makes it pass and hopefully does not break anything.
-postinstallcmds = ['touch %(installdir)s/lib/python%(pyshortver)s/site-packages/backports/__init__.py']
 
 sanity_check_commands = [
     ('python', "-c 'import configparser'"),

--- a/easybuild/easyconfigs/c/configparser/configparser-3.5.0-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/c/configparser/configparser-3.5.0-foss-2016b-Python-2.7.12.eb
@@ -1,0 +1,31 @@
+easyblock = 'PythonPackage'
+
+name = 'configparser'
+version = '3.5.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://docs.python.org/3/library/configparser.html'
+description = "configparser is a Python library that brings the updated configparser from Python 3.5 to Python 2.6-3.5"
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+
+source_urls = ['https://pypi.python.org/packages/7c/69/c2ce7e91c89dc073eb1aa74c0621c3eefbffe8216b3f9af9d3885265c01c/']
+sources = ['configparser-%(version)s.tar.gz']
+
+patches = ['configparser-%(version)s_no-backports-namespace.patch']
+
+dependencies = [('Python', '2.7.12')]
+
+use_pip = True
+
+sanity_check_paths = {
+    'files': ['lib/python%(pyshortver)s/site-packages/configparser.py'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/backports/configparser'],
+}
+
+sanity_check_commands = [
+    ('python', "-c 'import configparser'"),
+    ('python', "-c 'from backports import configparser'"),
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/c/configparser/configparser-3.5.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/c/configparser/configparser-3.5.0-intel-2016b-Python-2.7.12.eb
@@ -12,25 +12,16 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 source_urls = ['https://pypi.python.org/packages/7c/69/c2ce7e91c89dc073eb1aa74c0621c3eefbffe8216b3f9af9d3885265c01c/']
 sources = ['configparser-%(version)s.tar.gz']
 
-dependencies = [
-    ('Python', '2.7.12'),
-]
-builddependencies = [
-    ('pip', '8.1.2', versionsuffix),
-]
+patches = ['configparser-%(version)s_no-backports-namespace.patch']
+
+dependencies = [('Python', '2.7.12')]
 
 use_pip = True
-unpack_sources = False
 
 sanity_check_paths = {
     'files': ['lib/python%(pyshortver)s/site-packages/configparser.py'],
     'dirs': ['lib/python%(pyshortver)s/site-packages/backports/configparser'],
 }
-
-# XXX: hack! for some reason the sanity check imports fail, even though the
-# PYTHONPATH seems to point to the right directory?!? Creating the __init__.py
-# in backports makes it pass and hopefully does not break anything.
-postinstallcmds = ['touch %(installdir)s/lib/python%(pyshortver)s/site-packages/backports/__init__.py']
 
 sanity_check_commands = [
     ('python', "-c 'import configparser'"),

--- a/easybuild/easyconfigs/c/configparser/configparser-3.5.0-intel-2016b-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/c/configparser/configparser-3.5.0-intel-2016b-Python-3.5.2.eb
@@ -12,12 +12,11 @@ toolchain = {'name': 'intel', 'version': '2016b'}
 source_urls = ['https://pypi.python.org/packages/7c/69/c2ce7e91c89dc073eb1aa74c0621c3eefbffe8216b3f9af9d3885265c01c/']
 sources = ['configparser-%(version)s.tar.gz']
 
-dependencies = [
-    ('Python', '3.5.2'),
-]
+patches = ['configparser-%(version)s_no-backports-namespace.patch']
+
+dependencies = [('Python', '3.5.2')]
 
 use_pip = True
-unpack_sources = False
 
 sanity_check_paths = {
     'files': [],

--- a/easybuild/easyconfigs/c/configparser/configparser-3.5.0_no-backports-namespace.patch
+++ b/easybuild/easyconfigs/c/configparser/configparser-3.5.0_no-backports-namespace.patch
@@ -1,0 +1,31 @@
+don't let configparser define 'backports' namespace, since that interferes with other packaging that provide stuff in 'backports'
+
+patch obtained from https://github.com/NIXOS/nixpkgs/blob/master/pkgs/development/python-modules/configparser/0001-namespace-fix.patch
+see also https://bitbucket.org/ambv/configparser/issues/17/importerror-when-used-with-other-backports
+diff --git a/setup.py b/setup.py
+index 3b07823..63ed25d 100644
+--- a/setup.py
++++ b/setup.py
+@@ -42,7 +42,6 @@ setup(
+     py_modules=modules,
+     package_dir={'': 'src'},
+     packages=find_packages('src'),
+-    namespace_packages=['backports'],
+     include_package_data=True,
+     zip_safe=False,
+     install_requires=requirements,
+diff --git a/src/backports/__init__.py b/src/backports/__init__.py
+index f84d25c..febdb2f 100644
+--- a/src/backports/__init__.py
++++ b/src/backports/__init__.py
+@@ -3,9 +3,3 @@
+ 
+ from pkgutil import extend_path
+ __path__ = extend_path(__path__, __name__)
+-
+-try:
+-    import pkg_resources
+-    pkg_resources.declare_namespace(__name__)
+-except ImportError:
+-    pass
+-- 

--- a/easybuild/easyconfigs/e/entrypoints/entrypoints-0.2.2-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/e/entrypoints/entrypoints-0.2.2-foss-2016b-Python-2.7.12.eb
@@ -1,0 +1,28 @@
+easyblock = 'PythonPackage'
+
+name = 'entrypoints'
+version = '0.2.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/takluyver/entrypoints'
+description = """Entry points are a way for Python packages to advertise objects with some common interface."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+
+source_urls = ['https://pypi.python.org/packages/f8/ad/0e77a853c745a15981ab51fa9a0cb4eca7a7a007b4c1970106ee6ba01e0c/']
+sources = ['entrypoints-0.2.2-py2.py3-none-any.whl']
+
+dependencies = [
+    ('Python', '2.7.12'),
+    ('configparser', '3.5.0', versionsuffix),
+]
+
+use_pip = True
+unpack_sources = False
+
+sanity_check_paths = {
+    'files': ['lib/python%(pyshortver)s/site-packages/entrypoints.py'],
+    'dirs': []
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/i/IPython/IPython-5.1.0-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-5.1.0-foss-2016b-Python-2.7.12.eb
@@ -18,9 +18,7 @@ dependencies = [
     ('Python', '2.7.12'),
     ('PyZMQ', '16.0.2', '%s-zmq4' % versionsuffix),
     ('testpath', '0.3', versionsuffix),
-    # required by 'nbconvert', but causes problems w.r.t. 'backports' module...
-    # see https://github.com/hpcugent/easybuild-easyconfigs/issues/3825
-    # ('entrypoints', '0.2.2', versionsuffix),
+    ('entrypoints', '0.2.2', versionsuffix),
     ('path.py', '8.2.1', versionsuffix),
     ('prompt-toolkit', '1.0.6', versionsuffix),
 ]
@@ -114,11 +112,9 @@ exts_list = [
     ('pexpect', '4.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pexpect/'],
     }),
-    # disabled because entrypoints on which this depends pull in configparser, which causes problems
-    # see https://github.com/hpcugent/easybuild-easyconfigs/issues/3825
-    # ('nbconvert', '4.2.0', {
-    #    'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
-    # }),
+    ('nbconvert', '4.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
+    }),
     ('backports.shutil_get_terminal_size', '1.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/b/backports.shutil_get_terminal_size/'],
     }),

--- a/easybuild/easyconfigs/i/IPython/IPython-5.1.0-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-5.1.0-intel-2016b-Python-2.7.12.eb
@@ -18,9 +18,7 @@ dependencies = [
     ('Python', '2.7.12'),
     ('PyZMQ', '15.4.0', '%s-zmq4' % versionsuffix),
     ('testpath', '0.3', versionsuffix),
-    # required by 'nbconvert', but causes problems w.r.t. 'backports' module...
-    # see https://github.com/hpcugent/easybuild-easyconfigs/issues/3825
-    # ('entrypoints', '0.2.2', versionsuffix),
+    ('entrypoints', '0.2.2', versionsuffix),
     ('path.py', '8.2.1', versionsuffix),
     ('prompt-toolkit', '1.0.6', versionsuffix),
 ]
@@ -114,11 +112,9 @@ exts_list = [
     ('pexpect', '4.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pexpect/'],
     }),
-    # disabled because entrypoints on which this depends pull in configparser, which causes problems
-    # see https://github.com/hpcugent/easybuild-easyconfigs/issues/3825
-    # ('nbconvert', '4.2.0', {
-    #    'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
-    # }),
+    ('nbconvert', '4.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
+    }),
     ('backports.shutil_get_terminal_size', '1.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/b/backports.shutil_get_terminal_size/'],
     }),

--- a/easybuild/easyconfigs/i/IPython/IPython-5.2.2-intel-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-5.2.2-intel-2016b-Python-2.7.12.eb
@@ -18,9 +18,7 @@ dependencies = [
     ('Python', '2.7.12'),
     ('PyZMQ', '16.0.2', '%s-zmq4' % versionsuffix),
     ('testpath', '0.3', versionsuffix),
-    # required by 'nbconvert', but causes problems w.r.t. 'backports' module...
-    # see https://github.com/hpcugent/easybuild-easyconfigs/issues/3825
-    # ('entrypoints', '0.2.2', versionsuffix),
+    ('entrypoints', '0.2.2', versionsuffix),
     ('path.py', '10.1', versionsuffix),
     ('prompt-toolkit', '1.0.13', versionsuffix),
 ]
@@ -111,11 +109,13 @@ exts_list = [
     ('pexpect', '4.2.1', {
         'source_urls': ['https://pypi.python.org/packages/source/p/pexpect/'],
     }),
-    # disabled because entrypoints on which this depends pull in configparser, which causes problems
-    # see https://github.com/hpcugent/easybuild-easyconfigs/issues/3825
-    # ('nbconvert', '5.1.1', {
-    #    'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
-    # }),
+    ('pandocfilters', '1.4.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandocfilters/'],
+    }),
+    ('nbconvert', '5.1.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
+        'use_pip': True,
+    }),
     ('backports.shutil_get_terminal_size', '1.0.0', {
         'source_urls': ['https://pypi.python.org/packages/source/b/backports.shutil_get_terminal_size/'],
     }),


### PR DESCRIPTION
fix for #3825

requires ~~https://github.com/hpcugent/easybuild-framework/pull/2194~~, since `nbconvert` 5.1.1 requires that `use_pip` is enabled