### PR TITLE
add SHA256 checksums for libpciaccess

### DIFF
--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-GCC-4.7.2.eb
@@ -6,10 +6,11 @@ version = '0.13.1'
 homepage = 'http://cgit.freedesktop.org/xorg/lib/libpciaccess/'
 description = """Generic PCI access library."""
 
+toolchain = {'name': 'GCC', 'version': '4.7.2'}
+
 source_urls = ['https://www.x.org/releases/individual/lib/']
 sources = [SOURCE_TAR_GZ]
-
-toolchain = {'name': 'GCC', 'version': '4.7.2'}
+checksums = ['8641a3ce37c97a6b28439d4630adb9583d8bd3e3a08c2040aa81f9932a7a76f6']
 
 builddependencies = [
     ('Autoconf', '2.69'),

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-goolf-1.4.10.eb
@@ -6,10 +6,11 @@ version = '0.13.1'
 homepage = 'http://cgit.freedesktop.org/xorg/lib/libpciaccess/'
 description = """Generic PCI access library."""
 
+toolchain = {'name': 'goolf', 'version': '1.4.10'}
+
 source_urls = ['https://www.x.org/releases/individual/lib/']
 sources = [SOURCE_TAR_GZ]
-
-toolchain = {'name': 'goolf', 'version': '1.4.10'}
+checksums = ['8641a3ce37c97a6b28439d4630adb9583d8bd3e3a08c2040aa81f9932a7a76f6']
 
 builddependencies = [
     ('Autoconf', '2.69'),

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-ictce-5.3.0.eb
@@ -6,10 +6,11 @@ version = '0.13.1'
 homepage = 'http://cgit.freedesktop.org/xorg/lib/libpciaccess/'
 description = """Generic PCI access library."""
 
+toolchain = {'name': 'ictce', 'version': '5.3.0'}
+
 source_urls = ['https://www.x.org/releases/individual/lib/']
 sources = [SOURCE_TAR_GZ]
-
-toolchain = {'name': 'ictce', 'version': '5.3.0'}
+checksums = ['8641a3ce37c97a6b28439d4630adb9583d8bd3e3a08c2040aa81f9932a7a76f6']
 
 builddependencies = [
     ('Autoconf', '2.69'),

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-ictce-5.5.0.eb
@@ -6,10 +6,11 @@ version = '0.13.1'
 homepage = 'http://cgit.freedesktop.org/xorg/lib/libpciaccess/'
 description = """Generic PCI access library."""
 
+toolchain = {'name': 'ictce', 'version': '5.5.0'}
+
 source_urls = ['https://www.x.org/releases/individual/lib/']
 sources = [SOURCE_TAR_GZ]
-
-toolchain = {'name': 'ictce', 'version': '5.5.0'}
+checksums = ['8641a3ce37c97a6b28439d4630adb9583d8bd3e3a08c2040aa81f9932a7a76f6']
 
 builddependencies = [
     ('Autoconf', '2.69'),

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.1-intel-2015a.eb
@@ -6,10 +6,11 @@ version = '0.13.1'
 homepage = 'http://cgit.freedesktop.org/xorg/lib/libpciaccess/'
 description = """Generic PCI access library."""
 
+toolchain = {'name': 'intel', 'version': '2015a'}
+
 source_urls = ['https://www.x.org/releases/individual/lib/']
 sources = [SOURCE_TAR_GZ]
-
-toolchain = {'name': 'intel', 'version': '2015a'}
+checksums = ['8641a3ce37c97a6b28439d4630adb9583d8bd3e3a08c2040aa81f9932a7a76f6']
 
 builddependencies = [
     ('Autotools', '20150119', '', ('GCC', '4.9.2')),

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.3-intel-2015a.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.3-intel-2015a.eb
@@ -6,10 +6,11 @@ version = '0.13.3'
 homepage = 'http://cgit.freedesktop.org/xorg/lib/libpciaccess/'
 description = """Generic PCI access library."""
 
+toolchain = {'name': 'intel', 'version': '2015a'}
+
 source_urls = ['https://www.x.org/releases/individual/lib/']
 sources = [SOURCE_TAR_GZ]
-
-toolchain = {'name': 'intel', 'version': '2015a'}
+checksums = ['9e0244e815dc55cbedb135baa4dc1e4b0325875276e081edfe38ff2bf61dfe02']
 
 builddependencies = [
     ('Autoconf', '2.69'),

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-foss-2016a.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-foss-2016a.eb
@@ -6,10 +6,11 @@ version = '0.13.4'
 homepage = 'http://cgit.freedesktop.org/xorg/lib/libpciaccess/'
 description = """Generic PCI access library."""
 
+toolchain = {'name': 'foss', 'version': '2016a'}
+
 source_urls = ['https://www.x.org/releases/individual/lib/']
 sources = [SOURCE_TAR_GZ]
-
-toolchain = {'name': 'foss', 'version': '2016a'}
+checksums = ['74d92bda448e6fdb64fee4e0091255f48d625d07146a121653022ed3a0ca1f2f']
 
 builddependencies = [
     ('Autotools', '20150215'),

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-foss-2016b.eb
@@ -6,10 +6,11 @@ version = '0.13.4'
 homepage = 'http://cgit.freedesktop.org/xorg/lib/libpciaccess/'
 description = """Generic PCI access library."""
 
+toolchain = {'name': 'foss', 'version': '2016b'}
+
 source_urls = ['https://www.x.org/releases/individual/lib/']
 sources = [SOURCE_TAR_GZ]
-
-toolchain = {'name': 'foss', 'version': '2016b'}
+checksums = ['74d92bda448e6fdb64fee4e0091255f48d625d07146a121653022ed3a0ca1f2f']
 
 builddependencies = [
     ('Autotools', '20150215'),

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-gimkl-2.11.5.eb
@@ -6,10 +6,11 @@ version = '0.13.4'
 homepage = 'http://cgit.freedesktop.org/xorg/lib/libpciaccess/'
 description = """Generic PCI access library."""
 
+toolchain = {'name': 'gimkl', 'version': '2.11.5'}
+
 source_urls = ['https://www.x.org/releases/individual/lib/']
 sources = [SOURCE_TAR_GZ]
-
-toolchain = {'name': 'gimkl', 'version': '2.11.5'}
+checksums = ['74d92bda448e6fdb64fee4e0091255f48d625d07146a121653022ed3a0ca1f2f']
 
 builddependencies = [
     ('Autotools', '20150215'),

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-intel-2015b.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-intel-2015b.eb
@@ -6,10 +6,11 @@ version = '0.13.4'
 homepage = 'http://cgit.freedesktop.org/xorg/lib/libpciaccess/'
 description = """Generic PCI access library."""
 
+toolchain = {'name': 'intel', 'version': '2015b'}
+
 source_urls = ['https://www.x.org/releases/individual/lib/']
 sources = [SOURCE_TAR_GZ]
-
-toolchain = {'name': 'intel', 'version': '2015b'}
+checksums = ['74d92bda448e6fdb64fee4e0091255f48d625d07146a121653022ed3a0ca1f2f']
 
 builddependencies = [
     ('Autotools', '20150215', '', ('GNU', '4.9.3-2.25')),

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-intel-2016a.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-intel-2016a.eb
@@ -6,10 +6,11 @@ version = '0.13.4'
 homepage = 'http://cgit.freedesktop.org/xorg/lib/libpciaccess/'
 description = """Generic PCI access library."""
 
+toolchain = {'name': 'intel', 'version': '2016a'}
+
 source_urls = ['https://www.x.org/releases/individual/lib/']
 sources = [SOURCE_TAR_GZ]
-
-toolchain = {'name': 'intel', 'version': '2016a'}
+checksums = ['74d92bda448e6fdb64fee4e0091255f48d625d07146a121653022ed3a0ca1f2f']
 
 builddependencies = [
     ('Autotools', '20150215'),

--- a/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-intel-2016b.eb
+++ b/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.13.4-intel-2016b.eb
@@ -6,10 +6,11 @@ version = '0.13.4'
 homepage = 'http://cgit.freedesktop.org/xorg/lib/libpciaccess/'
 description = """Generic PCI access library."""
 
+toolchain = {'name': 'intel', 'version': '2016b'}
+
 source_urls = ['https://www.x.org/releases/individual/lib/']
 sources = [SOURCE_TAR_GZ]
-
-toolchain = {'name': 'intel', 'version': '2016b'}
+checksums = ['74d92bda448e6fdb64fee4e0091255f48d625d07146a121653022ed3a0ca1f2f']
 
 builddependencies = [
     ('Autotools', '20150215'),


### PR DESCRIPTION
source URLS for `libpciaccess` were fixed in #3960, but new downloaded source tarballs are not identical as the old downloads which required to run `autogen.sh` (which  is now no longer included)

Added checksums allow to recognise that the source tarballs needs to be redownloaded.