### PR TITLE
Added lib sanity check paths for debian compatibility

### DIFF
--- a/easybuild/easyconfigs/n/nettle/nettle-2.6-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/n/nettle/nettle-2.6-goolf-1.4.10.eb
@@ -15,8 +15,8 @@ dependencies = [('GMP', '5.0.5')]
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['nettle-hash', 'nettle-lfib-stream', 'pkcs1-conv', 'sexp-conv']] +
-             ['lib64/libhogweed.a', 'lib64/libhogweed.%s' % SHLIB_EXT,
-              'lib64/libnettle.a', 'lib64/libnettle.%s' % SHLIB_EXT],
+             [('lib/libhogweed.a', 'lib64/libhogweed.a'), ('lib/libhogweed.%s' % SHLIB_EXT, 'lib64/libhogweed.%s' % SHLIB_EXT),
+              ('lib/libnettle.a', 'lib64/libnettle.a'), ('lib/libnettle.%s' % SHLIB_EXT, 'lib64/libnettle.%s' % SHLIB_EXT)],
     'dirs': ['include/nettle'],
 }
 

--- a/easybuild/easyconfigs/n/nettle/nettle-3.1.1-GNU-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/n/nettle/nettle-3.1.1-GNU-4.9.3-2.25.eb
@@ -20,8 +20,8 @@ dependencies = [
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['nettle-hash', 'nettle-lfib-stream', 'pkcs1-conv', 'sexp-conv']] +
-             ['lib64/libhogweed.a', 'lib64/libhogweed.%s' % SHLIB_EXT,
-              'lib64/libnettle.a', 'lib64/libnettle.%s' % SHLIB_EXT],
+             [('lib/libhogweed.a', 'lib64/libhogweed.a'), ('lib/libhogweed.%s' % SHLIB_EXT, 'lib64/libhogweed.%s' % SHLIB_EXT),
+              ('lib/libnettle.a', 'lib64/libnettle.a'), ('lib/libnettle.%s' % SHLIB_EXT, 'lib64/libnettle.%s' % SHLIB_EXT)],
     'dirs': ['include/nettle'],
 }
 

--- a/easybuild/easyconfigs/n/nettle/nettle-3.1.1-foss-2016a.eb
+++ b/easybuild/easyconfigs/n/nettle/nettle-3.1.1-foss-2016a.eb
@@ -20,8 +20,8 @@ dependencies = [
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['nettle-hash', 'nettle-lfib-stream', 'pkcs1-conv', 'sexp-conv']] +
-             ['lib64/libhogweed.a', 'lib64/libhogweed.%s' % SHLIB_EXT,
-              'lib64/libnettle.a', 'lib64/libnettle.%s' % SHLIB_EXT],
+             [('lib/libhogweed.a', 'lib64/libhogweed.a'), ('lib/libhogweed.%s' % SHLIB_EXT, 'lib64/libhogweed.%s' % SHLIB_EXT),
+              ('lib/libnettle.a', 'lib64/libnettle.a'), ('lib/libnettle.%s' % SHLIB_EXT, 'lib64/libnettle.%s' % SHLIB_EXT)],
     'dirs': ['include/nettle'],
 }
 

--- a/easybuild/easyconfigs/n/nettle/nettle-3.1.1-intel-2016a.eb
+++ b/easybuild/easyconfigs/n/nettle/nettle-3.1.1-intel-2016a.eb
@@ -20,8 +20,8 @@ dependencies = [
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['nettle-hash', 'nettle-lfib-stream', 'pkcs1-conv', 'sexp-conv']] +
-             ['lib64/libhogweed.a', 'lib64/libhogweed.%s' % SHLIB_EXT,
-              'lib64/libnettle.a', 'lib64/libnettle.%s' % SHLIB_EXT],
+             [('lib/libhogweed.a', 'lib64/libhogweed.a'), ('lib/libhogweed.%s' % SHLIB_EXT, 'lib64/libhogweed.%s' % SHLIB_EXT),
+              ('lib/libnettle.a', 'lib64/libnettle.a'), ('lib/libnettle.%s' % SHLIB_EXT, 'lib64/libnettle.%s' % SHLIB_EXT)],
     'dirs': ['include/nettle'],
 }
 

--- a/easybuild/easyconfigs/n/nettle/nettle-3.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/n/nettle/nettle-3.2-foss-2016b.eb
@@ -20,8 +20,8 @@ dependencies = [
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['nettle-hash', 'nettle-lfib-stream', 'pkcs1-conv', 'sexp-conv']] +
-             ['lib64/libhogweed.a', 'lib64/libhogweed.%s' % SHLIB_EXT,
-              'lib64/libnettle.a', 'lib64/libnettle.%s' % SHLIB_EXT],
+             [('lib/libhogweed.a', 'lib64/libhogweed.a'), ('lib/libhogweed.%s' % SHLIB_EXT, 'lib64/libhogweed.%s' % SHLIB_EXT),
+              ('lib/libnettle.a', 'lib64/libnettle.a'), ('lib/libnettle.%s' % SHLIB_EXT, 'lib64/libnettle.%s' % SHLIB_EXT)],
     'dirs': ['include/nettle'],
 }
 

--- a/easybuild/easyconfigs/n/nettle/nettle-3.2-intel-2016b.eb
+++ b/easybuild/easyconfigs/n/nettle/nettle-3.2-intel-2016b.eb
@@ -20,8 +20,8 @@ dependencies = [
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['nettle-hash', 'nettle-lfib-stream', 'pkcs1-conv', 'sexp-conv']] +
-             ['lib64/libhogweed.a', 'lib64/libhogweed.%s' % SHLIB_EXT,
-              'lib64/libnettle.a', 'lib64/libnettle.%s' % SHLIB_EXT],
+             [('lib/libhogweed.a', 'lib64/libhogweed.a'), ('lib/libhogweed.%s' % SHLIB_EXT, 'lib64/libhogweed.%s' % SHLIB_EXT),
+              ('lib/libnettle.a', 'lib64/libnettle.a'), ('lib/libnettle.%s' % SHLIB_EXT, 'lib64/libnettle.%s' % SHLIB_EXT)],
     'dirs': ['include/nettle'],
 }
 

--- a/easybuild/easyconfigs/n/nettle/nettle-3.3-intel-2017a.eb
+++ b/easybuild/easyconfigs/n/nettle/nettle-3.3-intel-2017a.eb
@@ -20,8 +20,8 @@ dependencies = [
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['nettle-hash', 'nettle-lfib-stream', 'pkcs1-conv', 'sexp-conv']] +
-             ['lib64/libhogweed.a', 'lib64/libhogweed.%s' % SHLIB_EXT,
-              'lib64/libnettle.a', 'lib64/libnettle.%s' % SHLIB_EXT],
+             [('lib/libhogweed.a', 'lib64/libhogweed.a'), ('lib/libhogweed.%s' % SHLIB_EXT, 'lib64/libhogweed.%s' % SHLIB_EXT),
+              ('lib/libnettle.a', 'lib64/libnettle.a'), ('lib/libnettle.%s' % SHLIB_EXT, 'lib64/libnettle.%s' % SHLIB_EXT)],
     'dirs': ['include/nettle'],
 }
 


### PR DESCRIPTION
Fixed `nettle` easyconfig files. Sanity check library paths must include `lib/*` in order to pass on Debian and Ubuntu systems. See #4696 