### PR TITLE
{devel} [foss/2017a] [intel/2017a] LikWid 4.2.0

### DIFF
--- a/easybuild/easyconfigs/l/likwid/likwid-4.2.0-foss-2017a.eb
+++ b/easybuild/easyconfigs/l/likwid/likwid-4.2.0-foss-2017a.eb
@@ -1,0 +1,50 @@
+##
+# -*- mode: python; -*-
+# EasyBuild reciPY for LikWid -- see https://github.com/RRZE-HPC/likwid
+# as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2017 UL HPC -- hpc.uni.lu
+# Authors::   UL HPC Team <hpc-sysadmins@uni.lu>
+# License::   MIT/GPL
+#
+#
+easyblock = 'ConfigureMake'
+
+name = 'likwid'
+version = '4.2.0'
+
+homepage = 'https://github.com/RRZE-HPC/likwid'
+description = """Likwid stands for 'Like I knew what I am doing'. Likwid is a
+simple to install and use toolsuite of command line applications for performance
+oriented programmers. It works for Intel and AMD processors on the Linux
+operating system.
+"""
+
+toolchain = {'name': 'foss', 'version': '2017a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/RRZE-HPC/likwid/archive/']
+sources = ['%(version)s.tar.gz']
+
+patches = ['likwid-%(version)s-foss-config-mk.patch']
+
+builddependencies = [('binutils', '2.27')]
+
+skipsteps = ['configure']
+buildopts = 'CC="$CC" CFLAGS="$CFLAGS -std=c99" PREFIX=%(installdir)s'
+installopts = 'PREFIX=%(installdir)s'
+
+sanity_check_paths = {
+    'files': ["bin/likwid-memsweeper", "bin/likwid-mpirun", "bin/likwid-perfctr",
+              "bin/likwid-perfscope", "bin/likwid-pin", "bin/likwid-powermeter", "bin/likwid-topology",
+              "lib/liblikwidpin.%s" % SHLIB_EXT, "lib/liblikwid.%s" % SHLIB_EXT],
+    'dirs': ["man/man1"]
+}
+
+postinstallcmds = [
+    'echo "================================================================================\nIMPORTANT: you will have to manually apply the following changes **as root**:\n    sudo chown root:root \$EBROOTLIKWID/sbin/likwid-accessD\n    sudo chmod u+s \$EBROOTLIKWID/sbin/likwid-accessD\n ================================================================================"'
+]
+
+maxparallel = 1
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/likwid/likwid-4.2.0-foss-config-mk.patch
+++ b/easybuild/easyconfigs/l/likwid/likwid-4.2.0-foss-config-mk.patch
@@ -1,0 +1,40 @@
+--- likwid-likwid-4.2.orig/config.mk	2016-12-22 13:22:23.000000000 +0100
++++ likwid-likwid-4.2/config.mk	2017-06-19 14:36:15.521398000 +0200
+@@ -9,7 +9,7 @@
+ COLOR = BLUE#NO SPACE
+ 
+ # Path were to install likwid
+-PREFIX = /usr/local#NO SPACE
++# PREFIX = /usr/local#NO SPACE
+ 
+ # uncomment to optionally set external lua@5.3:
+ # default is use internally provide lua
+@@ -40,7 +40,7 @@
+ # chown installed tools to this user/group
+ # if you change anything here, make sure that the user/group can access
+ # the MSR devices and (on Intel) the PCI devices.
+-INSTALL_CHOWN = -g root -o root
++INSTALL_CHOWN =
+ 
+ # For the daemon based secure msr/pci access configure
+ # the absolute path to the msr daemon executable.
+@@ -51,7 +51,7 @@
+ # Build the accessDaemon. Have a look in the WIKI for details.
+ BUILDDAEMON = true#NO SPACE
+ #Build the setFrequencies tool
+-BUILDFREQ = true#NO SPACE
++BUILDFREQ = false#NO SPACE
+ 
+ # Set the default mode for MSR access.
+ # This can usually be overriden on the commandline.
+@@ -82,8 +82,8 @@
+ # a proper config file at CFG_FILE_PATH)
+ MAX_NUM_THREADS = 263
+ MAX_NUM_NODES = 64
+-CFG_FILE_PATH = /etc/likwid.cfg
+-TOPO_FILE_PATH = /etc/likwid_topo.cfg
++CFG_FILE_PATH = $(PREFIX)/etc/likwid.cfg
++TOPO_FILE_PATH = $(PREFIX)/etc/likwid_topo.cfg
+ 
+ # Versioning Information
+ VERSION = 4

