### PR TITLE
{bio}[foss/2016b] Circos 0.69-5

### DIFF
--- a/easybuild/easyconfigs/c/Circos/Circos-0.69-5-foss-2016b-Perl-5.24.0.eb
+++ b/easybuild/easyconfigs/c/Circos/Circos-0.69-5-foss-2016b-Perl-5.24.0.eb
@@ -1,0 +1,35 @@
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+
+easyblock = 'Tarball'
+
+name = 'Circos'
+version = '0.69-5'
+versionsuffix = '-Perl-%(perlver)s'
+
+homepage = 'http://www.circos.ca/'
+description = """Circos is a software package for visualizing data and information.
+ It visualizes data in a circular layout - this makes Circos ideal for exploring
+ relationships between objects or positions."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+
+source_urls = ['http://circos.ca/distribution/']
+sources = [SOURCELOWER_TGZ]
+
+checksums = ['49b4c467ba871fa416013c47d69db9e6']
+
+dependencies = [
+    ('Perl', '5.24.0'),
+    ('GD', '2.66', versionsuffix),
+]
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': ['lib/%(name)s'],
+}
+
+modextrapaths = {'PERL5LIB': 'lib'}
+
+sanity_check_commands = [('perl', '-e "use Circos"')]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/p/Perl/Perl-5.24.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Perl/Perl-5.24.0-foss-2016b.eb
@@ -887,6 +887,14 @@ exts_list = [
         'source_tmpl': 'PDF-API2-2.031.tar.gz',
         'source_urls': ['http://search.cpan.org/CPAN/authors/id/S/SS/SSIMMS/'],
     }),
+    ('SVG', '2.77', {
+        'source_tmpl': 'SVG-2.77.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/M/MA/MANWAR/'],
+    }),
+    ('Statistics::Basic', '1.6611', {
+        'source_tmpl': 'Statistics-Basic-1.6611.tar.gz',
+        'source_urls': ['http://search.cpan.org/CPAN/authors/id/J/JE/JETTERO/'],
+    }),
 ]
 
 moduleclass = 'lang'


### PR DESCRIPTION
Follow up for #4357. This adds Circos with toolchain `foss-2016b`. Also adds two new modules to the existing Perl EasyConfig. The `SVG` module only depends on core modules (http://deps.cpantesters.org/?module=SVG;perl=latest) and `Statistics::Basic` depends on core modules and `Number::Format` which is already included (http://deps.cpantesters.org/?module=Statistics%3A%3ABasic;perl=latest). Should the new Perl modules also be added to other Perl EasyConfigs for consistency?