### PR TITLE
set $OMP_NUM_THREADS during CP2K test step via dedicated easyconfig parameter

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-20111205-goolf-1.4.10-psmp.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-20111205-goolf-1.4.10-psmp.eb
@@ -37,7 +37,6 @@ maxtasks = 1
 
 # need to set OMP_NUM_THREADS to 1, to avoid failed tests during regression test
 # without this, 32 tests (out of 2196) fail
-import os
-os.environ['OMP_NUM_THREADS'] = '1'
+omp_num_threads = '1'
 
 moduleclass = 'chem'


### PR DESCRIPTION
requires https://github.com/hpcugent/easybuild-easyblocks/pull/1196

(required to make #2506 eligible for merging)