### PR TITLE
use 'git diff --name-only' and $TRAVIS_COMMIT_RANGE in Travis config to get list of changed files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,7 @@ install:
     - if [ ! -z $LMOD_VERSION ]; then source $(which install_eb_dep.sh) lua-5.1.4.8 $HOME; fi
     - if [ ! -z $LMOD_VERSION ]; then source $(which install_eb_dep.sh) Lmod-${LMOD_VERSION} $HOME; fi
 script:
+    - echo $TRAVIS_COMMIT_RANGE
+    - cd $TRAVIS_BUILD_DIR; git diff --name-only $(echo $TRAVIS_COMMIT_RANGE | sed 's/\.//'); cd - > /dev/null
     - export PYTHONPATH=$TRAVIS_BUILD_DIR
     - python -O -m test.easyconfigs.suite


### PR DESCRIPTION
For now, this will just print a list of changed files to the Travis log.

The idea is to see if we can use this to get a list of changes files for a PR, so we can do a partial style check, or check whether `SHA256` checksums are available for only the files touched by a PR rather than everything at once...

The `sed` is required because of https://github.com/travis-ci/travis-ci/issues/4596.