### PR TITLE
Change source_urls of pycrypto to encrypted https://pypi.python.org/...

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015a.eb
@@ -91,7 +91,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-foss-2015b.eb
@@ -91,7 +91,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-gimkl-2.11.5.eb
@@ -90,7 +90,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.4.10.eb
@@ -91,7 +91,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-goolf-1.7.20.eb
@@ -91,7 +91,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015a.eb
@@ -91,7 +91,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.10-intel-2015b.eb
@@ -90,7 +90,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-CrayGNU-2015.11.eb
@@ -93,7 +93,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-CrayGNU-2016.03.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-CrayGNU-2016.03.eb
@@ -93,7 +93,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2015a.eb
@@ -90,7 +90,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2016a.eb
@@ -90,7 +90,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-gimkl-2.11.5.eb
@@ -93,7 +93,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-goolf-1.7.20.eb
@@ -90,7 +90,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2015b.eb
@@ -93,7 +93,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016.02-GCC-4.9.eb
@@ -93,7 +93,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016a-libX11-1.6.3.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016a-libX11-1.6.3.eb
@@ -95,7 +95,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-intel-2016a.eb
@@ -93,7 +93,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-iomkl-2016.07.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-iomkl-2016.07.eb
@@ -92,7 +92,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -90,7 +90,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.12-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.12-foss-2016b.eb
@@ -85,7 +85,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.12-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.12-intel-2016b.eb
@@ -85,7 +85,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.12-iomkl-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.12-iomkl-2017a.eb
@@ -85,7 +85,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.13-intel-2017a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.13-intel-2017a.eb
@@ -86,7 +86,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-foss-2015b.eb
@@ -81,7 +81,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.8', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.4.10.eb
@@ -81,7 +81,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.8', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-goolf-1.5.14.eb
@@ -81,7 +81,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.8', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.2.0.eb
@@ -79,7 +79,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.8', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-ictce-5.3.0.eb
@@ -79,7 +79,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.8', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.3-intel-2015a.eb
@@ -79,7 +79,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.8', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-goolf-1.4.10.eb
@@ -82,7 +82,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.8', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.3.0.eb
@@ -82,7 +82,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.8', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.5-ictce-5.5.0.eb
@@ -82,7 +82,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.8', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.6-goolf-1.4.10.eb
@@ -81,7 +81,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.6-ictce-5.5.0.eb
@@ -84,7 +84,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-foss-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-foss-2014b.eb
@@ -81,7 +81,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-goolf-1.5.14.eb
@@ -87,7 +87,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-ictce-7.1.2.eb
@@ -91,7 +91,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2014.06.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2014.06.eb
@@ -88,7 +88,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2014b.eb
@@ -88,7 +88,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.8-intel-2015a.eb
@@ -84,7 +84,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-CrayGNU-2015.06.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-CrayGNU-2015.06.eb
@@ -87,7 +87,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-CrayGNU-2015.11.eb
@@ -87,7 +87,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015.05.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015.05.eb
@@ -87,7 +87,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['https://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015a.eb
@@ -87,7 +87,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-foss-2015b.eb
@@ -87,7 +87,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.14.eb
@@ -87,7 +87,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.16.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.5.16.eb
@@ -87,7 +87,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['https://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-goolf-1.7.20.eb
@@ -87,7 +87,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['https://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.9-intel-2015a.eb
@@ -88,7 +88,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-goolf-1.4.10.eb
@@ -62,7 +62,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.2.3-ictce-5.3.0.eb
@@ -62,7 +62,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
 ]
 

--- a/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2014b.eb
@@ -93,7 +93,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.1-intel-2015a.eb
@@ -93,7 +93,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.11', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.4.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.4.3-intel-2015a.eb
@@ -91,7 +91,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.5.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.0-intel-2015b.eb
@@ -93,7 +93,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2015a.eb
@@ -93,7 +93,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2016a.eb
@@ -93,7 +93,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.5.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.1-intel-2016a.eb
@@ -97,7 +97,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016.04.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016.04.eb
@@ -92,7 +92,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.2-foss-2016b.eb
@@ -92,7 +92,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.5.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.2-intel-2016b.eb
@@ -92,7 +92,7 @@ exts_list = [
     }),
     ('pycrypto', '2.6.1', {
         'modulename': 'Crypto',
-        'source_urls': ['http://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/'],
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
     }),
     ('ecdsa', '0.13', {
         'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],


### PR DESCRIPTION
There are at least three reasons for this:
- A crypto library should be downloaded via http**s**:// (it is remarkable that pycrypto is almost the only library which was downloaded unencrypted via http://)
- python.org is the more reliable source than dlitz.net
- dlitz.net is at the moment (20.4.2017) not online.