### PR TITLE
consistently use --with-harfbuzz=no configure option in freetype easyconfigs

### DIFF
--- a/easybuild/easyconfigs/f/freetype/freetype-2.4.10-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.4.10-goolf-1.4.10.eb
@@ -12,6 +12,8 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 source_urls = [GNU_SAVANNAH_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.4.10-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.4.10-ictce-5.3.0.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 source_urls = [GNU_SAVANNAH_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.4.11-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.4.11-goolf-1.4.10.eb
@@ -12,6 +12,8 @@ toolchain = {'name': 'goolf', 'version': '1.4.10'}
 source_urls = [GNU_SAVANNAH_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.4.11-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.4.11-ictce-5.3.0.eb
@@ -11,6 +11,8 @@ toolchain = {'name': 'ictce', 'version': '5.3.0'}
 source_urls = ['http://download.savannah.gnu.org/releases/freetype/']
 sources = [SOURCE_TAR_GZ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.5.0.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.5.0.1-goolf-1.4.10.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.6')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.5.0.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.5.0.1-ictce-5.3.0.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.6')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.5.0.1-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.5.0.1-ictce-5.5.0.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.6')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.5.2-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.5.2-ictce-5.5.0.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.9')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.5.3-foss-2014b.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.5.3-foss-2014b.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.12')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.5.3-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.5.3-goolf-1.7.20.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.12')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.5.3-intel-2014b.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.5.3-intel-2014b.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.12')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.5.5-foss-2015a.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.5.5-foss-2015a.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.16')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.5.5-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.5.5-goolf-1.7.20.eb
@@ -16,6 +16,8 @@ dependencies = [
     ('zlib', '1.2.8')
 ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT, 'lib/pkgconfig/freetype2.pc'],
     'dirs': ['include/freetype2'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.5.5-intel-2015a.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.5.5-intel-2015a.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.16')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.5.5-intel-2015b.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.5.5-intel-2015b.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.16')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6-foss-2015a.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6-foss-2015a.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.17')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6-goolf-1.7.20.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.17')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6-intel-2015a.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6-intel-2015a.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.17')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.1-intel-2015b-libpng-1.6.19.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.1-intel-2015b-libpng-1.6.19.eb
@@ -15,6 +15,8 @@ libpngver = '1.6.19'
 versionsuffix = '-libpng-%s' % libpngver
 dependencies = [('libpng', libpngver)]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.1-intel-2015b.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.1-intel-2015b.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.18')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.2-CrayGNU-2015.11.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.2-CrayGNU-2015.11.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.21')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.2-foss-2015a.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.20')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.2-foss-2015b.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.2-foss-2015b.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.21')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.2-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.2-foss-2016a.eb
@@ -17,6 +17,8 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.2-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.2-gimkl-2.11.5.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.21')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.2-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.2-goolf-1.7.20.eb
@@ -16,6 +16,8 @@ dependencies = [
     ('zlib', '1.2.8')
 ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT, 'lib/pkgconfig/freetype2.pc'],
     'dirs': ['include/freetype2'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.2-intel-2015b.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.2-intel-2015b.eb
@@ -13,6 +13,8 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [('libpng', '1.6.21')]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.2-intel-2016a.eb
@@ -17,6 +17,8 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.3-foss-2016a.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.3-foss-2016a.eb
@@ -17,6 +17,8 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.3-intel-2016a.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.3-intel-2016a.eb
@@ -17,6 +17,8 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.5-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.5-GCCcore-5.4.0.eb
@@ -19,6 +19,8 @@ dependencies = [
 
 builddependencies = [('binutils', '2.26', '', True)]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.5-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.5-foss-2016b.eb
@@ -17,6 +17,8 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.6.5-intel-2016b.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.6.5-intel-2016b.eb
@@ -17,6 +17,8 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.7-foss-2016b.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.7-foss-2016b.eb
@@ -17,6 +17,8 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.7-intel-2016b.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.7-intel-2016b.eb
@@ -17,6 +17,8 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.7.1-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.7.1-GCCcore-5.4.0.eb
@@ -20,6 +20,8 @@ dependencies = [
 # use same binutils version that was used when building GCCcore toolchain
 builddependencies = [('binutils', '2.26', '', True)]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.7.1-GCCcore-6.3.0-libpng-1.6.29.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.7.1-GCCcore-6.3.0-libpng-1.6.29.eb
@@ -22,6 +22,8 @@ dependencies = [
 # use same binutils version that was used when building GCCcore toolchain
 builddependencies = [('binutils', '2.27', '', True)]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.7.1-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.7.1-GCCcore-6.3.0.eb
@@ -20,6 +20,8 @@ dependencies = [
 # use same binutils version that was used when building GCCcore toolchain
 builddependencies = [('binutils', '2.27', '', True)]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],

--- a/easybuild/easyconfigs/f/freetype/freetype-2.7.1-intel-2016b.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.7.1-intel-2016b.eb
@@ -17,6 +17,8 @@ dependencies = [
     ('zlib', '1.2.8'),
 ]
 
+configopts = '--with-harfbuzz=no'
+
 sanity_check_paths = {
     'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
               'lib/pkgconfig/freetype2.pc'],


### PR DESCRIPTION
We can't include `HarfBuzz` as a dependency to `freetype`, since `HarfBuzz` itself depends on `freetype`, see also https://github.com/Homebrew/legacy-homebrew/issues/27847.

Since HarfBuzz is not a dependency to freetype, it should be configured accordingly to avoid problems, cfr. #4596.