### PR TITLE
add missing /gnu/ ins ftpmirror.gnu.org source_urls, or use GNU_SOURCE where possible

### DIFF
--- a/easybuild/easyconfigs/e/ed/ed-1.9-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/e/ed/ed-1.9-goolf-1.4.10.eb
@@ -8,8 +8,12 @@ description = """GNU ed is a line-oriented text editor."""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
+source_urls = [
+    'https://launchpad.net/ed/main/%(version)s/+download/',
+    GNU_SOURCE,
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = [GNU_SOURCE]
+checksums = ['d5b372cfadf073001823772272fceac2cfa87552c5cd5a8efc1c8aae61f45a88']
 
 sanity_check_paths = {
     'files': ['bin/ed'],

--- a/easybuild/easyconfigs/e/ed/ed-1.9-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/e/ed/ed-1.9-ictce-5.3.0.eb
@@ -9,7 +9,7 @@ description = """GNU ed is a line-oriented text editor."""
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['http://ftpmirror.gnu.org/%(name)s/']
+source_urls = [GNU_SOURCE]
 
 sanity_check_paths = {
     'files': ['bin/ed'],

--- a/easybuild/easyconfigs/e/ed/ed-1.9-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/e/ed/ed-1.9-ictce-5.3.0.eb
@@ -8,8 +8,12 @@ description = """GNU ed is a line-oriented text editor."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
+source_urls = [
+    'https://launchpad.net/ed/main/%(version)s/+download/',
+    GNU_SOURCE,
+]
 sources = [SOURCE_TAR_GZ]
-source_urls = [GNU_SOURCE]
+checksums = ['d5b372cfadf073001823772272fceac2cfa87552c5cd5a8efc1c8aae61f45a88']
 
 sanity_check_paths = {
     'files': ['bin/ed'],

--- a/easybuild/easyconfigs/g/GCC/GCC-4.1.2.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.1.2.eb
@@ -7,7 +7,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = {'name': 'dummy', 'version': ''}  # empty version to ensure that dependencies are loaded
 
-source_urls = ['http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s']
+source_urls = ['http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s']
 sources = [SOURCELOWER_TAR_BZ2]
 
 checksums = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.2.4.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.2.4.eb
@@ -7,7 +7,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = {'name': 'dummy', 'version': ''}  # empty version to ensure that dependencies are loaded
 
-source_urls = ['http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s']
+source_urls = ['http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s']
 sources = [SOURCELOWER_TAR_BZ2]
 
 checksums = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.3.6.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.3.6.eb
@@ -7,7 +7,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = {'name': 'dummy', 'version': ''}  # empty version to ensure that dependencies are loaded
 
-source_urls = ['http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s']
+source_urls = ['http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s']
 sources = [SOURCELOWER_TAR_BZ2]
 
 checksums = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.4.7.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.4.7.eb
@@ -7,7 +7,7 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 
 toolchain = {'name': 'dummy', 'version': ''}  # empty version to ensure that dependencies are loaded
 
-source_urls = ['http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s']
+source_urls = ['http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s']
 sources = [SOURCELOWER_TAR_BZ2]
 
 checksums = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.5.2.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.5.2.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.5.3-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.5.3-CLooG-PPL.eb
@@ -11,9 +11,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 pplver = '0.11'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://bugseng.com/products/ppl/download/ftp/releases/%s' % pplver,  # PPL official
     'http://www.bastoul.net/cloog/pages/download/count.php3?url=.',  # CLooG official

--- a/easybuild/easyconfigs/g/GCC/GCC-4.5.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.5.3.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.6.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.6.0.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.6.3-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.6.3-CLooG-PPL.eb
@@ -11,9 +11,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 pplver = '0.12'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://bugseng.com/products/ppl/download/ftp/releases/%s' % pplver,  # PPL official
     'http://www.bastoul.net/cloog/pages/download/count.php3?url=.',  # CLooG official

--- a/easybuild/easyconfigs/g/GCC/GCC-4.6.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.6.3.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.6.4.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.6.4.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.0-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.0-CLooG-PPL.eb
@@ -11,9 +11,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 pplver = '0.12'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://bugseng.com/products/ppl/download/ftp/releases/%s' % pplver,  # PPL official
     'http://www.bastoul.net/cloog/pages/download/count.php3?url=.',  # CLooG official

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.0.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.1-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.1-CLooG-PPL.eb
@@ -11,9 +11,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 pplver = '0.12'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://bugseng.com/products/ppl/download/ftp/releases/%s' % pplver,  # PPL official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.1.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.1.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.2.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.3-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.3-CLooG-PPL.eb
@@ -11,9 +11,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 pplver = '0.12.1'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://bugseng.com/products/ppl/download/ftp/releases/%s' % pplver,  # PPL official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.3.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.4-CLooG-PPL.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.4-CLooG-PPL.eb
@@ -11,9 +11,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 pplver = '0.12.1'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://bugseng.com/products/ppl/download/ftp/releases/%s' % pplver,  # PPL official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official

--- a/easybuild/easyconfigs/g/GCC/GCC-4.7.4.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.7.4.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.1-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.1-CLooG.eb
@@ -9,9 +9,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.1.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.1.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.2-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.2-CLooG-multilib.eb
@@ -9,9 +9,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.2-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.2-CLooG.eb
@@ -9,9 +9,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.2-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.2-multilib.eb
@@ -9,9 +9,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.2.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.2.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.3-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.3-CLooG-multilib.eb
@@ -9,9 +9,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.3.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.4-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.4-CLooG-multilib.eb
@@ -9,9 +9,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.4-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.4-CLooG.eb
@@ -9,9 +9,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.4.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.4.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.8.5.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.8.5.eb
@@ -8,9 +8,9 @@ description = """The GNU Compiler Collection includes front ends for C, C++, Obj
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG-multilib.eb
@@ -11,9 +11,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.0-CLooG.eb
@@ -11,9 +11,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.0.eb
@@ -10,9 +10,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG-multilib.eb
@@ -11,9 +11,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.1-CLooG.eb
@@ -11,9 +11,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.1.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.1.eb
@@ -10,9 +10,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG-multilib.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG-multilib.eb
@@ -11,9 +11,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2-CLooG.eb
@@ -11,9 +11,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'http://www.bastoul.net/cloog/pages/download/',  # CLooG official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2-binutils-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2-binutils-2.25.eb
@@ -13,9 +13,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.2.eb
@@ -10,9 +10,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3-binutils-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3-binutils-2.25.eb
@@ -13,9 +13,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-4.9.3.eb
@@ -10,9 +10,9 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCC/GCC-5.1.0-binutils-2.25.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.1.0-binutils-2.25.eb
@@ -13,9 +13,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-5.1.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.1.0.eb
@@ -10,9 +10,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-5.2.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.2.0.eb
@@ -10,9 +10,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.3'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies

--- a/easybuild/easyconfigs/g/GCC/GCC-5.3.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-5.3.0.eb
@@ -10,9 +10,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.3'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.2.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.2.eb
@@ -13,9 +13,9 @@ mpfr_version = '3.1.2'
 gcc_name = 'GCC'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/gcc/gcc-%s' % version,  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/gcc/gcc-%s' % version,  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.3.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.3.eb
@@ -12,9 +12,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.2'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/gcc/gcc-%s' % version,  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/gcc/gcc-%s' % version,  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.4.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-4.9.4.eb
@@ -12,9 +12,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.4'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/gcc/gcc-%s' % version,  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/gcc/gcc-%s' % version,  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 sources = [

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-5.3.0.eb
@@ -12,9 +12,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.3'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-5.4.0.eb
@@ -12,9 +12,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.4'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.1.0.eb
@@ -12,12 +12,12 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.4'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies
-    'http://ftpmirror.gnu.org/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
     'https://ftp.gnu.org/gnu/gcc/gcc-%(version)s/',  # Alternative GCC
     'http://isl.gforge.inria.fr/',  # original HTTP source for ISL
 ]

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.2.0.eb
@@ -12,9 +12,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.4'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.3.0.eb
@@ -12,9 +12,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.5'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-7.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-7.1.0.eb
@@ -12,9 +12,9 @@ toolchain = {'name': 'dummy', 'version': ''}
 mpfr_version = '3.1.5'
 
 source_urls = [
-    'http://ftpmirror.gnu.org/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
-    'http://ftpmirror.gnu.org/gmp',  # idem for GMP
-    'http://ftpmirror.gnu.org/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
     'http://www.multiprecision.org/mpc/download',  # MPC official
     'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
     'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies

--- a/easybuild/easyconfigs/g/GLPK/GLPK-4.48-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/g/GLPK/GLPK-4.48-ictce-5.3.0.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'opt': True, 'optarch': True, 'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://ftpmirror.gnu.org/%(namelower)s']
+source_urls = [GNU_SOURCE]
 
 dependencies = [
     ('GMP', '5.1.1'),

--- a/easybuild/easyconfigs/g/GLPK/GLPK-4.53-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/g/GLPK/GLPK-4.53-goolf-1.4.10.eb
@@ -11,7 +11,7 @@ written in ANSI C and organized in the form of a callable library."""
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://ftpmirror.gnu.org/%(namelower)s']
+source_urls = [GNU_SOURCE]
 
 dependencies = [
     ('GMP', '5.1.1'),

--- a/easybuild/easyconfigs/g/GLPK/GLPK-4.53-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/g/GLPK/GLPK-4.53-ictce-6.2.5.eb
@@ -12,7 +12,7 @@ toolchain = {'name': 'ictce', 'version': '6.2.5'}
 toolchainopts = {'opt': True, 'optarch': True, 'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://ftpmirror.gnu.org/%(namelower)s']
+source_urls = [GNU_SOURCE]
 
 dependencies = [
     ('GMP', '5.1.1'),

--- a/easybuild/easyconfigs/g/GLPK/GLPK-4.55-foss-2015a.eb
+++ b/easybuild/easyconfigs/g/GLPK/GLPK-4.55-foss-2015a.eb
@@ -13,7 +13,7 @@ description = """The GLPK (GNU Linear Programming Kit) package is intended for
 toolchain = {'name': 'foss', 'version': '2015a'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://ftp.gnu.org/gnu/%(namelower)s/']
+source_urls = [GNU_SOURCE]
 
 dependencies = [('GMP', '6.0.0a', '', ('GCC', '4.9.2'))]
 

--- a/easybuild/easyconfigs/g/GLPK/GLPK-4.55-intel-2015a.eb
+++ b/easybuild/easyconfigs/g/GLPK/GLPK-4.55-intel-2015a.eb
@@ -13,7 +13,7 @@ description = """The GLPK (GNU Linear Programming Kit) package is intended for
 toolchain = {'name': 'intel', 'version': '2015a'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://ftp.gnu.org/gnu/%(namelower)s/']
+source_urls = [GNU_SOURCE]
 
 dependencies = [('GMP', '6.0.0a', '', ('GCC', '4.9.2'))]
 

--- a/easybuild/easyconfigs/g/GLPK/GLPK-4.58-foss-2016a.eb
+++ b/easybuild/easyconfigs/g/GLPK/GLPK-4.58-foss-2016a.eb
@@ -13,7 +13,7 @@ description = """The GLPK (GNU Linear Programming Kit) package is intended for
 toolchain = {'name': 'foss', 'version': '2016a'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://ftp.gnu.org/gnu/%(namelower)s/']
+source_urls = [GNU_SOURCE]
 
 dependencies = [('GMP', '6.1.0')]
 

--- a/easybuild/easyconfigs/g/GLPK/GLPK-4.58-intel-2016a.eb
+++ b/easybuild/easyconfigs/g/GLPK/GLPK-4.58-intel-2016a.eb
@@ -13,7 +13,7 @@ description = """The GLPK (GNU Linear Programming Kit) package is intended for
 toolchain = {'name': 'intel', 'version': '2016a'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://ftp.gnu.org/gnu/%(namelower)s/']
+source_urls = [GNU_SOURCE]
 
 dependencies = [('GMP', '6.1.0')]
 

--- a/easybuild/easyconfigs/g/GLPK/GLPK-4.60-intel-2016b.eb
+++ b/easybuild/easyconfigs/g/GLPK/GLPK-4.60-intel-2016b.eb
@@ -13,7 +13,7 @@ description = """The GLPK (GNU Linear Programming Kit) package is intended for
 toolchain = {'name': 'intel', 'version': '2016b'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://ftp.gnu.org/gnu/%(namelower)s/']
+source_urls = [GNU_SOURCE]
 
 dependencies = [('GMP', '6.1.1')]
 

--- a/easybuild/easyconfigs/g/GLPK/GLPK-4.61-intel-2017a.eb
+++ b/easybuild/easyconfigs/g/GLPK/GLPK-4.61-intel-2017a.eb
@@ -13,7 +13,7 @@ description = """The GLPK (GNU Linear Programming Kit) package is intended for
 toolchain = {'name': 'intel', 'version': '2017a'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://ftp.gnu.org/gnu/%(namelower)s/']
+source_urls = [GNU_SOURCE]
 
 dependencies = [('GMP', '6.1.2')]
 

--- a/easybuild/easyconfigs/g/GSL/GSL-1.16-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/g/GSL/GSL-1.16-goolf-1.7.20.eb
@@ -11,7 +11,7 @@ description = """The GNU Scientific Library (GSL) is a numerical library for C a
 toolchain = {'name': 'goolf', 'version': '1.7.20'}
 toolchainopts = {'unroll': True, 'pic': True}
 
-source_urls = ['http://ftpmirror.gnu.org/gnu/gsl/']
+source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 
 configopts = "--with-pic"

--- a/easybuild/easyconfigs/g/GSL/GSL-1.16-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/g/GSL/GSL-1.16-goolf-1.7.20.eb
@@ -11,7 +11,7 @@ description = """The GNU Scientific Library (GSL) is a numerical library for C a
 toolchain = {'name': 'goolf', 'version': '1.7.20'}
 toolchainopts = {'unroll': True, 'pic': True}
 
-source_urls = ['http://ftpmirror.gnu.org/gsl/']
+source_urls = ['http://ftpmirror.gnu.org/gnu/gsl/']
 sources = [SOURCELOWER_TAR_GZ]
 
 configopts = "--with-pic"

--- a/easybuild/easyconfigs/g/gzip/gzip-1.6-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/g/gzip/gzip-1.6-ictce-5.3.0.eb
@@ -21,7 +21,7 @@ description = "gzip (GNU zip) is a popular data compression program as a replace
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 
 # eg. http://ftp.gnu.org/gnu/gzip/gzip-1.6.tar.gz
-source_urls = ['http://ftpmirror.gnu.org/gzip']
+source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 # make sure the gzip, gunzip and compress binaries are available after installation

--- a/easybuild/easyconfigs/g/gzip/gzip-1.6-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/g/gzip/gzip-1.6-ictce-5.5.0.eb
@@ -21,7 +21,7 @@ description = "gzip (GNU zip) is a popular data compression program as a replace
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 
 # eg. http://ftp.gnu.org/gnu/gzip/gzip-1.6.tar.gz
-source_urls = ['http://ftpmirror.gnu.org/gzip']
+source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 # make sure the gzip, gunzip and compress binaries are available after installation

--- a/easybuild/easyconfigs/g/gzip/gzip-1.6-ictce-6.2.5.eb
+++ b/easybuild/easyconfigs/g/gzip/gzip-1.6-ictce-6.2.5.eb
@@ -21,7 +21,7 @@ description = "gzip (GNU zip) is a popular data compression program as a replace
 toolchain = {'name': 'ictce', 'version': '6.2.5'}
 
 # eg. http://ftp.gnu.org/gnu/gzip/gzip-1.6.tar.gz
-source_urls = ['http://ftpmirror.gnu.org/gzip']
+source_urls = [GNU_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 # make sure the gzip, gunzip and compress binaries are available after installation

--- a/easybuild/easyconfigs/m/M4/M4-1.4.16-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.16-ictce-5.5.0.eb
@@ -11,7 +11,7 @@ description = """GNU M4 is an implementation of the traditional Unix macro proce
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://ftpmirror.gnu.org/m4']
+source_urls = [GNU_SOURCE]
 
 patches = ['M4-%(version)s-no-gets.patch']
 

--- a/easybuild/easyconfigs/m/mutil/mutil-1.822.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/m/mutil/mutil-1.822.3-intel-2016a.eb
@@ -17,7 +17,7 @@ sources = [
 ]
 source_urls = [
     SOURCEFORGE_SOURCE,
-    'http://ftpmirror.gnu.org/coreutils',
+    'http://ftpmirror.gnu.org/gnu/coreutils',
 ]
 
 dependencies = [


### PR DESCRIPTION
fix for https://github.com/hpcugent/easybuild-framework/issues/2233