--- a/easybuild/easyconfigs/l/likwid/likwid-4.2.0-intel-2017a.eb
+++ b/easybuild/easyconfigs/l/likwid/likwid-4.2.0-intel-2017a.eb
@@ -1,0 +1,49 @@
+##
+# -*- mode: python; -*-
+# EasyBuild reciPY for LikWid -- see https://github.com/RRZE-HPC/likwid
+# as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2017 UL HPC -- hpc.uni.lu
+# Authors::   UL HPC Team <hpc-sysadmins@uni.lu>
+# License::   MIT/GPL
+#
+#
+easyblock = 'ConfigureMake'
+
+name = 'likwid'
+version = '4.2.0'
+
+homepage = 'https://github.com/RRZE-HPC/likwid'
+description = """Likwid stands for 'Like I knew what I am doing'. Likwid is a
+simple to install and use toolsuite of command line applications for performance
+oriented programmers. It works for Intel and AMD processors on the Linux
+operating system."""
+
+toolchain = {'name': 'intel', 'version': '2017a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/RRZE-HPC/likwid/archive/']
+sources = ['%(version)s.tar.gz']
+
+patches = ['likwid-%(version)s-intel-config-mk.patch']
+
+builddependencies = [('binutils', '2.27')]
+
+skipsteps = ['configure']
+buildopts = 'CC="$CC" CFLAGS="$CFLAGS -std=c99" PREFIX=%(installdir)s'
+installopts = 'PREFIX=%(installdir)s'
+
+sanity_check_paths = {
+    'files': ["bin/likwid-memsweeper", "bin/likwid-mpirun", "bin/likwid-perfctr",
+              "bin/likwid-perfscope", "bin/likwid-pin", "bin/likwid-powermeter", "bin/likwid-topology",
+              "lib/liblikwidpin.%s" % SHLIB_EXT, "lib/liblikwid.%s" % SHLIB_EXT],
+    'dirs': ["man/man1"]
+}
+
+postinstallcmds = [
+    'echo "================================================================================\nIMPORTANT: you will have to manually apply the following changes **as root**:\n    sudo chown root:root \$EBROOTLIKWID/sbin/likwid-accessD\n    sudo chmod u+s \$EBROOTLIKWID/sbin/likwid-accessD\n ================================================================================"'
+]
+
+maxparallel = 1
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/likwid/likwid-4.2.0-intel-config-mk.patch
+++ b/easybuild/easyconfigs/l/likwid/likwid-4.2.0-intel-config-mk.patch
@@ -1,0 +1,49 @@
+--- likwid-likwid-4.2.orig/config.mk	2016-12-22 13:22:23.000000000 +0100
++++ likwid-likwid-4.2/config.mk	2017-06-22 10:14:28.585696000 +0200
+@@ -1,7 +1,7 @@
+ # Please have a look in INSTALL and the WIKI for details on
+ # configuration options setup steps.
+ # supported: GCC, CLANG, ICC, MIC (ICC), GCCX86 (for 32bit systems)
+-COMPILER = GCC#NO SPACE
++COMPILER = ICC#NO SPACE
+ 
+ # Define the color of the likwid-pin output
+ # Can be NONE, BLACK, RED, GREEN, YELLOW, BLUE,
+@@ -9,7 +9,7 @@
+ COLOR = BLUE#NO SPACE
+ 
+ # Path were to install likwid
+-PREFIX = /usr/local#NO SPACE
++# PREFIX = /usr/local#NO SPACE
+ 
+ # uncomment to optionally set external lua@5.3:
+ # default is use internally provide lua
+@@ -40,7 +40,7 @@
+ # chown installed tools to this user/group
+ # if you change anything here, make sure that the user/group can access
+ # the MSR devices and (on Intel) the PCI devices.
+-INSTALL_CHOWN = -g root -o root
++INSTALL_CHOWN =
+ 
+ # For the daemon based secure msr/pci access configure
+ # the absolute path to the msr daemon executable.
+@@ -51,7 +51,7 @@
+ # Build the accessDaemon. Have a look in the WIKI for details.
+ BUILDDAEMON = true#NO SPACE
+ #Build the setFrequencies tool
+-BUILDFREQ = true#NO SPACE
++BUILDFREQ = false#NO SPACE
+ 
+ # Set the default mode for MSR access.
+ # This can usually be overriden on the commandline.
+@@ -82,8 +82,8 @@
+ # a proper config file at CFG_FILE_PATH)
+ MAX_NUM_THREADS = 263
+ MAX_NUM_NODES = 64
+-CFG_FILE_PATH = /etc/likwid.cfg
+-TOPO_FILE_PATH = /etc/likwid_topo.cfg
++CFG_FILE_PATH = $(PREFIX)/etc/likwid.cfg
++TOPO_FILE_PATH = $(PREFIX)/etc/likwid_topo.cfg
+ 
+ # Versioning Information
+ VERSION = 4


### PR DESCRIPTION
Updated reciPY for Likwid on top of foss and intel 2017a
Signed-off-by: Sebastien Varrette <Sebastien.Varrette@uni.lu>