### PR TITLE
fix source URLs for HDF5

### DIFF
--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-foss-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-foss-2016b.eb
@@ -1,7 +1,7 @@
 name = 'HDF5'
 version = '1.10.0-patch1'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-goolfc-2016.10.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-goolfc-2016.10.eb
@@ -1,7 +1,7 @@
 name = 'HDF5'
 version = '1.10.0-patch1'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-intel-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-intel-2016b.eb
@@ -1,7 +1,7 @@
 name = 'HDF5'
 version = '1.10.0-patch1'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-intel-2017.01.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-intel-2017.01.eb
@@ -1,7 +1,7 @@
 name = 'HDF5'
 version = '1.10.0-patch1'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-intel-2017a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-intel-2017a.eb
@@ -1,7 +1,7 @@
 name = 'HDF5'
 version = '1.10.0-patch1'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.1-intel-2017a.eb
@@ -1,7 +1,7 @@
 name = 'HDF5'
 version = '1.10.1'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-GCC-4.8.1-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-GCC-4.8.1-serial.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.10'
 versionsuffix = '-serial'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.1'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-goolf-1.4.10.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.10'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-5.3.0-gpfs-zlib-1.2.5.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-5.3.0-gpfs-zlib-1.2.5.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.10'
 versionsuffix = "-gpfs"
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management
  of extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-5.3.0-gpfs.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-5.3.0-gpfs.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.10'
 versionsuffix = "-gpfs"
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management
  of extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-5.3.0-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-5.3.0-serial.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.10'
 versionsuffix = '-serial'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-5.3.0.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.10'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-5.4.0-gpfs.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-5.4.0-gpfs.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.10'
 versionsuffix = "-gpfs"
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management
  of extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.4.0'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-5.5.0-gpfs.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-5.5.0-gpfs.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.10'
 versionsuffix = "-gpfs"
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management
  of extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-6.1.5-gpfs.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-ictce-6.1.5-gpfs.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.10'
 versionsuffix = "-gpfs"
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management
  of extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '6.1.5'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-intel-2014b-gpfs.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-intel-2014b-gpfs.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.10'
 versionsuffix = "-gpfs"
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management
  of extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2014b'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-patch1-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-patch1-goolf-1.4.10.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.10-patch1'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-patch1-goolf-1.5.14.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-patch1-goolf-1.5.14.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.10-patch1'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'goolf', 'version': '1.5.14'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-patch1-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.10-patch1-ictce-5.3.0.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.10-patch1'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.11-GCC-4.8.1-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.11-GCC-4.8.1-serial.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.11'
 versionsuffix = '-serial'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.1'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.11-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.11-goolf-1.4.10.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.11'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.11-ictce-5.3.0-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.11-ictce-5.3.0-serial.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.11'
 versionsuffix = '-serial'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'optarch': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.12-goolf-1.4.10-zlib-1.2.7.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.12-goolf-1.4.10-zlib-1.2.7.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.12'
 versionsuffix = '-zlib-1.2.7'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.12-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.12-ictce-5.4.0.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.12'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.4.0'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.12-ictce-5.5.0-zlib-1.2.8.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.12-ictce-5.5.0-zlib-1.2.8.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.12'
 versionsuffix = '-zlib-1.2.8'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.12-ictce-5.5.0.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.12-ictce-5.5.0.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.12'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.5.0'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.12-intel-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.12-intel-2016b.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.12'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-foss-2014b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-foss-2014b.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.13'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2014b'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-foss-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-foss-2015a.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.13'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2015a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-intel-2014b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-intel-2014b.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.13'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2014b'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-intel-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-intel-2015a.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.13'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-intel-2015b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-intel-2015b.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.13'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2015b'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-foss-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-foss-2015a.eb
@@ -2,14 +2,14 @@
 name = 'HDF5'
 version = "1.8.14"
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2015a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-ictce-7.1.2-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-ictce-7.1.2-serial.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.14'
 versionsuffix = '-serial'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '7.1.2'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': False}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-ictce-7.1.2.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.14'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '7.1.2'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-intel-2015a-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-intel-2015a-serial.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.14'
 versionsuffix = '-serial'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': False}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-intel-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-intel-2015a.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.14'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-foss-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-foss-2015a.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.15'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2015a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-intel-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-intel-2015a.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.15'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-intel-2015b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-intel-2015b.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.15'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2015b'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-foss-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-foss-2015a.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.15-patch1'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2015a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-foss-2015b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-foss-2015b.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.15-patch1'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2015b'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-intel-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-intel-2015a.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.15-patch1'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2015a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-intel-2015b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-intel-2015b.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.15-patch1'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2015b'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-foss-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-foss-2015a.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.16'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2015a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-foss-2016a-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-foss-2016a-serial.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.16'
 versionsuffix = '-serial'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2016a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': False}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-foss-2016a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-foss-2016a.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.16'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2016a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-gimkl-2.11.5-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-gimkl-2.11.5-serial.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.16'
 versionsuffix = '-serial'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'gimkl', 'version': '2.11.5'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2015b-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2015b-serial.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.16'
 versionsuffix = '-serial'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2015b'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': False}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2015b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2015b.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.16'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2015b'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2016.02-GCC-4.9.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.16'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2016a-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2016a-serial.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.16'
 versionsuffix = '-serial'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2016a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': False}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2016a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2016a.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.16'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2016a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-iomkl-2016.07.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-iomkl-2016.07.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.16'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'iomkl', 'version': '2016.07'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.16'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'iomkl', 'version': '2016.09-GCC-4.9.3-2.25'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-foss-2016a-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-foss-2016a-serial.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.17'
 versionsuffix = '-serial'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2016a'}
 toolchainopts = {'optarch': True, 'pic': True, 'usempi': False}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-foss-2016a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-foss-2016a.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.17'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2016a'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-foss-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-foss-2016b.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.17'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2016b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-intel-2016a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-intel-2016a.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.17'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2016a'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-intel-2016b-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-intel-2016b-serial.eb
