### PR TITLE
Go 1.8.1 binary release

### DIFF
--- a/easybuild/easyconfigs/g/Go/Go-1.8.1.eb
+++ b/easybuild/easyconfigs/g/Go/Go-1.8.1.eb
@@ -1,0 +1,21 @@
+easyblock = 'Tarball'
+
+name = 'Go'
+version = '1.8.1'
+
+homepage = 'http://www.golang.org'
+description = """Go is an open source programming language that makes it easy to build
+ simple, reliable, and efficient software."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+sources = ['%(namelower)s%(version)s.linux-amd64.tar.gz']
+source_urls = ['https://storage.googleapis.com/golang/']
+
+sanity_check_paths = {
+    'files': ['bin/go', 'bin/gofmt'],
+    'dirs': ['api', 'doc', 'lib', 'pkg'],
+}
+
+modextravars = {'GOROOT': '%(installdir)s'}
+moduleclass = 'compiler'


### PR DESCRIPTION
Used the binary distribution, since building from source requires you to already have an older Go compiler.