### PR TITLE
avoid use of import in ANSYS & MATLAB easyconfigs

### DIFF
--- a/easybuild/easyconfigs/a/ANSYS/ANSYS-15.0.eb
+++ b/easybuild/easyconfigs/a/ANSYS/ANSYS-15.0.eb
@@ -10,10 +10,6 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 # create a zip file from the 3 install iso files.
 # make sure all files of the iso's are in the same directory.
-sources = ['ANSYS-15.0.zip']
-
-import os
-license_server = os.getenv('EB_ANSYS_LICENSE_SERVER', 'license.example.com')
-license_server_port = os.getenv('EB_ANSYS_LICENSE_SERVER_PORT', '2325:1055')
+sources = ['ANSYS-%(version)s.zip']
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/MATLAB/MATLAB-2012b.eb
+++ b/easybuild/easyconfigs/m/MATLAB/MATLAB-2012b.eb
@@ -12,9 +12,4 @@ sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [('Java', '1.7.0_10')]
 
-import os
-license_server = os.getenv('EB_MATLAB_LICENSE_SERVER', 'license.example.com')
-license_server_port = os.getenv('EB_MATLAB_LICENSE_SERVER_PORT', '00000')
-key = os.getenv('EB_MATLAB_KEY', '00000-00000-00000-00000-00000-00000-00000-00000-00000-00000')
-
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MATLAB/MATLAB-2015a.eb
+++ b/easybuild/easyconfigs/m/MATLAB/MATLAB-2015a.eb
@@ -12,9 +12,4 @@ sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [('Java', '1.8.0_45')]
 
-import os
-license_server = os.getenv('EB_MATLAB_LICENSE_SERVER', 'license.example.com')
-license_server_port = os.getenv('EB_MATLAB_LICENSE_SERVER_PORT', '00000')
-key = os.getenv('EB_MATLAB_KEY', '00000-00000-00000-00000-00000-00000-00000-00000-00000-00000')
-
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MATLAB/MATLAB-2016a.eb
+++ b/easybuild/easyconfigs/m/MATLAB/MATLAB-2016a.eb
@@ -12,9 +12,4 @@ sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [('Java', '1.8.0_92')]
 
-import os
-license_server = os.getenv('EB_MATLAB_LICENSE_SERVER', 'license.example.com')
-license_server_port = os.getenv('EB_MATLAB_LICENSE_SERVER_PORT', '00000')
-key = os.getenv('EB_MATLAB_KEY', '00000-00000-00000-00000-00000-00000-00000-00000-00000-00000')
-
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MATLAB/MATLAB-2017a.eb
+++ b/easybuild/easyconfigs/m/MATLAB/MATLAB-2017a.eb
@@ -14,9 +14,4 @@ sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [('Java', '1.8.0_121')]
 
-import os
-license_server = os.getenv('EB_MATLAB_LICENSE_SERVER', 'license.example.com')
-license_server_port = os.getenv('EB_MATLAB_LICENSE_SERVER_PORT', '00000')
-key = os.getenv('EB_MATLAB_KEY', '00000-00000-00000-00000-00000-00000-00000-00000-00000-00000')
-
 moduleclass = 'math'


### PR DESCRIPTION
requires https://github.com/hpcugent/easybuild-easyblocks/pull/1195 to retain backward compatibility

(required to make #2506 eligible for merging)