### PR TITLE
remove buildopts from HDF5 easyconfigs, taken care of by updated HDF5 easyblock now

### DIFF
--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-foss-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-foss-2016b.eb
@@ -12,8 +12,6 @@ source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_ma
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['9180ff0ef8dc2ef3f61bd37a7404f295']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-goolfc-2016.10.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-goolfc-2016.10.eb
@@ -12,8 +12,6 @@ source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_ma
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['9180ff0ef8dc2ef3f61bd37a7404f295']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-intel-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-intel-2016b.eb
@@ -12,8 +12,6 @@ source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_ma
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['9180ff0ef8dc2ef3f61bd37a7404f295']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-intel-2017.01.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-intel-2017.01.eb
@@ -12,8 +12,6 @@ source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_ma
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['9180ff0ef8dc2ef3f61bd37a7404f295']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-intel-2017a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.0-patch1-intel-2017a.eb
@@ -12,8 +12,6 @@ source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_ma
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['9180ff0ef8dc2ef3f61bd37a7404f295']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.11'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.1-intel-2017a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.1-intel-2017a.eb
@@ -12,8 +12,6 @@ source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_ma
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['43a2f9466702fb1db31df98ae6677f15']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.11'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.12-intel-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.12-intel-2016b.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-foss-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-foss-2015a.eb
@@ -15,8 +15,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-intel-2014b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-intel-2014b.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-intel-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-intel-2015a.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-intel-2015b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.13-intel-2015b.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-foss-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-foss-2015a.eb
@@ -1,4 +1,3 @@
-# Built with EasyBuild version 2.2.0dev on 2015-06-16_11-02-41
 name = 'HDF5'
 version = "1.8.14"
 
@@ -15,8 +14,6 @@ sources = [SOURCELOWER_TAR_GZ]
 patches = [
     'configure_libtool.patch',
 ]
-
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
 
 dependencies = [
     ('zlib', '1.2.8'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-ictce-7.1.2-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-ictce-7.1.2-serial.eb
@@ -17,8 +17,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-ictce-7.1.2.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-ictce-7.1.2.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-intel-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.14-intel-2015a.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-foss-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-foss-2015a.eb
@@ -13,8 +13,6 @@ sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-intel-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-intel-2015a.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-intel-2015b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-intel-2015b.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-foss-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-foss-2015a.eb
@@ -13,8 +13,6 @@ sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-foss-2015b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-foss-2015b.eb
@@ -13,8 +13,6 @@ sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-intel-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-intel-2015a.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-intel-2015b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.15-patch1-intel-2015b.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-foss-2015a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-foss-2015a.eb
@@ -13,8 +13,6 @@ sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-foss-2016a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-foss-2016a.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2015b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2015b.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2016.02-GCC-4.9.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2016.02-GCC-4.9.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2016a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-intel-2016a.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-iomkl-2016.07.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-iomkl-2016.07.eb
@@ -13,8 +13,6 @@ sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-iomkl-2016.09-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.16-iomkl-2016.09-GCC-4.9.3-2.25.eb
@@ -13,8 +13,6 @@ sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['configure_libtool.patch']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-foss-2016a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-foss-2016a.eb
@@ -15,8 +15,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-foss-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-foss-2016b.eb
@@ -15,8 +15,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-intel-2016a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-intel-2016a.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-intel-2016b-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-intel-2016b-serial.eb
@@ -17,8 +17,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-intel-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.17-intel-2016b.eb
@@ -16,8 +16,6 @@ patches = [
     'configure_libtool.patch',
 ]
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-foss-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-foss-2016b.eb
@@ -13,8 +13,6 @@ source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_ma
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['dd2148b740713ca0295442ec683d7b1c']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-foss-2017a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-foss-2017a.eb
@@ -13,8 +13,6 @@ source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_ma
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['dd2148b740713ca0295442ec683d7b1c']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.11'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2016b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2016b.eb
@@ -13,8 +13,6 @@ source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_ma
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['dd2148b740713ca0295442ec683d7b1c']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2017.01.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2017.01.eb
@@ -13,8 +13,6 @@ source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_ma
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['dd2148b740713ca0295442ec683d7b1c']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.8'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2017a-serial.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2017a-serial.eb
@@ -14,8 +14,6 @@ source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_ma
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['dd2148b740713ca0295442ec683d7b1c']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.11'),
     ('Szip', '2.1'),

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2017a.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.8.18-intel-2017a.eb
@@ -13,8 +13,6 @@ source_urls = ['https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-%(version_ma
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['dd2148b740713ca0295442ec683d7b1c']
 
-buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
-
 dependencies = [
     ('zlib', '1.2.11'),
     ('Szip', '2.1'),


### PR DESCRIPTION
requires https://github.com/hpcugent/easybuild-easyblocks/pull/1200