@@ -2,14 +2,14 @@ name = 'HDF5'
 version = '1.8.17'
 versionsuffix = '-serial'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'pic': True, 'usempi': False}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-intel-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-intel-2016b.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.17'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-foss-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-foss-2016b.eb
@@ -1,17 +1,14 @@
 name = 'HDF5'
 version = '1.8.18'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2016b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = [
-    'https://support.hdfgroup.org/ftp/HDF5/current18/src/',
-    'https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(versions)/src/'
-]
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['dd2148b740713ca0295442ec683d7b1c']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-foss-2017a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-foss-2017a.eb
@@ -1,17 +1,14 @@
 name = 'HDF5'
 version = '1.8.18'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'foss', 'version': '2017a'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = [
-    'https://support.hdfgroup.org/ftp/HDF5/current18/src/',
-    'https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(versions)/src/'
-]
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['dd2148b740713ca0295442ec683d7b1c']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2016b.eb
@@ -1,17 +1,14 @@
 name = 'HDF5'
 version = '1.8.18'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2016b'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = [
-    'https://support.hdfgroup.org/ftp/HDF5/current18/src/',
-    'https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(versions)/src/'
-]
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['dd2148b740713ca0295442ec683d7b1c']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2017.01.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2017.01.eb
@@ -1,17 +1,14 @@
 name = 'HDF5'
 version = '1.8.18'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2017.01'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = [
-    'https://support.hdfgroup.org/ftp/HDF5/current18/src/',
-    'https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(versions)/src/'
-]
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['dd2148b740713ca0295442ec683d7b1c']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2017a-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2017a-serial.eb
@@ -2,17 +2,14 @@ name = 'HDF5'
 version = '1.8.18'
 versionsuffix = '-serial'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 toolchainopts = {'pic': True, 'usempi': False}
 
-source_urls = [
-    'https://support.hdfgroup.org/ftp/HDF5/current18/src/',
-    'https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(versions)/src/'
-]
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['dd2148b740713ca0295442ec683d7b1c']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2017a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2017a.eb
@@ -1,17 +1,14 @@
 name = 'HDF5'
 version = '1.8.18'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 toolchainopts = {'pic': True, 'usempi': True}
 
-source_urls = [
-    'https://support.hdfgroup.org/ftp/HDF5/current18/src/',
-    'https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(versions)/src/'
-]
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['dd2148b740713ca0295442ec683d7b1c']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.7-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.7-goolf-1.4.10.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.7'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.7-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.7-ictce-5.3.0.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.7'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.9-goolf-1.4.10.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.9-goolf-1.4.10.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.9'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'goolf', 'version': '1.4.10'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.9-goolf-1.5.16.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.9-goolf-1.5.16.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.9'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'goolf', 'version': '1.5.16'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.9-ictce-5.2.0.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.9-ictce-5.2.0.eb
@@ -1,15 +1,15 @@
 name = 'HDF5'
 version = '1.8.9'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
 extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.2.0'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
 
 patches = [
     'HDF5_configure_ictce.patch',

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.9-ictce-5.3.0.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.9-ictce-5.3.0.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.9'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.3.0'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.9-ictce-5.4.0.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.9-ictce-5.4.0.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.9'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'ictce', 'version': '5.4.0'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.9-intel-2014b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.9-intel-2014b.eb
@@ -1,14 +1,14 @@
 name = 'HDF5'
 version = '1.8.9'
 
-homepage = 'http://www.hdfgroup.org/HDF5/'
+homepage = 'https://support.hdfgroup.org/HDF5/'
 description = """HDF5 is a unique technology suite that makes possible the management of 
  extremely large and complex data collections."""
 
 toolchain = {'name': 'intel', 'version': '2014b'}
 toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
 
-source_urls = ['http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version)s/src']
+source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_major_minor)s/hdf5-%(version)s/src']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = [


### PR DESCRIPTION
following the issue opened by @reedts on the download issues for HDF5 1.8.18, and contacting HDF5 support on this, I figured out that we're actually using the wrong source URLs for HDF5...

In https://support.hdfgroup.org/ftp/HDF5/releases, there are subdirectories for the 1.8.x and 1.10.x versions of HDF5, which in turn have a subdirectory per version.

For some/most of these there is also a symlink directly in https://support.hdfgroup.org/ftp/HDF5/releases, but this is apparently something they are considering to remove...

This PR fixes the HDF5 source URLs to use the subdirectories specific to 1.8.x and 1.10.x, and also aligns the homepage while at it...