### PR TITLE
use patch to enable use of double precision floating point in METIS 5.1.0 foss/2016a easyconfig

### DIFF
--- a/easybuild/easyconfigs/m/METIS/METIS-5.1.0-foss-2016a.eb
+++ b/easybuild/easyconfigs/m/METIS/METIS-5.1.0-foss-2016a.eb
@@ -15,6 +15,9 @@ source_urls = [
     'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD',
 ]
 
+# We use 32bit for indices and 64bit for content
+patches = ['METIS-5.1.0-use-doubles.patch']
+
 builddependencies = [('CMake', '3.4.3')]
 
 configopts = ['', 'shared=1']


### PR DESCRIPTION
Needed for https://github.com/hpcugent/easybuild-easyconfigs/pull/3131