### PR TITLE
{bio}[dummy] BEDOPS 2.4.26

### DIFF
--- a/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.26.eb
+++ b/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.26.eb
@@ -1,0 +1,26 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+
+easyblock = 'Tarball'
+
+name = 'BEDOPS'
+version = '2.4.26'
+
+homepage = 'http://bedops.readthedocs.io/en/latest/index.html'
+description = """BEDOPS is an open-source command-line toolkit that performs highly efficient
+ and scalable Boolean and other set operations, statistical calculations, archiving, conversion
+ and other management of genomic data of arbitrary scale. Tasks can be easily split by chromosome
+ for distributing whole-genome analyses across a computational cluster."""
+
+sources = ['%(namelower)s_linux_x86_64-v%(version)s.tar.bz2']
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v%(version)s/']
+
+checksums = ['eb39bf1dadd138dff2faa45171f8f78e']
+
+sanity_check_paths = {
+    'files': ['bam2bed', '%(namelower)s', 'convert2bed', 'unstarch'],
+    'dirs': ['.'],
+}
+
+modextrapaths = {'PATH': ''}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.26.eb
+++ b/easybuild/easyconfigs/b/BEDOPS/BEDOPS-2.4.26.eb
@@ -11,6 +11,8 @@ description = """BEDOPS is an open-source command-line toolkit that performs hig
  and other management of genomic data of arbitrary scale. Tasks can be easily split by chromosome
  for distributing whole-genome analyses across a computational cluster."""
 
+toolchain = {'version': 'dummy', 'name': 'dummy'}
+
 sources = ['%(namelower)s_linux_x86_64-v%(version)s.tar.bz2']
 source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v%(version)s/']
 


### PR DESCRIPTION
Adds an EasyConfig for BEDOPS 2.4.26. The existing one for 2.4.20 fails with `--try-software-version=2.4.26` because the old easyconfig has `.v2` in the `source_urls`.